### PR TITLE
Fix bug with dates in URL in getPossibleDatesForLayer

### DIFF
--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -90,7 +90,7 @@ export const getPossibleDatesForLayer = (
     }
   };
 
-  return datesArray().map(d => d.displayDate);
+  return datesArray()?.map(d => d.displayDate);
 };
 
 export function formatUrl(

--- a/src/utils/server-utils.ts
+++ b/src/utils/server-utils.ts
@@ -90,7 +90,7 @@ export const getPossibleDatesForLayer = (
     }
   };
 
-  return datesArray()?.map(d => d.displayDate);
+  return datesArray()?.map(d => d.displayDate) ?? [];
 };
 
 export function formatUrl(


### PR DESCRIPTION
This PR fixes the following error on master when loading prism using an analysis url:

<img width="687" alt="image" src="https://user-images.githubusercontent.com/3285923/191196480-45c72a75-9dc3-4e33-a9bb-7529fa930938.png">

**How to test:** Using mozambique or any country deployment that contains adamts_buffers layer:

- Open the following link: http://localhost:3000/?analysisHazardLayerId=adamts_buffers&analysisAdminLevel=1&analysisStartDate=2020-08-02&analysisEndDate=2022-05-11&analysisStatistic=mean

