### PR TITLE
Fix conditional to include date parameter for geotiff url

### DIFF
--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -245,8 +245,7 @@ const createAPIRequestParams = (
     : undefined;
 
   const { wcsConfig } = geotiffLayer;
-  const dateValue =
-    !wcsConfig || !wcsConfig.disableDateParam ? date : undefined;
+  const dateValue = !wcsConfig?.disableDateParam ? date : undefined;
 
   // we force group_by to be defined with &
   // eslint-disable-next-line camelcase

--- a/src/context/analysisResultStateSlice.ts
+++ b/src/context/analysisResultStateSlice.ts
@@ -246,7 +246,7 @@ const createAPIRequestParams = (
 
   const { wcsConfig } = geotiffLayer;
   const dateValue =
-    !wcsConfig || wcsConfig.disableDateParam === false ? date : undefined;
+    !wcsConfig || !wcsConfig.disableDateParam ? date : undefined;
 
   // we force group_by to be defined with &
   // eslint-disable-next-line camelcase


### PR DESCRIPTION
closes #585 

**How to test:**
- Set to run analysis.
- Select SPI 1 month as hazard layer.
- Select admin boundaries as baseline layer.
- Press run analysis

Verify that within the stats request in the network tab, the geotiff url has the time parameter, with the date specified.

<img width="1275" alt="image" src="https://user-images.githubusercontent.com/3285923/195006101-963129a7-135c-480a-9227-1b1bfbb08fd2.png">


