### PR TITLE
Update ODC endpoints to use WFP's prod environment

### DIFF
--- a/api-flask/app/sample_requests.py
+++ b/api-flask/app/sample_requests.py
@@ -1,7 +1,7 @@
 """Sample Data for stats and alert."""
 
 stats_data = {
-    "geotiff_url": "https://odc.ovio.org/?service=WCS&request=GetCoverage&version=1.0.0"
+    "geotiff_url": "https://api.earthobservation.vam.wfp.org/ows/?service=WCS&request=GetCoverage&version=1.0.0"
     "&coverage=r1h_dekad&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098"
     "&height=2304&format=GeoTIFF&time=2022-04-11",
     "zones_url": "https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/"
@@ -58,7 +58,7 @@ alert_data = {
         "title": "Monthly rainfall anomaly",
         "serverLayerName": "r1q_dekad",
         "contentPath": "data/myanmar/contents.md#monthly-rainfall-anomaly",
-        "baseUrl": "https://odc.ovio.org/",
+        "baseUrl": "https://api.earthobservation.vam.wfp.org/ows/",
         "dateInterval": "days",
         "opacity": 0.7,
         "legendText": "Monthly precipitation anomaly compared to the long term average."

--- a/api-flask/app/tests/test_api.py
+++ b/api-flask/app/tests/test_api.py
@@ -81,7 +81,7 @@ def test_stats_endpoint1():
         "/stats",
         headers={"Accept": "application/json"},
         json={
-            "geotiff_url": "https://odc.ovio.org/?service=WCS&request=GetCoverage&version=2.0.0&coverageId=wp_pop_cicunadj&subset=Long(95.71,96.68)&subset=Lat(19.42,20.33)",
+            "geotiff_url": "https://api.earthobservation.vam.wfp.org/ows/?service=WCS&request=GetCoverage&version=2.0.0&coverageId=wp_pop_cicunadj&subset=Long(95.71,96.68)&subset=Lat(19.42,20.33)",
             "zones_url": "https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/mmr_admin_boundaries.json",
             "group_by": "TS_PCODE",
             "wfs_params": {
@@ -104,7 +104,7 @@ def test_stats_endpoint2():
         "/stats",
         headers={"Accept": "application/json"},
         json={
-            "geotiff_url": "https://odc.ovio.org/?service=WCS&request=GetCoverage&version=1.0.0&coverage=hfs1_sfw_mask_mmr&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098&height=2304&format=GeoTIFF&time=2022-08-12",
+            "geotiff_url": "https://api.earthobservation.vam.wfp.org/ows/?service=WCS&request=GetCoverage&version=1.0.0&coverage=hfs1_sfw_mask_mmr&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098&height=2304&format=GeoTIFF&time=2022-08-12",
             "zones_url": "https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/mmr_admin_boundaries.json",
             "group_by": "TS",
             "geojson_out": False,
@@ -121,9 +121,9 @@ def test_stats_endpoint_masked():
         "/stats",
         headers={"Accept": "application/json"},
         json={
-            "geotiff_url": "https://odc.ovio.org/?service=WCS&request=GetCoverage&version=2.0.0&coverageId=wp_pop_cicunadj&subset=Long(95.71,96.68)&subset=Lat(19.42,20.33)",
+            "geotiff_url": "https://api.earthobservation.vam.wfp.org/ows/?service=WCS&request=GetCoverage&version=2.0.0&coverageId=wp_pop_cicunadj&subset=Long(95.71,96.68)&subset=Lat(19.42,20.33)",
             "zones_url": "https://prism-admin-boundaries.s3.us-east-2.amazonaws.com/mmr_admin_boundaries.json",
-            "mask_url": "https://odc.ovio.org/?service=WCS&request=GetCoverage&version=1.0.0&coverage=hfs1_sfw_mask_mmr&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098&height=2304&format=GeoTIFF&time=2022-08-22",
+            "mask_url": "https://api.earthobservation.vam.wfp.org/ows/?service=WCS&request=GetCoverage&version=1.0.0&coverage=hfs1_sfw_mask_mmr&crs=EPSG%3A4326&bbox=92.2%2C9.7%2C101.2%2C28.5&width=1098&height=2304&format=GeoTIFF&time=2022-08-22",
             "group_by": "TS_PCODE",
             "geojson_out": True,
         },

--- a/src/config/cambodia/layers.json
+++ b/src/config/cambodia/layers.json
@@ -130,7 +130,7 @@
     "additional_query_params": {
       "styles": "rfh_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -189,7 +189,7 @@
     "title": "10-day rainfall anomaly",
     "type": "wms",
     "server_layer_name": "rfq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -236,7 +236,7 @@
     "title": "Monthly rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -283,7 +283,7 @@
     "title": "3-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r3q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -330,7 +330,7 @@
     "title": "6-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r6q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -377,7 +377,7 @@
     "title": "9-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r9q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -424,7 +424,7 @@
     "title": "1-year rainfall anomaly",
     "type": "wms",
     "server_layer_name": "ryq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -471,7 +471,7 @@
     "title": "1-month rainfall aggregate",
     "type": "wms",
     "server_layer_name": "r1h_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "additional_query_params": {
       "styles": "rfh_1500"
     },
@@ -537,7 +537,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
@@ -595,7 +595,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
@@ -653,7 +653,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
@@ -711,7 +711,7 @@
     "additional_query_params": {
       "styles": "rfh_1500"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
@@ -766,7 +766,7 @@
     "title": "SPI - 1-month",
     "type": "wms",
     "server_layer_name": "r1s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -826,7 +826,7 @@
     "title": "SPI - 3-month",
     "type": "wms",
     "server_layer_name": "r3s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -886,7 +886,7 @@
     "title": "SPI - 6-month",
     "type": "wms",
     "server_layer_name": "r6s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -946,7 +946,7 @@
     "title": "SPI - 9-month",
     "type": "wms",
     "server_layer_name": "r9s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1006,7 +1006,7 @@
     "title": "SPI - 1-year",
     "type": "wms",
     "server_layer_name": "rys_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1066,7 +1066,7 @@
     "title": "Number of dry days",
     "type": "wms",
     "server_layer_name": "dlc_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1117,7 +1117,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1168,7 +1168,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -1219,7 +1219,7 @@
     "title": "Number of days with intense rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xni_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -1270,7 +1270,7 @@
     "title": "Number of days with extreme rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xne_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -1321,7 +1321,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -1372,7 +1372,7 @@
     "title": "10-day NDVI (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -1424,7 +1424,7 @@
     "title": "10-day NDVI anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -1474,7 +1474,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -1522,7 +1522,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -1585,7 +1585,7 @@
     "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {
@@ -1636,7 +1636,7 @@
       "scale": "0.1"
     },
     "server_layer_name": "wp_pop_cicunadj_khm_2020",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "opacity": 0,
     "legend_text": "",
     "legend": []
@@ -1645,7 +1645,7 @@
     "title": "Potential flooding (Sentinel-1)",
     "type": "wms",
     "server_layer_name": "hfs1_sfw_mask_khm",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Sentinel-1 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",
@@ -1663,7 +1663,7 @@
     "title": "Potential flooding (Sentinel-2)",
     "type": "wms",
     "server_layer_name": "hfs2_sfw_mask_khm",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Sentinel-2 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",
@@ -1678,7 +1678,7 @@
     "title": "Potential flooding (Landsat)",
     "type": "wms",
     "server_layer_name": "hfl8_sfw_mask_khm",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Landsat-8 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",

--- a/src/config/cambodia/prism.json
+++ b/src/config/cambodia/prism.json
@@ -17,7 +17,7 @@
   "serversUrls": {
     "wms": [
       "https://geonode.wfp.org/geoserver/prism/wms/",
-      "https://odc.ovio.org/wms"
+      "https://api.earthobservation.vam.wfp.org/ows/wms"
     ]
   },
   "map": {

--- a/src/config/cuba/layers.json
+++ b/src/config/cuba/layers.json
@@ -39,7 +39,7 @@
     "title": "SPI - 1-month",
     "type": "wms",
     "server_layer_name": "r1s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -99,7 +99,7 @@
     "title": "SPI - 3-month",
     "type": "wms",
     "server_layer_name": "r3s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -159,7 +159,7 @@
     "title": "SPI - 6-month",
     "type": "wms",
     "server_layer_name": "r6s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -219,7 +219,7 @@
     "title": "SPI - 9-month",
     "type": "wms",
     "server_layer_name": "r9s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -279,7 +279,7 @@
     "title": "SPI - 1-year",
     "type": "wms",
     "server_layer_name": "rys_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -342,7 +342,7 @@
     "additional_query_params": {
       "styles": "rfh_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -406,7 +406,7 @@
     "title": "10-day rainfall anomaly",
     "type": "wms",
     "server_layer_name": "rfq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -453,7 +453,7 @@
     "title": "Monthly rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -500,7 +500,7 @@
     "title": "3-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r3q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -547,7 +547,7 @@
     "title": "6-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r6q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -594,7 +594,7 @@
     "title": "9-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r9q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -641,7 +641,7 @@
     "title": "1-year rainfall anomaly",
     "type": "wms",
     "server_layer_name": "ryq_blended_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -688,7 +688,7 @@
     "title": "1-month rainfall aggregate (mm)",
     "type": "wms",
     "server_layer_name": "r1h_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "additional_query_params": {
       "styles": "rfh_1500"
     },
@@ -749,7 +749,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
@@ -807,7 +807,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
@@ -865,7 +865,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
@@ -923,7 +923,7 @@
     "additional_query_params": {
       "styles": "rfh_1500"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
@@ -978,7 +978,7 @@
     "title": "Number of dry days",
     "type": "wms",
     "server_layer_name": "dlc_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1029,7 +1029,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1080,7 +1080,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1131,7 +1131,7 @@
     "title": "Number of days with intense rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xni_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -1182,7 +1182,7 @@
     "title": "Number of days with extreme rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xne_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -1233,7 +1233,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1284,7 +1284,7 @@
     "title": "10-day NDVI (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -1336,7 +1336,7 @@
     "title": "10-day NDVI anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -1386,7 +1386,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -1434,7 +1434,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -1497,7 +1497,7 @@
     "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {

--- a/src/config/cuba/prism.json
+++ b/src/config/cuba/prism.json
@@ -12,7 +12,7 @@
   "defaultDisplayBoundaries": ["admin_boundaries", "admin1_boundaries"],
   "serversUrls": {
     "wms": [
-      "https://odc.ovio.org/wms"
+      "https://api.earthobservation.vam.wfp.org/ows/wms"
     ]
   },
   "map": {

--- a/src/config/ecuador/layers.json
+++ b/src/config/ecuador/layers.json
@@ -39,7 +39,7 @@
       "title": "SPI - 1-month",
       "type": "wms",
       "server_layer_name": "r1s_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -99,7 +99,7 @@
       "title": "SPI - 3-month",
       "type": "wms",
       "server_layer_name": "r3s_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -159,7 +159,7 @@
       "title": "SPI - 6-month",
       "type": "wms",
       "server_layer_name": "r6s_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -219,7 +219,7 @@
       "title": "SPI - 9-month",
       "type": "wms",
       "server_layer_name": "r9s_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -279,7 +279,7 @@
       "title": "SPI - 1-year",
       "type": "wms",
       "server_layer_name": "rys_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -342,7 +342,7 @@
       "additional_query_params": {
         "styles": "rfh_350"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group)",
@@ -406,7 +406,7 @@
       "title": "10-day rainfall anomaly",
       "type": "wms",
       "server_layer_name": "rfq_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group)",
@@ -453,7 +453,7 @@
       "title": "Monthly rainfall anomaly",
       "type": "wms",
       "server_layer_name": "r1q_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group)",
@@ -500,7 +500,7 @@
       "title": "3-month rainfall anomaly",
       "type": "wms",
       "server_layer_name": "r3q_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group)",
@@ -547,7 +547,7 @@
       "title": "6-month rainfall anomaly",
       "type": "wms",
       "server_layer_name": "r6q_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group)",
@@ -594,7 +594,7 @@
       "title": "9-month rainfall anomaly",
       "type": "wms",
       "server_layer_name": "r9q_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group)",
@@ -641,7 +641,7 @@
       "title": "1-year rainfall anomaly",
       "type": "wms",
       "server_layer_name": "ryq_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group)",
@@ -688,7 +688,7 @@
       "title": "1-month rainfall aggregate (mm)",
       "type": "wms",
       "server_layer_name": "r1h_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "additional_query_params": {
         "styles": "rfh_1500"
       },
@@ -749,7 +749,7 @@
       "additional_query_params": {
         "styles": "rfh_800"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Total aggregate precipitation over a 3-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group)",
@@ -807,7 +807,7 @@
       "additional_query_params": {
         "styles": "rfh_800"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Total aggregate precipitation over a 6-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group)",
@@ -865,7 +865,7 @@
       "additional_query_params": {
         "styles": "rfh_800"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Total aggregate precipitation over a 9-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group)",
@@ -923,7 +923,7 @@
       "additional_query_params": {
         "styles": "rfh_1500"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Total aggregate precipitation over a 1-year period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group)",
@@ -978,7 +978,7 @@
       "title": "Number of dry days",
       "type": "wms",
       "server_layer_name": "dlc_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1029,7 +1029,7 @@
       "title": "Longest number of consecutive dry days",
       "type": "wms",
       "server_layer_name": "dlx_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1080,7 +1080,7 @@
       "title": "Number of days with heavy rainfall in the last 30 days",
       "type": "wms",
       "server_layer_name": "xnh_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -1131,7 +1131,7 @@
       "title": "Number of days with intense rainfall in the last 30 days",
       "type": "wms",
       "server_layer_name": "xni_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -1182,7 +1182,7 @@
       "title": "Number of days with extreme rainfall in the last 30 days",
       "type": "wms",
       "server_layer_name": "xne_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -1233,7 +1233,7 @@
       "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
       "type": "wms",
       "server_layer_name": "xlh_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -1284,7 +1284,7 @@
       "title": "10-day NDVI (MODIS)",
       "type": "wms",
       "server_layer_name": "mxd13a2_vim_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.0001,
@@ -1336,7 +1336,7 @@
       "title": "10-day NDVI anomaly (MODIS)",
       "type": "wms",
       "server_layer_name": "mxd13a2_viq_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "additional_query_params": {
         "styles": "viq"
@@ -1386,7 +1386,7 @@
       "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
       "type": "wms",
       "server_layer_name": "myd11a2_taa_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "wcsConfig": {
         "scale": 0.02,
         "offset": 0,
@@ -1434,7 +1434,7 @@
       "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
       "type": "wms",
       "server_layer_name": "myd11a2_txa_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.02,
@@ -1497,7 +1497,7 @@
       "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
       "type": "wms",
       "server_layer_name": "myd11a2_txd_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "additional_query_params": {

--- a/src/config/ecuador/prism.json
+++ b/src/config/ecuador/prism.json
@@ -11,7 +11,7 @@
     },
     "serversUrls": {
       "wms": [
-        "https://odc.ovio.org/wms"
+        "https://api.earthobservation.vam.wfp.org/ows/wms"
       ]
     },
     "map": {

--- a/src/config/global/layers.json
+++ b/src/config/global/layers.json
@@ -24,7 +24,7 @@
     "additional_query_params": {
       "styles": "rfh_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -48,7 +48,7 @@
     "title": "10-day rainfall anomaly",
     "type": "wms",
     "server_layer_name": "rfq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -68,7 +68,7 @@
     "title": "Monthly rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -89,7 +89,7 @@
     "title": "1-month rainfall aggregate",
     "type": "wms",
     "server_layer_name": "r1h_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "additional_query_params": {
       "styles": "rfh_1500"
     },
@@ -115,7 +115,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -136,7 +136,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -157,7 +157,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -179,7 +179,7 @@
     "title": "10-day NDVI (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -231,7 +231,7 @@
     "title": "10-day NDVI anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -254,7 +254,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -302,7 +302,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -332,7 +332,7 @@
     "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {
@@ -412,7 +412,7 @@
       "scale": "0.1"
     },
     "server_layer_name": "wp_pop_cicunadj",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "opacity": 0,
     "legend_text": "",
     "legend": []

--- a/src/config/global/prism.json
+++ b/src/config/global/prism.json
@@ -12,7 +12,7 @@
   "serversUrls": {
     "wms": [
       "https://geonode.wfp.org/geoserver/prism/wms/",
-      "https://odc.ovio.org/wms"
+      "https://api.earthobservation.vam.wfp.org/ows/wms"
     ]
   },
   "map": {

--- a/src/config/jordan/layers.json
+++ b/src/config/jordan/layers.json
@@ -21,7 +21,7 @@
       "title": "SPI - 1-month",
       "type": "wms",
       "server_layer_name": "r1s_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -81,7 +81,7 @@
       "title": "SPI - 3-month",
       "type": "wms",
       "server_layer_name": "r3s_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -141,7 +141,7 @@
       "title": "SPI - 6-month",
       "type": "wms",
       "server_layer_name": "r6s_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -201,7 +201,7 @@
       "title": "SPI - 9-month",
       "type": "wms",
       "server_layer_name": "r9s_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -261,7 +261,7 @@
       "title": "SPI - 1-year",
       "type": "wms",
       "server_layer_name": "rys_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -324,7 +324,7 @@
       "additional_query_params": {
         "styles": "rfh_350"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -388,7 +388,7 @@
       "title": "10-day rainfall anomaly",
       "type": "wms",
       "server_layer_name": "rfq_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -435,7 +435,7 @@
       "title": "Monthly rainfall anomaly",
       "type": "wms",
       "server_layer_name": "r1q_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -482,7 +482,7 @@
       "title": "3-month rainfall anomaly",
       "type": "wms",
       "server_layer_name": "r3q_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -529,7 +529,7 @@
       "title": "6-month rainfall anomaly",
       "type": "wms",
       "server_layer_name": "r6q_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -576,7 +576,7 @@
       "title": "9-month rainfall anomaly",
       "type": "wms",
       "server_layer_name": "r9q_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -623,7 +623,7 @@
       "title": "1-year rainfall anomaly",
       "type": "wms",
       "server_layer_name": "ryq_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -670,7 +670,7 @@
       "title": "1-month rainfall aggregate (mm)",
       "type": "wms",
       "server_layer_name": "r1h_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "additional_query_params": {
         "styles": "rfh_1500"
       },
@@ -731,7 +731,7 @@
       "additional_query_params": {
         "styles": "rfh_800"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
@@ -789,7 +789,7 @@
       "additional_query_params": {
         "styles": "rfh_800"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
@@ -847,7 +847,7 @@
       "additional_query_params": {
         "styles": "rfh_800"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
@@ -905,7 +905,7 @@
       "additional_query_params": {
         "styles": "rfh_1500"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
@@ -960,7 +960,7 @@
       "title": "Number of dry days",
       "type": "wms",
       "server_layer_name": "dlc_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1011,7 +1011,7 @@
       "title": "Longest number of consecutive dry days",
       "type": "wms",
       "server_layer_name": "dlx_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1062,7 +1062,7 @@
       "title": "Number of days with heavy rainfall in the last 30 days",
       "type": "wms",
       "server_layer_name": "xnh_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1113,7 +1113,7 @@
       "title": "Number of days with intense rainfall in the last 30 days",
       "type": "wms",
       "server_layer_name": "xni_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -1164,7 +1164,7 @@
       "title": "Number of days with extreme rainfall in the last 30 days",
       "type": "wms",
       "server_layer_name": "xne_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -1215,7 +1215,7 @@
       "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
       "type": "wms",
       "server_layer_name": "xlh_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1266,7 +1266,7 @@
       "title": "10-day NDVI (MODIS)",
       "type": "wms",
       "server_layer_name": "mxd13a2_vim_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.0001,
@@ -1318,7 +1318,7 @@
       "title": "10-day NDVI anomaly (MODIS)",
       "type": "wms",
       "server_layer_name": "mxd13a2_viq_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "additional_query_params": {
         "styles": "viq"
@@ -1368,7 +1368,7 @@
       "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
       "type": "wms",
       "server_layer_name": "myd11a2_taa_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "wcsConfig": {
         "scale": 0.02,
         "offset": 0,
@@ -1416,7 +1416,7 @@
       "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
       "type": "wms",
       "server_layer_name": "myd11a2_txa_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.02,
@@ -1479,7 +1479,7 @@
       "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
       "type": "wms",
       "server_layer_name": "myd11a2_txd_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "additional_query_params": {

--- a/src/config/jordan/prism.json
+++ b/src/config/jordan/prism.json
@@ -11,7 +11,7 @@
     },
     "serversUrls": {
       "wms": [
-        "https://odc.ovio.org/wms"
+        "https://api.earthobservation.vam.wfp.org/ows/wms"
       ]
     },
     "map": {

--- a/src/config/kyrgyzstan/layers.json
+++ b/src/config/kyrgyzstan/layers.json
@@ -390,7 +390,7 @@
     "additional_query_params": {
       "styles": "rfh_200"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -458,7 +458,7 @@
     "title": "10-day rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -505,7 +505,7 @@
     "title": "Monthly rainfall anomaly",
     "type": "wms",
     "server_layer_name": "rfq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -552,7 +552,7 @@
     "title": "3-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r3q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -599,7 +599,7 @@
     "title": "6-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r6q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -646,7 +646,7 @@
     "title": "9-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r9q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -693,7 +693,7 @@
     "title": "1-year rainfall anomaly",
     "type": "wms",
     "server_layer_name": "ryq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -743,7 +743,7 @@
     "additional_query_params": {
       "styles": "rfh_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total aggregate precipitation over a 1-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -810,7 +810,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
@@ -868,7 +868,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
@@ -926,7 +926,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
@@ -984,7 +984,7 @@
     "additional_query_params": {
       "styles": "rfh_1500"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
@@ -1039,7 +1039,7 @@
     "title": "SPI - 1-month",
     "type": "wms",
     "server_layer_name": "r1s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1099,7 +1099,7 @@
     "title": "SPI - 3-month",
     "type": "wms",
     "server_layer_name": "r3s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1159,7 +1159,7 @@
     "title": "SPI - 6-month",
     "type": "wms",
     "server_layer_name": "r6s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1219,7 +1219,7 @@
     "title": "SPI - 9-month",
     "type": "wms",
     "server_layer_name": "r9s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1279,7 +1279,7 @@
     "title": "SPI - 1-year",
     "type": "wms",
     "server_layer_name": "rys_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1339,7 +1339,7 @@
     "title": "Number of dry days",
     "type": "wms",
     "server_layer_name": "dlc_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1390,7 +1390,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1441,7 +1441,7 @@
     "title": "Number of days with intense rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xni_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -1492,7 +1492,7 @@
     "title": "Number of days with extreme rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xne_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -1543,7 +1543,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1594,7 +1594,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1650,7 +1650,7 @@
     "title": "10-day NDVI (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -1702,7 +1702,7 @@
     "title": "10-day NDVI anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -1752,7 +1752,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -1800,7 +1800,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -1863,7 +1863,7 @@
     "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {

--- a/src/config/kyrgyzstan/prism.json
+++ b/src/config/kyrgyzstan/prism.json
@@ -26,7 +26,7 @@
   ],
   "serversUrls": {
     "wms": [
-      "https://odc.ovio.org/wms",
+      "https://api.earthobservation.vam.wfp.org/ows/wms",
       "https://geonode.wfp.org/geoserver/prism/wms/",
       "https://kyrgyzstan.sibelius-datacube.org:5000/wms"
     ]

--- a/src/config/mozambique/layers.json
+++ b/src/config/mozambique/layers.json
@@ -67,7 +67,7 @@
       ],
       "type": "bar"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -146,7 +146,7 @@
       ],
       "type": "line"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -193,7 +193,7 @@
     "title": "1-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "1-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -240,7 +240,7 @@
     "title": "3-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r3q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -287,7 +287,7 @@
     "title": "6-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r6q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -334,7 +334,7 @@
     "title": "9-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r9q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -381,7 +381,7 @@
     "title": "1-year rainfall anomaly",
     "type": "wms",
     "server_layer_name": "ryq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -431,7 +431,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 1-month period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -494,7 +494,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 2 month dekadal rainfall aggregations (mm)",
@@ -557,7 +557,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 3-month period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -620,7 +620,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 6-month period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -683,7 +683,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 9-month period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -746,7 +746,7 @@
     "additional_query_params": {
       "styles": "rfh_1500"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 1-year period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -806,7 +806,7 @@
     "title": "Number of dry days",
     "type": "wms",
     "server_layer_name": "dlc_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -857,7 +857,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -908,7 +908,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -959,7 +959,7 @@
     "title": "Number of days with intense rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xni_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -1010,7 +1010,7 @@
     "title": "Number of days with extreme rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xne_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -1061,7 +1061,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -1127,7 +1127,7 @@
       ],
       "type": "line"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -1179,7 +1179,7 @@
     "title": "10-day NDVI 1km (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -1246,7 +1246,7 @@
       ],
       "type": "line"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -1296,7 +1296,7 @@
     "title": "10-day NDVI anomaly 1km (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -1346,7 +1346,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -1394,7 +1394,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -1457,7 +1457,7 @@
     "title": "Daytime Land Surface Temperature - 10-day 1km (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -1520,7 +1520,7 @@
       "title": "INAM blended mean maximum air temperature (10-day)",
       "type": "wms",
       "server_layer_name": "myd11a2_blended_txb_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.02,
@@ -1588,7 +1588,7 @@
       "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
       "type": "wms",
       "server_layer_name": "myd11a2_txd_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "additional_query_params": {
@@ -1638,7 +1638,7 @@
       "title": "Daytime Land Surface Temperature - 10-day Anomaly 1km (MODIS)",
       "type": "wms",
       "server_layer_name": "myd11a2_txd_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "additional_query_params": {
@@ -1688,7 +1688,7 @@
       "title": "INAM blended mean maximum air temperature anomaly (10-day)",
       "type": "wms",
       "server_layer_name": "myd11a2_blended_txd_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Temperature anomaly based on long term average compared to local station data from INAM blended with MODIS daytime land surface temperature estimates",
@@ -1738,7 +1738,7 @@
       "additional_query_params": {
         "styles": "rfb_350"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Local station data from INAM blended with CHIRP rainfall estimates",
@@ -1805,7 +1805,7 @@
       "additional_query_params": {
         "styles": "rfq"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "legend_text": "Rainfall anomaly based on long term averaged from local station data from INAM blended with CHIRP rainfall estimates",
@@ -1852,7 +1852,7 @@
       "title": "INAM blended monthly aggregate rainfall",
       "type": "wms",
       "server_layer_name": "rnb_blended_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "opacity": 0.7,
       "additional_query_params": {
@@ -1925,7 +1925,7 @@
         ],
         "type": "line"
       },
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -1985,7 +1985,7 @@
       "title": "SPI - 3-month",
       "type": "wms",
       "server_layer_name": "r3s_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -2045,7 +2045,7 @@
       "title": "SPI - 6-month",
       "type": "wms",
       "server_layer_name": "r6s_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -2105,7 +2105,7 @@
       "title": "SPI - 9-month",
       "type": "wms",
       "server_layer_name": "r9s_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -2165,7 +2165,7 @@
       "title": "SPI - 1-year",
       "type": "wms",
       "server_layer_name": "rys_dekad",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "date_interval": "days",
       "wcsConfig": {
         "scale": 0.001,
@@ -2255,7 +2255,7 @@
         "offset": 0
       },
       "server_layer_name": "wp_pop_cicunadj",
-      "base_url": "https://odc.ovio.org/",
+      "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
       "opacity": 0,
       "legend_text": "",
       "legend": []

--- a/src/config/mozambique/prism.json
+++ b/src/config/mozambique/prism.json
@@ -17,9 +17,8 @@
   ],
   "serversUrls": {
     "wms": [
-      "https://odc.ovio.org/wms",
-      "https://geonode.wfp.org/geoserver/prism/wms",
-      "https://ows.digitalearth.africa/wms"
+      "https://api.earthobservation.vam.wfp.org/ows/wms",
+      "https://geonode.wfp.org/geoserver/prism/wms"
     ]
   },
   "map": {

--- a/src/config/myanmar/layers.json
+++ b/src/config/myanmar/layers.json
@@ -291,7 +291,7 @@
     "additional_query_params": {
       "styles": "rfh_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -316,7 +316,7 @@
     "type": "wms",
     "server_layer_name": "rfq_dekad",
     "content_path": "data/myanmar/contents.md#10-day-rainfall-anomaly",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -337,7 +337,7 @@
     "type": "wms",
     "server_layer_name": "r1q_dekad",
     "content_path": "data/myanmar/contents.md#monthly-rainfall-anomaly",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -362,7 +362,7 @@
     "additional_query_params": {
       "styles": "rfh_1500"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total aggregate precipitation over a 1-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -386,7 +386,7 @@
     "type": "wms",
     "server_layer_name": "dlx_dekad",
     "content_path": "data/myanmar/contents.md#longest-number-of-consecutive-dry-days",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -408,7 +408,7 @@
     "type": "wms",
     "server_layer_name": "xnh_dekad",
     "content_path": "data/myanmar/contents.md#number-of-days-with-heavy-rainfall-in-the-last-30-days",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -430,7 +430,7 @@
     "type": "wms",
     "server_layer_name": "xlh_dekad",
     "content_path": "data/myanmar/contents.md#longest-consecutive-number-of-days-with-heavy-rainfall-in-the-last-30-days",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -452,7 +452,7 @@
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
     "content_path": "data/myanmar/contents.md#10-day-NDVI",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -505,7 +505,7 @@
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
     "content_path": "data/myanmar/contents.md#10-day-NDVI-anomaly",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -528,7 +528,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -577,7 +577,7 @@
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
     "content_path": "data/myanmar/contents.md#land-surface-temperature",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -608,7 +608,7 @@
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
     "content_path": "data/myanmar/contents.md#land-surface-temperature-anomaly",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {
@@ -1314,7 +1314,7 @@
       "scale": "0.1"
     },
     "server_layer_name": "wp_pop_cicunadj",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "opacity": 0,
     "legend_text": "",
     "legend": []
@@ -1334,7 +1334,7 @@
     "title": "Potential flooding (Sentinel-1)",
     "type": "wms",
     "server_layer_name": "hfs1_sfw_mask_mmr",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Sentinel-1 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",
@@ -1347,7 +1347,7 @@
     "title": "Potential flooding (Sentinel-2)",
     "type": "wms",
     "server_layer_name": "hfs2_sfw_mask_mmr",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Sentinel-2 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",
@@ -1360,7 +1360,7 @@
     "title": "Potential flooding (Landsat-8)",
     "type": "wms",
     "server_layer_name": "hfl8_sfw_mask_mmr",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 1.0,
     "legend_text": "Flood water detected from Landsat-8 data and a permanent water mask from JRC. Source: SERVIR Mekong HYDRAFloods",

--- a/src/config/myanmar/prism.json
+++ b/src/config/myanmar/prism.json
@@ -22,7 +22,7 @@
   ],
   "serversUrls": {
     "wms": [
-      "https://odc.ovio.org/wms",
+      "https://api.earthobservation.vam.wfp.org/ows/wms",
       "https://geonode.wfp.org/geoserver/prism/wms/"
     ]
   },

--- a/src/config/namibia/layers.json
+++ b/src/config/namibia/layers.json
@@ -24,7 +24,7 @@
     "additional_query_params": {
       "styles": "rfh_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS rainfall global dekad",
@@ -48,7 +48,7 @@
     "title": "10-day rainfall anomaly",
     "type": "wms",
     "server_layer_name": "rfq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS rainfall anomaly dekad",
@@ -95,7 +95,7 @@
     "title": "1-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -142,7 +142,7 @@
     "title": "3-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r3q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -189,7 +189,7 @@
     "title": "6-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r6q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -236,7 +236,7 @@
     "title": "9-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r9q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -283,7 +283,7 @@
     "title": "1-year rainfall anomaly",
     "type": "wms",
     "server_layer_name": "ryq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -333,7 +333,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 month dekadal rainfall aggregations (mm)",
@@ -359,7 +359,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 2 month dekadal rainfall aggregations (mm)",
@@ -385,7 +385,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
@@ -411,7 +411,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
@@ -437,7 +437,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
@@ -463,7 +463,7 @@
     "additional_query_params": {
       "styles": "rfh_1500"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
@@ -486,7 +486,7 @@
     "title": "Number of dry days",
     "type": "wms",
     "server_layer_name": "dlc_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -507,7 +507,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -528,7 +528,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -549,7 +549,7 @@
     "title": "Number of days with intense rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xni_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -570,7 +570,7 @@
     "title": "Number of days with extreme rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xne_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -591,7 +591,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -613,7 +613,7 @@
     "title": "10-day NDVI (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -665,7 +665,7 @@
     "title": "10-day NDVI 1km (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "wcsConfig": {
@@ -717,7 +717,7 @@
     "title": "10-day NDVI anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -740,7 +740,7 @@
     "title": "10-day NDVI anomaly 1km (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -763,7 +763,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -811,7 +811,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -841,7 +841,7 @@
     "title": "Daytime Land Surface Temperature - 10-day 1km (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -871,7 +871,7 @@
     "title": "Blended air temperature daily max (10-day)",
     "type": "wms",
     "server_layer_name": "myd11a2_blended_txb_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "LEGEND",
@@ -898,7 +898,7 @@
     "title": "Blended air temperature max anomaly (10-day)",
     "type": "wms",
     "server_layer_name": "myd11a2_blended_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "LEGEND",
@@ -921,7 +921,7 @@
     "title": "Blended temperature estimates (10-day)",
     "type": "wms",
     "server_layer_name": "myd11a2_blended_txb_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -950,7 +950,7 @@
     "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {
@@ -973,7 +973,7 @@
     "title": "Daytime Land Surface Temperature - 10-day Anomaly 1km (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {
@@ -996,7 +996,7 @@
     "title": "Blended temperature anomaly (10-day)",
     "type": "wms",
     "server_layer_name": "myd11a2_blended_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Temperature anomaly based on long term average compared to local station data blended with MODIS daytime land surface temperature estimates",
@@ -1019,7 +1019,7 @@
     "additional_query_params": {
       "styles": "rfb_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Local station data blended with CHIRP rainfall estimates",
@@ -1046,7 +1046,7 @@
     "additional_query_params": {
       "styles": "rfq"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Rainfall anomaly based on long term averaged from local station data blended with CHIRP rainfall estimates",
@@ -1066,7 +1066,7 @@
     "title": "Blended monthly aggregate rainfall",
     "type": "wms",
     "server_layer_name": "rnb_blended_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {
@@ -1097,7 +1097,7 @@
       "offset": 0
     },
     "server_layer_name": "wp_pop_cicunadj",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "opacity": 0,
     "legend_text": "",
     "legend": []

--- a/src/config/namibia/prism.json
+++ b/src/config/namibia/prism.json
@@ -10,7 +10,7 @@
   "alertFormActive": false,
   "serversUrls": {
     "wms": [
-      "https://odc.ovio.org/wms",
+      "https://api.earthobservation.vam.wfp.org/ows/wms",
       "https://geonode.wfp.org/geoserver/prism/wms"
     ]
   },

--- a/src/config/rbd/layers.json
+++ b/src/config/rbd/layers.json
@@ -78,7 +78,7 @@
     "additional_query_params": {
       "styles": "rfh_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -137,7 +137,7 @@
     "title": "10-day rainfall anomaly",
     "type": "wms",
     "server_layer_name": "rfq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -184,7 +184,7 @@
     "title": "1-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -231,7 +231,7 @@
     "title": "3-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r3q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -278,7 +278,7 @@
     "title": "6-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r6q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -325,7 +325,7 @@
     "title": "9-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r9q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -372,7 +372,7 @@
     "title": "1-year rainfall anomaly",
     "type": "wms",
     "server_layer_name": "ryq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -422,7 +422,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total aggregate precipitation over a 1-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -480,7 +480,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total aggregate precipitation over a 3-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -538,7 +538,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total aggregate precipitation over a 6-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -596,7 +596,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total aggregate precipitation over a 9-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -654,7 +654,7 @@
     "additional_query_params": {
       "styles": "rfh_1500"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total aggregate precipitation over a 1-year period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -709,7 +709,7 @@
     "title": "SPI - 1-month",
     "type": "wms",
     "server_layer_name": "r1s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -769,7 +769,7 @@
     "title": "SPI - 3-month",
     "type": "wms",
     "server_layer_name": "r3s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -829,7 +829,7 @@
     "title": "SPI - 6-month",
     "type": "wms",
     "server_layer_name": "r6s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -889,7 +889,7 @@
     "title": "SPI - 9-month",
     "type": "wms",
     "server_layer_name": "r9s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -949,7 +949,7 @@
     "title": "SPI - 1-year",
     "type": "wms",
     "server_layer_name": "rys_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1009,7 +1009,7 @@
     "title": "Number of dry days",
     "type": "wms",
     "server_layer_name": "dlc_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1060,7 +1060,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1111,7 +1111,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -1162,7 +1162,7 @@
     "title": "Number of days with intense rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xni_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -1213,7 +1213,7 @@
     "title": "Number of days with extreme rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xne_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -1264,7 +1264,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -1315,7 +1315,7 @@
     "title": "10-day NDVI (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -1367,7 +1367,7 @@
     "title": "10-day NDVI anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -1417,7 +1417,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -1465,7 +1465,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -1528,7 +1528,7 @@
     "title": "Nighttime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -1591,7 +1591,7 @@
     "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {

--- a/src/config/rbd/prism.json
+++ b/src/config/rbd/prism.json
@@ -15,7 +15,7 @@
   "defaultLayer": "rain_anomaly_dekad",
   "serversUrls": {
     "wms": [
-      "https://odc.ovio.org/wms"
+      "https://api.earthobservation.vam.wfp.org/ows/wms"
     ]
   },
   "map": {

--- a/src/config/sierraleone/layers.json
+++ b/src/config/sierraleone/layers.json
@@ -21,7 +21,7 @@
     "title": "SPI - 1-month",
     "type": "wms",
     "server_layer_name": "r1s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -81,7 +81,7 @@
     "title": "SPI - 3-month",
     "type": "wms",
     "server_layer_name": "r3s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -141,7 +141,7 @@
     "title": "SPI - 6-month",
     "type": "wms",
     "server_layer_name": "r6s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -201,7 +201,7 @@
     "title": "SPI - 9-month",
     "type": "wms",
     "server_layer_name": "r9s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -261,7 +261,7 @@
     "title": "SPI - 1-year",
     "type": "wms",
     "server_layer_name": "rys_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -324,7 +324,7 @@
     "additional_query_params": {
       "styles": "rfh_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -388,7 +388,7 @@
     "title": "10-day rainfall anomaly",
     "type": "wms",
     "server_layer_name": "rfq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -435,7 +435,7 @@
     "title": "Monthly rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -482,7 +482,7 @@
     "title": "3-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r3q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -529,7 +529,7 @@
     "title": "6-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r6q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -576,7 +576,7 @@
     "title": "9-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r9q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -623,7 +623,7 @@
     "title": "1-year rainfall anomaly",
     "type": "wms",
     "server_layer_name": "ryq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -670,7 +670,7 @@
     "title": "1-month rainfall aggregate (mm)",
     "type": "wms",
     "server_layer_name": "r1h_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "additional_query_params": {
       "styles": "rfh_1500"
     },
@@ -731,7 +731,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
@@ -789,7 +789,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
@@ -847,7 +847,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
@@ -905,7 +905,7 @@
     "additional_query_params": {
       "styles": "rfh_1500"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
@@ -960,7 +960,7 @@
     "title": "Number of dry days",
     "type": "wms",
     "server_layer_name": "dlc_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1011,7 +1011,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1062,7 +1062,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1113,7 +1113,7 @@
     "title": "Number of days with intense rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xni_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -1164,7 +1164,7 @@
     "title": "Number of days with extreme rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xne_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -1215,7 +1215,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1266,7 +1266,7 @@
     "title": "10-day NDVI (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -1318,7 +1318,7 @@
     "title": "10-day NDVI anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -1368,7 +1368,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -1416,7 +1416,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -1479,7 +1479,7 @@
     "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {
@@ -1586,7 +1586,7 @@
       "scale": "0.1"
     },
     "server_layer_name": "wp_pop_cicunadj",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "opacity": 0,
     "legend_text": "",
     "legend": []

--- a/src/config/sierraleone/prism.json
+++ b/src/config/sierraleone/prism.json
@@ -13,7 +13,7 @@
   "serversUrls": {
     "wms": [
       "https://geonode.wfp.org/geoserver/prism/wms/",
-      "https://odc.ovio.org/wms"
+      "https://api.earthobservation.vam.wfp.org/ows/wms"
     ]
   },
   "map": {

--- a/src/config/srilanka/layers.json
+++ b/src/config/srilanka/layers.json
@@ -57,7 +57,7 @@
     "title": "SPI - 1-month",
     "type": "wms",
     "server_layer_name": "r1s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -117,7 +117,7 @@
     "title": "SPI - 3-month",
     "type": "wms",
     "server_layer_name": "r3s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -177,7 +177,7 @@
     "title": "SPI - 6-month",
     "type": "wms",
     "server_layer_name": "r6s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -237,7 +237,7 @@
     "title": "SPI - 9-month",
     "type": "wms",
     "server_layer_name": "r9s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -297,7 +297,7 @@
     "title": "SPI - 1-year",
     "type": "wms",
     "server_layer_name": "rys_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -360,7 +360,7 @@
     "additional_query_params": {
       "styles": "rfh_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -424,7 +424,7 @@
     "title": "10-day rainfall anomaly",
     "type": "wms",
     "server_layer_name": "rfq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -471,7 +471,7 @@
     "title": "Monthly rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -518,7 +518,7 @@
     "title": "3-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r3q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -565,7 +565,7 @@
     "title": "6-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r6q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -612,7 +612,7 @@
     "title": "9-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r9q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -659,7 +659,7 @@
     "title": "1-year rainfall anomaly",
     "type": "wms",
     "server_layer_name": "ryq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -706,7 +706,7 @@
     "title": "1-month rainfall aggregate (mm)",
     "type": "wms",
     "server_layer_name": "r1h_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "additional_query_params": {
       "styles": "rfh_1500"
     },
@@ -767,7 +767,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
@@ -825,7 +825,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
@@ -883,7 +883,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
@@ -941,7 +941,7 @@
     "additional_query_params": {
       "styles": "rfh_1500"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
@@ -996,7 +996,7 @@
     "title": "Number of dry days",
     "type": "wms",
     "server_layer_name": "dlc_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1047,7 +1047,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1098,7 +1098,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1149,7 +1149,7 @@
     "title": "Number of days with intense rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xni_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -1200,7 +1200,7 @@
     "title": "Number of days with extreme rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xne_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -1251,7 +1251,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1302,7 +1302,7 @@
     "title": "10-day NDVI (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -1354,7 +1354,7 @@
     "title": "10-day NDVI anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -1404,7 +1404,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -1452,7 +1452,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -1515,7 +1515,7 @@
     "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {
@@ -1622,7 +1622,7 @@
       "scale": "0.1"
     },
     "server_layer_name": "wp_pop_cicunadj",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "opacity": 0,
     "legend_text": "",
     "legend": []

--- a/src/config/srilanka/prism.json
+++ b/src/config/srilanka/prism.json
@@ -12,7 +12,7 @@
   "serversUrls": {
     "wms": [
       "https://geonode.wfp.org/geoserver/prism/wms/",
-      "https://odc.ovio.org/wms"
+      "https://api.earthobservation.vam.wfp.org/ows/wms"
     ]
   },
   "map": {

--- a/src/config/tajikistan/layers.json
+++ b/src/config/tajikistan/layers.json
@@ -24,7 +24,7 @@
     "additional_query_params": {
       "styles": "rfh_200"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -49,7 +49,7 @@
     "title": "10-day rainfall anomaly",
     "type": "wms",
     "server_layer_name": "rfq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -69,7 +69,7 @@
     "title": "Monthly rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -92,7 +92,7 @@
     "additional_query_params": {
       "styles": "rfh_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total aggregate precipitation over a 1-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -116,7 +116,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -137,7 +137,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -158,7 +158,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -180,7 +180,7 @@
     "title": "10-day NDVI (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -232,7 +232,7 @@
     "title": "10-day NDVI anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -255,7 +255,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -303,7 +303,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -333,7 +333,7 @@
     "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {
@@ -361,7 +361,7 @@
       "scale": "0.1"
     },
     "server_layer_name": "wp_pop_cicunadj",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "opacity": 0,
     "legend_text": "",
     "legend": []

--- a/src/config/tajikistan/prism.json
+++ b/src/config/tajikistan/prism.json
@@ -11,7 +11,7 @@
   "alertFormActive": false,
   "serversUrls": {
     "wms": [
-      "https://odc.ovio.org/wms",
+      "https://api.earthobservation.vam.wfp.org/ows/wms",
       "https://geonode.wfp.org/geoserver/prism/wms"
     ]
   },

--- a/src/config/ukraine/layers.json
+++ b/src/config/ukraine/layers.json
@@ -68,7 +68,7 @@
       ],
       "type": "bar"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS rainfall global dekad",
@@ -132,7 +132,7 @@
     "title": "10-day rainfall anomaly",
     "type": "wms",
     "server_layer_name": "rfq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS rainfall anomaly dekad",
@@ -179,7 +179,7 @@
     "title": "1-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -226,7 +226,7 @@
     "title": "3-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r3q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -273,7 +273,7 @@
     "title": "6-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r6q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -320,7 +320,7 @@
     "title": "9-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r9q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -367,7 +367,7 @@
     "title": "1-year rainfall anomaly",
     "type": "wms",
     "server_layer_name": "ryq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -417,7 +417,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 month dekadal rainfall aggregations (mm)",
@@ -480,7 +480,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 2 month dekadal rainfall aggregations (mm)",
@@ -543,7 +543,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
@@ -606,7 +606,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
@@ -669,7 +669,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
@@ -732,7 +732,7 @@
     "additional_query_params": {
       "styles": "rfh_1500"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
@@ -792,7 +792,7 @@
     "title": "Number of dry days",
     "type": "wms",
     "server_layer_name": "dlc_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -843,7 +843,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -894,7 +894,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -945,7 +945,7 @@
     "title": "Number of days with intense rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xni_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -996,7 +996,7 @@
     "title": "Number of days with extreme rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xne_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -1047,7 +1047,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
@@ -1106,7 +1106,7 @@
     "additional_query_params": {
       "styles": "vim_12_0_1"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -1198,7 +1198,7 @@
     "title": "10-day NDVI anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq_12_50_150_new"
@@ -1291,7 +1291,7 @@
     "additional_query_params": {
       "styles": "taa_13_0_38_v2"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "wcsConfig": {
@@ -1372,7 +1372,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -1476,7 +1476,7 @@
     "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {
@@ -1555,7 +1555,7 @@
     "title": "SPI - 1-month",
     "type": "wms",
     "server_layer_name": "r1s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1615,7 +1615,7 @@
     "title": "SPI - 3-month",
     "type": "wms",
     "server_layer_name": "r3s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1675,7 +1675,7 @@
     "title": "SPI - 6-month",
     "type": "wms",
     "server_layer_name": "r6s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1735,7 +1735,7 @@
     "title": "SPI - 9-month",
     "type": "wms",
     "server_layer_name": "r9s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -1795,7 +1795,7 @@
     "title": "SPI - 1-year",
     "type": "wms",
     "server_layer_name": "rys_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,

--- a/src/config/ukraine/prism.json
+++ b/src/config/ukraine/prism.json
@@ -12,7 +12,7 @@
   "defaultDisplayBoundaries": ["admin_boundaries", "admin1_boundaries"],
   "serversUrls": {
     "wms": [
-      "https://odc.ovio.org/wms"
+      "https://api.earthobservation.vam.wfp.org/ows/wms"
     ]
   },
   "map": {

--- a/src/config/zimbabwe/layers.json
+++ b/src/config/zimbabwe/layers.json
@@ -39,7 +39,7 @@
     "title": "SPI - 1-month",
     "type": "wms",
     "server_layer_name": "r1s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -99,7 +99,7 @@
     "title": "SPI - 3-month",
     "type": "wms",
     "server_layer_name": "r3s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -159,7 +159,7 @@
     "title": "SPI - 6-month",
     "type": "wms",
     "server_layer_name": "r6s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -219,7 +219,7 @@
     "title": "SPI - 9-month",
     "type": "wms",
     "server_layer_name": "r9s_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -279,7 +279,7 @@
     "title": "SPI - 1-year",
     "type": "wms",
     "server_layer_name": "rys_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.001,
@@ -342,7 +342,7 @@
     "additional_query_params": {
       "styles": "rfh_350"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -406,7 +406,7 @@
     "title": "10-day rainfall anomaly",
     "type": "wms",
     "server_layer_name": "rfq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -453,7 +453,7 @@
     "title": "Monthly rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r1q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -500,7 +500,7 @@
     "title": "3-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r3q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -547,7 +547,7 @@
     "title": "6-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r6q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -594,7 +594,7 @@
     "title": "9-month rainfall anomaly",
     "type": "wms",
     "server_layer_name": "r9q_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -641,7 +641,7 @@
     "title": "1-year rainfall anomaly",
     "type": "wms",
     "server_layer_name": "ryq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -688,7 +688,7 @@
     "title": "1-month rainfall aggregate (mm)",
     "type": "wms",
     "server_layer_name": "r1h_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "additional_query_params": {
       "styles": "rfh_1500"
     },
@@ -749,7 +749,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
@@ -807,7 +807,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
@@ -865,7 +865,7 @@
     "additional_query_params": {
       "styles": "rfh_800"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
@@ -923,7 +923,7 @@
     "additional_query_params": {
       "styles": "rfh_1500"
     },
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
@@ -978,7 +978,7 @@
     "title": "Number of dry days",
     "type": "wms",
     "server_layer_name": "dlc_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
@@ -1029,7 +1029,7 @@
     "title": "Longest number of consecutive dry days",
     "type": "wms",
     "server_layer_name": "dlx_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1080,7 +1080,7 @@
     "title": "Number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xnh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1131,7 +1131,7 @@
     "title": "Number of days with intense rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xni_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
@@ -1182,7 +1182,7 @@
     "title": "Number of days with extreme rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xne_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
@@ -1233,7 +1233,7 @@
     "title": "Longest consecutive number of days with heavy rainfall in the last 30 days",
     "type": "wms",
     "server_layer_name": "xlh_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -1284,7 +1284,7 @@
     "title": "10-day NDVI (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "wcsConfig": {
@@ -1336,7 +1336,7 @@
     "title": "10-day NDVI anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "mxd13a2_viq_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
       "styles": "viq"
@@ -1386,7 +1386,7 @@
     "title": "Land Surface Temperature - 10-day Amplitude (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_taa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "wcsConfig": {
       "scale": 0.02,
       "offset": 0,
@@ -1434,7 +1434,7 @@
     "title": "Daytime Land Surface Temperature - 10-day (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txa_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.02,
@@ -1497,7 +1497,7 @@
     "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
-    "base_url": "https://odc.ovio.org/",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {

--- a/src/config/zimbabwe/prism.json
+++ b/src/config/zimbabwe/prism.json
@@ -3,7 +3,7 @@
   "alertFormActive": false,
   "serversUrls": {
     "wms": [
-      "https://odc.ovio.org/wms",
+      "https://api.earthobservation.vam.wfp.org/ows/wms",
       "https://geonode.wfp.org/geoserver/prism/wms"
     ]
   },


### PR DESCRIPTION
This PR updates the configuration of all PRISM deployments to replace references to WFP's Data Cube deployment to make use of the final production URL. Replaces https://odc.ovio.org/ with https://api.earthobservation.vam.wfp.org/ows/

Two test files were also updated