### PR TITLE
Update color ramps & styles for climate layers; reorganize top navigation; COUNTRY=srilanka

### DIFF
--- a/src/config/srilanka/layers.json
+++ b/src/config/srilanka/layers.json
@@ -53,6 +53,354 @@
       }
     }
   },
+  "rainfall_dekad": {
+    "title": "10-day rainfall estimate (mm)",
+    "type": "wms",
+    "server_layer_name": "rfh_dekad",
+    "additional_query_params": {
+      "styles": "rfh_16_0_300"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-2 mm", "color": "#fffadf" },
+      { "value": 2, "label": "2-5 mm", "color": "#d3f9d0" },
+      { "value": 5, "label": "5-10 mm", "color": "#a9e4a3" },
+      { "value": 10, "label": "10-20 mm", "color": "#7cc594" },
+      { "value": 20, "label": "20-30 mm", "color": "#5eab91" },
+      { "value": 30, "label": "30-40 mm", "color": "#9fffe8" },
+      { "value": 40, "label": "40-50 mm", "color": "#90e0ef" },
+      { "value": 50, "label": "50-60 mm", "color": "#00b1de" },
+      { "value": 60, "label": "60-80 mm", "color": "#0083f3" },
+      { "value": 80, "label": "80-100 mm", "color": "#0052cd" },
+      { "value": 100, "label": "100-120 mm", "color": "#0000c8" },
+      { "value": 120, "label": "120-150 mm", "color": "#6003b8" },
+      { "value": 150, "label": "150-200 mm", "color": "#a002fa" },
+      { "value": 200, "label": "200-300 mm", "color": "#fa78fa" },
+      { "value": 300, "label": ">= 300 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "rain_anomaly_dekad": {
+    "title": "10-day rainfall anomaly",
+    "type": "wms",
+    "server_layer_name": "rfq_dekad",
+    "additional_query_params": {
+      "styles": "ryq_14_50_200"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
+    "legend": [
+      { "value": 0, "label": "< 20%", "color": "#8c4800" },
+      { "value": 20, "label": "20-40%", "color": "#af6b27" },
+      { "value": 40, "label": "40-60%", "color": "#d58c3e" },
+      { "value": 60, "label": "60-70%", "color": "#eaa83d" },
+      { "value": 70, "label": "70-80%", "color": "#f5c878" },
+      { "value": 80, "label": "80-90%", "color": "#fff0c4" },
+      { "value": 90, "label": "90-110%", "color": "#fafafa" },
+      { "value": 110, "label": "110-120%", "color": "#befafa" },
+      { "value": 120, "label": "120-130%", "color": "#78e2f0" },
+      { "value": 130, "label": "130-150%", "color": "#00b9de" },
+      { "value": 150, "label": "150-200%", "color": "#0083f3" },
+      { "value": 200, "label": "200-300%", "color": "#0052cd" },
+      { "value": 300, "label": "300-400%", "color": "#0000c8" },
+      { "value": 400, "label": "> 400%", "color": "#a002fa" }
+    ]
+  },
+  "rain_anomaly_1month": {
+    "title": "Monthly rainfall anomaly",
+    "type": "wms",
+    "server_layer_name": "r1q_dekad",
+    "additional_query_params": {
+      "styles": "rfq_14_20_400"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
+    "legend": [
+      { "value": 0, "label": "< 20%", "color": "#8c4800" },
+      { "value": 20, "label": "20-40%", "color": "#af6b27" },
+      { "value": 40, "label": "40-60%", "color": "#d58c3e" },
+      { "value": 60, "label": "60-70%", "color": "#eaa83d" },
+      { "value": 70, "label": "70-80%", "color": "#f5c878" },
+      { "value": 80, "label": "80-90%", "color": "#fff0c4" },
+      { "value": 90, "label": "90-110%", "color": "#fafafa" },
+      { "value": 110, "label": "110-120%", "color": "#befafa" },
+      { "value": 120, "label": "120-130%", "color": "#78e2f0" },
+      { "value": 130, "label": "130-150%", "color": "#00b9de" },
+      { "value": 150, "label": "150-200%", "color": "#0083f3" },
+      { "value": 200, "label": "200-300%", "color": "#0052cd" },
+      { "value": 300, "label": "300-400%", "color": "#0000c8" },
+      { "value": 400, "label": "> 400%", "color": "#a002fa" }
+    ]
+  },
+  "rain_anomaly_3month": {
+    "title": "3-month rainfall anomaly",
+    "type": "wms",
+    "server_layer_name": "r3q_dekad",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "additional_query_params": {
+      "styles": "rfq_14_20_400"
+    },
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
+    "legend": [
+      { "value": 0, "label": "< 20%", "color": "#8c4800" },
+      { "value": 20, "label": "20-40%", "color": "#af6b27" },
+      { "value": 40, "label": "40-60%", "color": "#d58c3e" },
+      { "value": 60, "label": "60-70%", "color": "#eaa83d" },
+      { "value": 70, "label": "70-80%", "color": "#f5c878" },
+      { "value": 80, "label": "80-90%", "color": "#fff0c4" },
+      { "value": 90, "label": "90-110%", "color": "#fafafa" },
+      { "value": 110, "label": "110-120%", "color": "#befafa" },
+      { "value": 120, "label": "120-130%", "color": "#78e2f0" },
+      { "value": 130, "label": "130-150%", "color": "#00b9de" },
+      { "value": 150, "label": "150-200%", "color": "#0083f3" },
+      { "value": 200, "label": "200-300%", "color": "#0052cd" },
+      { "value": 300, "label": "300-400%", "color": "#0000c8" },
+      { "value": 400, "label": "> 400%", "color": "#a002fa" }
+    ]
+  },
+  "rain_anomaly_6month": {
+    "title": "6-month rainfall anomaly",
+    "type": "wms",
+    "server_layer_name": "r6q_dekad",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "additional_query_params": {
+      "styles": "ryq_14_50_200"
+    },
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
+    "legend": [
+      { "value": 0, "label": "< 50%", "color": "#8c4800" },
+      { "value": 50, "label": "50-60%", "color": "#af6b27" },
+      { "value": 60, "label": "60-70%", "color": "#d58c3e" },
+      { "value": 70, "label": "70-80%", "color": "#eaa83d" },
+      { "value": 80, "label": "80-90%", "color": "#f5c878" },
+      { "value": 90, "label": "90-95%", "color": "#fff0c4" },
+      { "value": 95, "label": "95-105%", "color": "#fafafa" },
+      { "value": 105, "label": "105-110%", "color": "#befafa" },
+      { "value": 110, "label": "110-120%", "color": "#78e2f0" },
+      { "value": 120, "label": "120-130%", "color": "#00b9de" },
+      { "value": 130, "label": "130-150%", "color": "#0083f3" },
+      { "value": 150, "label": "150-170%", "color": "#0052cd" },
+      { "value": 170, "label": "170-200%", "color": "#0000c8" },
+      { "value": 200, "label": "> 200%", "color": "#a002fa" }
+    ]
+  },
+  "rain_anomaly_9month": {
+    "title": "9-month rainfall anomaly",
+    "type": "wms",
+    "server_layer_name": "r9q_dekad",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "additional_query_params": {
+      "styles": "ryq_14_50_200"
+    },
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
+    "legend": [
+      { "value": 0, "label": "< 50%", "color": "#8c4800" },
+      { "value": 50, "label": "50-60%", "color": "#af6b27" },
+      { "value": 60, "label": "60-70%", "color": "#d58c3e" },
+      { "value": 70, "label": "70-80%", "color": "#eaa83d" },
+      { "value": 80, "label": "80-90%", "color": "#f5c878" },
+      { "value": 90, "label": "90-95%", "color": "#fff0c4" },
+      { "value": 95, "label": "95-105%", "color": "#fafafa" },
+      { "value": 105, "label": "105-110%", "color": "#befafa" },
+      { "value": 110, "label": "110-120%", "color": "#78e2f0" },
+      { "value": 120, "label": "120-130%", "color": "#00b9de" },
+      { "value": 130, "label": "130-150%", "color": "#0083f3" },
+      { "value": 150, "label": "150-170%", "color": "#0052cd" },
+      { "value": 170, "label": "170-200%", "color": "#0000c8" },
+      { "value": 200, "label": "> 200%", "color": "#a002fa" }
+    ]
+  },
+  "rain_anomaly_1year": {
+    "title": "1-year rainfall anomaly",
+    "type": "wms",
+    "server_layer_name": "ryq_dekad",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "additional_query_params": {
+      "styles": "ryq_14_50_200"
+    },
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
+    "legend": [
+      { "value": 0, "label": "< 50%", "color": "#8c4800" },
+      { "value": 50, "label": "50-60%", "color": "#af6b27" },
+      { "value": 60, "label": "60-70%", "color": "#d58c3e" },
+      { "value": 70, "label": "70-80%", "color": "#eaa83d" },
+      { "value": 80, "label": "80-90%", "color": "#f5c878" },
+      { "value": 90, "label": "90-95%", "color": "#fff0c4" },
+      { "value": 95, "label": "95-105%", "color": "#fafafa" },
+      { "value": 105, "label": "105-110%", "color": "#befafa" },
+      { "value": 110, "label": "110-120%", "color": "#78e2f0" },
+      { "value": 120, "label": "120-130%", "color": "#00b9de" },
+      { "value": 130, "label": "130-150%", "color": "#0083f3" },
+      { "value": 150, "label": "150-170%", "color": "#0052cd" },
+      { "value": 170, "label": "170-200%", "color": "#0000c8" },
+      { "value": 200, "label": "> 200%", "color": "#a002fa" }
+    ]
+  },
+  "rainfall_agg_1month": {
+    "title": "1-month rainfall aggregate",
+    "type": "wms",
+    "server_layer_name": "r1h_dekad",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "additional_query_params": {
+      "styles": "rfh_16_0_400"
+    },
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Total aggregate precipitation over a 1-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-5 mm", "color": "#fffadf" },
+      { "value": 5, "label": "5-10 mm", "color": "#d3f9d0" },
+      { "value": 10, "label": "10-20 mm", "color": "#a9e4a3" },
+      { "value": 20, "label": "20-30 mm", "color": "#7cc594" },
+      { "value": 30, "label": "30-40 mm", "color": "#5eab91" },
+      { "value": 40, "label": "40-60 mm", "color": "#9fffe8" },
+      { "value": 60, "label": "60-90 mm", "color": "#90e0ef" },
+      { "value": 90, "label": "90-120 mm", "color": "#00b1de" },
+      { "value": 120, "label": "120-150 mm", "color": "#0083f3" },
+      { "value": 150, "label": "150-200 mm", "color": "#0052cd" },
+      { "value": 200, "label": "200-250 mm", "color": "#0000c8" },
+      { "value": 250, "label": "250-300 mm", "color": "#6003b8" },
+      { "value": 300, "label": "300-350 mm", "color": "#a002fa" },
+      { "value": 350, "label": "350-400 mm", "color": "#fa78fa" },
+      { "value": 400, "label": ">= 400 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "rainfall_agg_3month": {
+    "title": "3-month rainfall aggregate (mm)",
+    "type": "wms",
+    "server_layer_name": "r3h_dekad",
+    "additional_query_params": {
+      "styles": "rfh_16_0_1000"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-10 mm", "color": "#fffadf" },
+      { "value": 10, "label": "10-20 mm", "color": "#d3f9d0" },
+      { "value": 20, "label": "20-30 mm", "color": "#a9e4a3" },
+      { "value": 30, "label": "30-50 mm", "color": "#7cc594" },
+      { "value": 50, "label": "50-100 mm", "color": "#5eab91" },
+      { "value": 100, "label": "100-200 mm", "color": "#9fffe8" },
+      { "value": 200, "label": "200-300 mm", "color": "#90e0ef" },
+      { "value": 300, "label": "300-400 mm", "color": "#00b1de" },
+      { "value": 400, "label": "400-500 mm", "color": "#0083f3" },
+      { "value": 500, "label": "500-600 mm", "color": "#0052cd" },
+      { "value": 600, "label": "600-700 mm", "color": "#0000c8" },
+      { "value": 700, "label": "700-800 mm", "color": "#6003b8" },
+      { "value": 800, "label": "800-900 mm", "color": "#a002fa" },
+      { "value": 900, "label": "900-1000 mm", "color": "#fa78fa" },
+      { "value": 1000, "label": "> 1000 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "rainfall_agg_6month": {
+    "title": "6-month rainfall aggregate (mm)",
+    "type": "wms",
+    "server_layer_name": "r6h_dekad",
+    "additional_query_params": {
+      "styles": "rfh_16_0_2000"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-10 mm", "color": "#fffadf" },
+      { "value": 10, "label": "10-50 mm", "color": "#d3f9d0" },
+      { "value": 50, "label": "50-100 mm", "color": "#a9e4a3" },
+      { "value": 100, "label": "100-200 mm", "color": "#7cc594" },
+      { "value": 200, "label": "200-300 mm", "color": "#5eab91" },
+      { "value": 300, "label": "300-400 mm", "color": "#9fffe8" },
+      { "value": 400, "label": "400-600 mm", "color": "#90e0ef" },
+      { "value": 600, "label": "600-800 mm", "color": "#00b1de" },
+      { "value": 800, "label": "800-1000 mm", "color": "#0083f3" },
+      { "value": 1000, "label": "1000-1200 mm", "color": "#0052cd" },
+      { "value": 1200, "label": "1200-1400 mm", "color": "#0000c8" },
+      { "value": 1400, "label": "1400-1600 mm", "color": "#6003b8" },
+      { "value": 1600, "label": "1600-1800 mm", "color": "#a002fa" },
+      { "value": 1800, "label": "1800-2000 mm", "color": "#fa78fa" },
+      { "value": 2000, "label": "> 2000 mm", "color": "#ffc4ee" }
+  ]
+  },
+  "rainfall_agg_9month": {
+    "title": "9-month rainfall aggregate (mm)",
+    "type": "wms",
+    "server_layer_name": "r9h_dekad",
+    "additional_query_params": {
+      "styles": "rfh_16_0_2400"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-10 mm", "color": "#fffadf" },
+      { "value": 10, "label": "10-50 mm", "color": "#d3f9d0" },
+      { "value": 50, "label": "50-100 mm", "color": "#a9e4a3" },
+      { "value": 100, "label": "100-200 mm", "color": "#7cc594" },
+      { "value": 200, "label": "200-400 mm", "color": "#5eab91" },
+      { "value": 400, "label": "400-600 mm", "color": "#9fffe8" },
+      { "value": 600, "label": "600-800 mm", "color": "#90e0ef" },
+      { "value": 800, "label": "800-1000 mm", "color": "#00b1de" },
+      { "value": 1000, "label": "1000-1200 mm", "color": "#0083f3" },
+      { "value": 1200, "label": "1200-1400 mm", "color": "#0052cd" },
+      { "value": 1400, "label": "1400-1600 mm", "color": "#0000c8" },
+      { "value": 1600, "label": "1600-1800 mm", "color": "#6003b8" },
+      { "value": 1800, "label": "1800-2000 mm", "color": "#a002fa" },
+      { "value": 2000, "label": "2000-2400 mm", "color": "#fa78fa" },
+      { "value": 2400, "label": "> 2400 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "rainfall_agg_1year": {
+    "title": "1-year rainfall aggregate (mm)",
+    "type": "wms",
+    "server_layer_name": "ryh_dekad",
+    "additional_query_params": {
+      "styles": "rfh_16_0_4000"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-50 mm", "color": "#fffadf" },
+      { "value": 50, "label": "50-100 mm", "color": "#d3f9d0" },
+      { "value": 100, "label": "100-200 mm", "color": "#a9e4a3" },
+      { "value": 200, "label": "200-300 mm", "color": "#7cc594" },
+      { "value": 300, "label": "300-400 mm", "color": "#5eab91" },
+      { "value": 400, "label": "400-600 mm", "color": "#9fffe8" },
+      { "value": 600, "label": "600-800 mm", "color": "#90e0ef" },
+      { "value": 800, "label": "800-1000 mm", "color": "#00b1de" },
+      { "value": 1000, "label": "1000-1500 mm", "color": "#0083f3" },
+      { "value": 1500, "label": "1500-2000 mm", "color": "#0052cd" },
+      { "value": 2000, "label": "2000-2500 mm", "color": "#0000c8" },
+      { "value": 2500, "label": "2500-3000 mm", "color": "#6003b8" },
+      { "value": 3000, "label": "3000-3500 mm", "color": "#a002fa" },
+      { "value": 3500, "label": "3500-4000 mm", "color": "#fa78fa" },
+      { "value": 4000, "label": "> 4000 mm", "color": "#ffc4ee" }
+    ]
+  },
   "spi_1m": {
     "title": "SPI - 1-month",
     "type": "wms",
@@ -353,694 +701,31 @@
       }
     ]
   },
-  "rainfall_dekad": {
-    "title": "10-day rainfall estimate (mm)",
-    "type": "wms",
-    "server_layer_name": "rfh_dekad",
-    "additional_query_params": {
-      "styles": "rfh_350"
-    },
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "Estimate of precipitation over a 10-day period derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
-    "legend": [
-      {
-        "label": "-0",
-        "color": "#ffffff",
-        "alpha": 0
-      },
-      {
-        "label": "1 mm",
-        "color": "#ffffff"
-      },
-      {
-        "label": "20 mm",
-        "color": "#faf5e6"
-      },
-      {
-        "label": "40 mm",
-        "color": "#faf3d2"
-      },
-      {
-        "label": "60 mm",
-        "color": "#dae3a1"
-      },
-      {
-        "label": "80 mm",
-        "color": "#a0c787"
-      },
-      {
-        "label": "100 mm",
-        "color": "#68ab79"
-      },
-      {
-        "label": "125 mm",
-        "color": "#9beafa"
-      },
-      {
-        "label": "150 mm",
-        "color": "#00b1de"
-      },
-      {
-        "label": "200 mm",
-        "color": "#005ae6"
-      },
-      {
-        "label": "250 mm",
-        "color": "#0000c8"
-      },
-      {
-        "label": "300 mm",
-        "color": "#a000fa"
-      },
-      {
-        "label": "350 mm",
-        "color": "#fa78fa"
-      }
-    ]
-  },
-  "rain_anomaly_dekad": {
-    "title": "10-day rainfall anomaly",
-    "type": "wms",
-    "server_layer_name": "rfq_dekad",
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "10-day precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
-    "legend": [
-      {
-        "label": "< 60%",
-        "color": "#d79b0b"
-      },
-      {
-        "label": "60%",
-        "color": "#e1b344"
-      },
-      {
-        "label": "80%",
-        "color": "#ebcb7d"
-      },
-      {
-        "label": "90%",
-        "color": "#f5e3b6"
-      },
-      {
-        "label": "110%",
-        "color": "#f2f2f2"
-      },
-      {
-        "label": "120%",
-        "color": "#b5e7fe"
-      },
-      {
-        "label": "140%",
-        "color": "#7dd4fd"
-      },
-      {
-        "label": "180%",
-        "color": "#45c1fc"
-      },
-      {
-        "label": ">= 200%",
-        "color": "#0fb0fb"
-      }
-    ]
-  },
-  "rain_anomaly_monthly": {
-    "title": "Monthly rainfall anomaly",
-    "type": "wms",
-    "server_layer_name": "r1q_dekad",
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "Monthly precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
-    "legend": [
-      {
-        "label": "< 60%",
-        "color": "#d79b0b"
-      },
-      {
-        "label": "60%",
-        "color": "#e1b344"
-      },
-      {
-        "label": "80%",
-        "color": "#ebcb7d"
-      },
-      {
-        "label": "90%",
-        "color": "#f5e3b6"
-      },
-      {
-        "label": "110%",
-        "color": "#f2f2f2"
-      },
-      {
-        "label": "120%",
-        "color": "#b5e7fe"
-      },
-      {
-        "label": "140%",
-        "color": "#7dd4fd"
-      },
-      {
-        "label": "180%",
-        "color": "#45c1fc"
-      },
-      {
-        "label": ">= 200%",
-        "color": "#0fb0fb"
-      }
-    ]
-  },
-  "rain_anomaly_3month": {
-    "title": "3-month rainfall anomaly",
-    "type": "wms",
-    "server_layer_name": "r3q_dekad",
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
-    "legend": [
-      {
-        "label": "< 60%",
-        "color": "#d79b0b"
-      },
-      {
-        "label": "60%",
-        "color": "#e1b344"
-      },
-      {
-        "label": "80%",
-        "color": "#ebcb7d"
-      },
-      {
-        "label": "90%",
-        "color": "#f5e3b6"
-      },
-      {
-        "label": "110%",
-        "color": "#f2f2f2"
-      },
-      {
-        "label": "120%",
-        "color": "#b5e7fe"
-      },
-      {
-        "label": "140%",
-        "color": "#7dd4fd"
-      },
-      {
-        "label": "180%",
-        "color": "#45c1fc"
-      },
-      {
-        "label": ">= 200%",
-        "color": "#0fb0fb"
-      }
-    ]
-  },
-  "rain_anomaly_6month": {
-    "title": "6-month rainfall anomaly",
-    "type": "wms",
-    "server_layer_name": "r6q_dekad",
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "6-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
-    "legend": [
-      {
-        "label": "< 60%",
-        "color": "#d79b0b"
-      },
-      {
-        "label": "60%",
-        "color": "#e1b344"
-      },
-      {
-        "label": "80%",
-        "color": "#ebcb7d"
-      },
-      {
-        "label": "90%",
-        "color": "#f5e3b6"
-      },
-      {
-        "label": "110%",
-        "color": "#f2f2f2"
-      },
-      {
-        "label": "120%",
-        "color": "#b5e7fe"
-      },
-      {
-        "label": "140%",
-        "color": "#7dd4fd"
-      },
-      {
-        "label": "180%",
-        "color": "#45c1fc"
-      },
-      {
-        "label": ">= 200%",
-        "color": "#0fb0fb"
-      }
-    ]
-  },
-  "rain_anomaly_9month": {
-    "title": "9-month rainfall anomaly",
-    "type": "wms",
-    "server_layer_name": "r9q_dekad",
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "9-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
-    "legend": [
-      {
-        "label": "< 60%",
-        "color": "#d79b0b"
-      },
-      {
-        "label": "60%",
-        "color": "#e1b344"
-      },
-      {
-        "label": "80%",
-        "color": "#ebcb7d"
-      },
-      {
-        "label": "90%",
-        "color": "#f5e3b6"
-      },
-      {
-        "label": "110%",
-        "color": "#f2f2f2"
-      },
-      {
-        "label": "120%",
-        "color": "#b5e7fe"
-      },
-      {
-        "label": "140%",
-        "color": "#7dd4fd"
-      },
-      {
-        "label": "180%",
-        "color": "#45c1fc"
-      },
-      {
-        "label": ">= 200%",
-        "color": "#0fb0fb"
-      }
-    ]
-  },
-  "rain_anomaly_1year": {
-    "title": "1-year rainfall anomaly",
-    "type": "wms",
-    "server_layer_name": "ryq_dekad",
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "1-year precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
-    "legend": [
-      {
-        "label": "< 60%",
-        "color": "#d79b0b"
-      },
-      {
-        "label": "60%",
-        "color": "#e1b344"
-      },
-      {
-        "label": "80%",
-        "color": "#ebcb7d"
-      },
-      {
-        "label": "90%",
-        "color": "#f5e3b6"
-      },
-      {
-        "label": "110%",
-        "color": "#f2f2f2"
-      },
-      {
-        "label": "120%",
-        "color": "#b5e7fe"
-      },
-      {
-        "label": "140%",
-        "color": "#7dd4fd"
-      },
-      {
-        "label": "180%",
-        "color": "#45c1fc"
-      },
-      {
-        "label": ">= 200%",
-        "color": "#0fb0fb"
-      }
-    ]
-  },
-  "rainfall_agg_month": {
-    "title": "1-month rainfall aggregate (mm)",
-    "type": "wms",
-    "server_layer_name": "r1h_dekad",
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "additional_query_params": {
-      "styles": "rfh_1500"
-    },
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "Total aggregate precipitation over a 1-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
-    "legend": [
-      {
-        "label": "50 mm",
-        "color": "#faf3d2"
-      },
-      {
-        "label": "100 mm",
-        "color": "#dae3a1"
-      },
-      {
-        "label": "200 mm",
-        "color": "#a0c787"
-      },
-      {
-        "label": "300 mm",
-        "color": "#68ab79"
-      },
-      {
-        "label": "400 mm",
-        "color": "#9beafa"
-      },
-      {
-        "label": "500 mm",
-        "color": "#00b1de"
-      },
-      {
-        "label": "600 mm",
-        "color": "#005ae6"
-      },
-      {
-        "label": "800 mm",
-        "color": "#0000c8"
-      },
-      {
-        "label": "1000 mm",
-        "color": "#a000fa"
-      },
-      {
-        "label": "1500 mm",
-        "color": "#fa78fa"
-      },
-      {
-        "label": "> 1500 mm",
-        "color": "#ffc4ee"
-      }
-    ]
-  },
-  "rainfall_agg_3month": {
-    "title": "3-month rainfall aggregate (mm)",
-    "type": "wms",
-    "server_layer_name": "r3h_dekad",
-    "additional_query_params": {
-      "styles": "rfh_800"
-    },
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "CHIRPS 3 month dekadal rainfall aggregations",
-    "legend": [
-      {
-        "label": "50 mm",
-        "color": "#faf3d2"
-      },
-      {
-        "label": "100 mm",
-        "color": "#dae3a1"
-      },
-      {
-        "label": "150 mm",
-        "color": "#a0c787"
-      },
-      {
-        "label": "200 mm",
-        "color": "#68ab79"
-      },
-      {
-        "label": "250 mm",
-        "color": "#9beafa"
-      },
-      {
-        "label": "300 mm",
-        "color": "#00b1de"
-      },
-      {
-        "label": "400 mm",
-        "color": "#005ae6"
-      },
-      {
-        "label": "500 mm",
-        "color": "#0000c8"
-      },
-      {
-        "label": "600 mm",
-        "color": "#a000fa"
-      },
-      {
-        "label": "800 mm",
-        "color": "#fa78fa"
-      },
-      {
-        "label": "> 800 mm",
-        "color": "#ffc4ee"
-      }
-    ]
-  },
-  "rainfall_agg_6month": {
-    "title": "6-month rainfall aggregate (mm)",
-    "type": "wms",
-    "server_layer_name": "r6h_dekad",
-    "additional_query_params": {
-      "styles": "rfh_800"
-    },
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "CHIRPS 6 month dekadal rainfall aggregations",
-    "legend": [
-      {
-        "label": "50 mm",
-        "color": "#faf3d2"
-      },
-      {
-        "label": "100 mm",
-        "color": "#dae3a1"
-      },
-      {
-        "label": "150 mm",
-        "color": "#a0c787"
-      },
-      {
-        "label": "200 mm",
-        "color": "#68ab79"
-      },
-      {
-        "label": "250 mm",
-        "color": "#9beafa"
-      },
-      {
-        "label": "300 mm",
-        "color": "#00b1de"
-      },
-      {
-        "label": "400 mm",
-        "color": "#005ae6"
-      },
-      {
-        "label": "500 mm",
-        "color": "#0000c8"
-      },
-      {
-        "label": "600 mm",
-        "color": "#a000fa"
-      },
-      {
-        "label": "800 mm",
-        "color": "#fa78fa"
-      },
-      {
-        "label": "> 800 mm",
-        "color": "#ffc4ee"
-      }
-    ]
-  },
-  "rainfall_agg_9month": {
-    "title": "9-month rainfall aggregate (mm)",
-    "type": "wms",
-    "server_layer_name": "r9h_dekad",
-    "additional_query_params": {
-      "styles": "rfh_800"
-    },
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "CHIRPS 9 month dekadal rainfall aggregations",
-    "legend": [
-      {
-        "label": "50 mm",
-        "color": "#faf3d2"
-      },
-      {
-        "label": "100 mm",
-        "color": "#dae3a1"
-      },
-      {
-        "label": "150 mm",
-        "color": "#a0c787"
-      },
-      {
-        "label": "200 mm",
-        "color": "#68ab79"
-      },
-      {
-        "label": "250 mm",
-        "color": "#9beafa"
-      },
-      {
-        "label": "300 mm",
-        "color": "#00b1de"
-      },
-      {
-        "label": "400 mm",
-        "color": "#005ae6"
-      },
-      {
-        "label": "500 mm",
-        "color": "#0000c8"
-      },
-      {
-        "label": "600 mm",
-        "color": "#a000fa"
-      },
-      {
-        "label": "800 mm",
-        "color": "#fa78fa"
-      },
-      {
-        "label": "> 800 mm",
-        "color": "#ffc4ee"
-      }
-    ]
-  },
-  "rainfall_agg_1year": {
-    "title": "1-year rainfall aggregate (mm)",
-    "type": "wms",
-    "server_layer_name": "ryh_dekad",
-    "additional_query_params": {
-      "styles": "rfh_1500"
-    },
-    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
-    "date_interval": "days",
-    "opacity": 0.7,
-    "legend_text": "CHIRPS 1 year dekadal rainfall aggregations",
-    "legend": [
-      {
-        "label": "50 mm",
-        "color": "#faf3d2"
-      },
-      {
-        "label": "100 mm",
-        "color": "#dae3a1"
-      },
-      {
-        "label": "200 mm",
-        "color": "#a0c787"
-      },
-      {
-        "label": "300 mm",
-        "color": "#68ab79"
-      },
-      {
-        "label": "400 mm",
-        "color": "#9beafa"
-      },
-      {
-        "label": "500 mm",
-        "color": "#00b1de"
-      },
-      {
-        "label": "600 mm",
-        "color": "#005ae6"
-      },
-      {
-        "label": "800 mm",
-        "color": "#0000c8"
-      },
-      {
-        "label": "1000 mm",
-        "color": "#a000fa"
-      },
-      {
-        "label": "1500 mm",
-        "color": "#fa78fa"
-      },
-      {
-        "label": "2000 mm",
-        "color": "#ffc4ee"
-      }
-    ]
-  },
   "days_dry": {
-    "title": "Number of dry days",
+    "title": "Days since last rain",
     "type": "wms",
     "server_layer_name": "dlc_dekad",
+    "additional_query_params": {
+      "styles": "dlx_13_0_26"
+    },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Number of consecutive days with less than 2 mm precipitation in the last 30 days",
     "legend": [
-      {
-        "label": "0 days",
-        "color": "#fff9c7"
-      },
-      {
-        "label": "1 day",
-        "color": "#ffeea9"
-      },
-      {
-        "label": "4 days",
-        "color": "#fede86"
-      },
-      {
-        "label": "6 days",
-        "color": "#fec754"
-      },
-      {
-        "label": "10 days",
-        "color": "#fea937"
-      },
-      {
-        "label": "14 days",
-        "color": "#f88a21"
-      },
-      {
-        "label": "18 days",
-        "color": "#e96d13"
-      },
-      {
-        "label": "22 days",
-        "color": "#d15205"
-      },
-      {
-        "label": "25 days",
-        "color": "#b03f03"
-      },
-      {
-        "label": "30 days",
-        "color": "#8b3005"
-      }
+      { "value": 0, "label": "None", "color": "#6c9fa4" },
+      { "value": 4, "label": "1-4 Days", "color": "#57bec1" },
+      { "value": 6, "label": "5-6 Days", "color": "#aee0c4" },
+      { "value": 8, "label": "7-8 Days", "color": "#dcf1b2" },
+      { "value": 10, "label": "9-10 Days", "color": "#ffffbf" },
+      { "value": 12, "label": "11-12 Days", "color": "#ffeebd" },
+      { "value": 14, "label": "13-14 Days", "color": "#ffec81" },
+      { "value": 16, "label": "15-16 Days", "color": "#fed380" },
+      { "value": 18, "label": "17-18 Days", "color": "#fec754" },
+      { "value": 20, "label": "19-20 Days", "color": "#f5af28" },
+      { "value": 22, "label": "21-22 Days", "color": "#d79b0b" },
+      { "value": 26, "label": "23-26 Days", "color": "#c98a4b" },
+      { "value": 27, "label": "> 26 Days", "color": "#aa5a00" }
     ]
   },
   "streak_dry_days": {
@@ -1048,50 +733,26 @@
     "type": "wms",
     "server_layer_name": "dlx_dekad",
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "additional_query_params": {
+      "styles": "dlx_13_0_26"
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
+    "legend_text": "Longest number of consecutive days with less than 2 mm precipitation in the last 30 days",
     "legend": [
-      {
-        "label": "0 days",
-        "color": "#fff9c7"
-      },
-      {
-        "label": "1 day",
-        "color": "#ffeea9"
-      },
-      {
-        "label": "4 days",
-        "color": "#fede86"
-      },
-      {
-        "label": "6 days",
-        "color": "#fec754"
-      },
-      {
-        "label": "10 days",
-        "color": "#fea937"
-      },
-      {
-        "label": "14 days",
-        "color": "#f88a21"
-      },
-      {
-        "label": "18 days",
-        "color": "#e96d13"
-      },
-      {
-        "label": "22 days",
-        "color": "#d15205"
-      },
-      {
-        "label": "25 days",
-        "color": "#b03f03"
-      },
-      {
-        "label": "30 days",
-        "color": "#8b3005"
-      }
+      { "value": 0, "label": "None", "color": "#6c9fa4" },
+      { "value": 4, "label": "1-4 Days", "color": "#57bec1" },
+      { "value": 6, "label": "5-6 Days", "color": "#aee0c4" },
+      { "value": 8, "label": "7-8 Days", "color": "#dcf1b2" },
+      { "value": 10, "label": "9-10 Days", "color": "#ffffbf" },
+      { "value": 12, "label": "11-12 Days", "color": "#ffeebd" },
+      { "value": 14, "label": "13-14 Days", "color": "#ffec81" },
+      { "value": 16, "label": "15-16 Days", "color": "#fed380" },
+      { "value": 18, "label": "17-18 Days", "color": "#fec754" },
+      { "value": 20, "label": "19-20 Days", "color": "#f5af28" },
+      { "value": 22, "label": "21-22 Days", "color": "#d79b0b" },
+      { "value": 26, "label": "23-26 Days", "color": "#c98a4b" },
+      { "value": 27, "label": "> 26 Days", "color": "#aa5a00" }
     ]
   },
   "days_heavy_rain": {
@@ -1099,50 +760,25 @@
     "type": "wms",
     "server_layer_name": "xnh_dekad",
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "additional_query_params": {
+      "styles": "xnhie_12_0_14"
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
+    "legend_text": "Total number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
     "legend": [
-      {
-        "label": "0 days",
-        "color": "#f2fabc"
-      },
-      {
-        "label": "1 day",
-        "color": "#dcf1b2"
-      },
-      {
-        "label": "4 days",
-        "color": "#bbe4b5"
-      },
-      {
-        "label": "6 days",
-        "color": "#85cfba"
-      },
-      {
-        "label": "10 days",
-        "color": "#57bec1"
-      },
-      {
-        "label": "14 days",
-        "color": "#34a9c3"
-      },
-      {
-        "label": "18 days",
-        "color": "#1d8dbe"
-      },
-      {
-        "label": "22 days",
-        "color": "#2166ac"
-      },
-      {
-        "label": "25 days",
-        "color": "#24479d"
-      },
-      {
-        "label": "30 days",
-        "color": "#1d2e83"
-      }
+      { "value": 0, "label": "None", "color": "#fafafa" },
+      { "value": 1, "label": "1 Day", "color": "#d3f9d0" },
+      { "value": 2, "label": "2 Days", "color": "#a9e4a3" },
+      { "value": 3, "label": "3 Days", "color": "#5eab91" },
+      { "value": 4, "label": "4 Days", "color": "#9fffe8" },
+      { "value": 5, "label": "5 Days", "color": "#90e0ef" },
+      { "value": 6, "label": "6 Days", "color": "#00b1de" },
+      { "value": 8, "label": "7-8 Days", "color": "#0083f3" },
+      { "value": 10, "label": "9-10 Days", "color": "#0052cd" },
+      { "value": 12, "label": "11-12 Days", "color": "#0031ac" },
+      { "value": 14, "label": "13-14 Days", "color": "#a002fa" },
+      { "value": 15, "label": "> 14 Days", "color": "#ffc4ee" }
     ]
   },
   "days_intense_rain": {
@@ -1150,50 +786,25 @@
     "type": "wms",
     "server_layer_name": "xni_dekad",
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "additional_query_params": {
+      "styles": "xnhie_12_0_14"
+    },
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 90th percentile) within last 30 days of dekad",
     "legend": [
-      {
-        "label": "0 days",
-        "color": "#f2fabc"
-      },
-      {
-        "label": "1 day",
-        "color": "#dcf1b2"
-      },
-      {
-        "label": "4 days",
-        "color": "#bbe4b5"
-      },
-      {
-        "label": "6 days",
-        "color": "#85cfba"
-      },
-      {
-        "label": "10 days",
-        "color": "#57bec1"
-      },
-      {
-        "label": "14 days",
-        "color": "#34a9c3"
-      },
-      {
-        "label": "18 days",
-        "color": "#1d8dbe"
-      },
-      {
-        "label": "22 days",
-        "color": "#2166ac"
-      },
-      {
-        "label": "25 days",
-        "color": "#24479d"
-      },
-      {
-        "label": "30 days",
-        "color": "#1d2e83"
-      }
+      { "value": 0, "label": "None", "color": "#fafafa" },
+      { "value": 1, "label": "1 Day", "color": "#d3f9d0" },
+      { "value": 2, "label": "2 Days", "color": "#a9e4a3" },
+      { "value": 3, "label": "3 Days", "color": "#5eab91" },
+      { "value": 4, "label": "4 Days", "color": "#9fffe8" },
+      { "value": 5, "label": "5 Days", "color": "#90e0ef" },
+      { "value": 6, "label": "6 Days", "color": "#00b1de" },
+      { "value": 8, "label": "7-8 Days", "color": "#0083f3" },
+      { "value": 10, "label": "9-10 Days", "color": "#0052cd" },
+      { "value": 12, "label": "11-12 Days", "color": "#0031ac" },
+      { "value": 14, "label": "13-14 Days", "color": "#a002fa" },
+      { "value": 15, "label": "> 14 Days", "color": "#ffc4ee" }
     ]
   },
   "days_extreme_rain": {
@@ -1201,50 +812,25 @@
     "type": "wms",
     "server_layer_name": "xne_dekad",
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "additional_query_params": {
+      "styles": "xnhie_12_0_14"
+    },
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total number of heavy rain days (rainfall > 95th percentile) within last 30 days of dekad",
     "legend": [
-      {
-        "label": "0 days",
-        "color": "#f2fabc"
-      },
-      {
-        "label": "1 day",
-        "color": "#dcf1b2"
-      },
-      {
-        "label": "4 days",
-        "color": "#bbe4b5"
-      },
-      {
-        "label": "6 days",
-        "color": "#85cfba"
-      },
-      {
-        "label": "10 days",
-        "color": "#57bec1"
-      },
-      {
-        "label": "14 days",
-        "color": "#34a9c3"
-      },
-      {
-        "label": "18 days",
-        "color": "#1d8dbe"
-      },
-      {
-        "label": "22 days",
-        "color": "#2166ac"
-      },
-      {
-        "label": "25 days",
-        "color": "#24479d"
-      },
-      {
-        "label": "30 days",
-        "color": "#1d2e83"
-      }
+      { "value": 0, "label": "None", "color": "#fafafa" },
+      { "value": 1, "label": "1 Day", "color": "#d3f9d0" },
+      { "value": 2, "label": "2 Days", "color": "#a9e4a3" },
+      { "value": 3, "label": "3 Days", "color": "#5eab91" },
+      { "value": 4, "label": "4 Days", "color": "#9fffe8" },
+      { "value": 5, "label": "5 Days", "color": "#90e0ef" },
+      { "value": 6, "label": "6 Days", "color": "#00b1de" },
+      { "value": 8, "label": "7-8 Days", "color": "#0083f3" },
+      { "value": 10, "label": "9-10 Days", "color": "#0052cd" },
+      { "value": 12, "label": "11-12 Days", "color": "#0031ac" },
+      { "value": 14, "label": "13-14 Days", "color": "#a002fa" },
+      { "value": 15, "label": "> 14 Days", "color": "#ffc4ee" }
     ]
   },
   "streak_heavy_rain": {
@@ -1252,50 +838,77 @@
     "type": "wms",
     "server_layer_name": "xlh_dekad",
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "additional_query_params": {
+      "styles": "xnhie_12_0_14"
+    },
     "date_interval": "days",
     "opacity": 0.7,
-    "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
+    "legend_text": "Longest consecutive number of heavy rain days (rainfall > 75th percentile) within last 30 days of dekad",
     "legend": [
-      {
-        "label": "0 days",
-        "color": "#f2fabc"
-      },
-      {
-        "label": "1 day",
-        "color": "#dcf1b2"
-      },
-      {
-        "label": "4 days",
-        "color": "#bbe4b5"
-      },
-      {
-        "label": "6 days",
-        "color": "#85cfba"
-      },
-      {
-        "label": "10 days",
-        "color": "#57bec1"
-      },
-      {
-        "label": "14 days",
-        "color": "#34a9c3"
-      },
-      {
-        "label": "18 days",
-        "color": "#1d8dbe"
-      },
-      {
-        "label": "22 days",
-        "color": "#2166ac"
-      },
-      {
-        "label": "25 days",
-        "color": "#24479d"
-      },
-      {
-        "label": "30 days",
-        "color": "#1d2e83"
-      }
+      { "value": 0, "label": "None", "color": "#fafafa" },
+      { "value": 1, "label": "1 Day", "color": "#d3f9d0" },
+      { "value": 2, "label": "2 Days", "color": "#a9e4a3" },
+      { "value": 3, "label": "3 Days", "color": "#5eab91" },
+      { "value": 4, "label": "4 Days", "color": "#9fffe8" },
+      { "value": 5, "label": "5 Days", "color": "#90e0ef" },
+      { "value": 6, "label": "6 Days", "color": "#00b1de" },
+      { "value": 8, "label": "7-8 Days", "color": "#0083f3" },
+      { "value": 10, "label": "9-10 Days", "color": "#0052cd" },
+      { "value": 12, "label": "11-12 Days", "color": "#0031ac" },
+      { "value": 14, "label": "13-14 Days", "color": "#a002fa" },
+      { "value": 15, "label": "> 14 Days", "color": "#ffc4ee" }
+    ]
+  },
+  "streak_intense_rain": {
+    "title": "Longest consecutive intense rainfall days",
+    "type": "wms",
+    "server_layer_name": "xli_dekad",
+    "additional_query_params": {
+      "styles": "xnhie_12_0_14"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Longest consecutive number of intense rain days (rainfall > 90th percentile) within last 30 days of dekad",
+    "legend": [
+      { "value": 0, "label": "None", "color": "#fafafa" },
+      { "value": 1, "label": "1 Day", "color": "#d3f9d0" },
+      { "value": 2, "label": "2 Days", "color": "#a9e4a3" },
+      { "value": 3, "label": "3 Days", "color": "#5eab91" },
+      { "value": 4, "label": "4 Days", "color": "#9fffe8" },
+      { "value": 5, "label": "5 Days", "color": "#90e0ef" },
+      { "value": 6, "label": "6 Days", "color": "#00b1de" },
+      { "value": 8, "label": "7-8 Days", "color": "#0083f3" },
+      { "value": 10, "label": "9-10 Days", "color": "#0052cd" },
+      { "value": 12, "label": "11-12 Days", "color": "#0031ac" },
+      { "value": 14, "label": "13-14 Days", "color": "#a002fa" },
+      { "value": 15, "label": "> 14 Days", "color": "#ffc4ee" }
+    ]
+  },
+  "streak_extreme_rain": {
+    "title": "Longest consecutive extreme rainfall days",
+    "type": "wms",
+    "server_layer_name": "xle_dekad",
+    "additional_query_params": {
+      "styles": "xnhie_12_0_14"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Longest consecutive number of extreme rain days (rainfall > 95th percentile) within last 30 days of dekad",
+    "legend": [
+      { "value": 0, "label": "None", "color": "#fafafa" },
+      { "value": 1, "label": "1 Day", "color": "#d3f9d0" },
+      { "value": 2, "label": "2 Days", "color": "#a9e4a3" },
+      { "value": 3, "label": "3 Days", "color": "#5eab91" },
+      { "value": 4, "label": "4 Days", "color": "#9fffe8" },
+      { "value": 5, "label": "5 Days", "color": "#90e0ef" },
+      { "value": 6, "label": "6 Days", "color": "#00b1de" },
+      { "value": 8, "label": "7-8 Days", "color": "#0083f3" },
+      { "value": 10, "label": "9-10 Days", "color": "#0052cd" },
+      { "value": 12, "label": "11-12 Days", "color": "#0031ac" },
+      { "value": 14, "label": "13-14 Days", "color": "#a002fa" },
+      { "value": 15, "label": "> 14 Days", "color": "#ffc4ee" }
     ]
   },
   "ndvi_dekad": {
@@ -1303,6 +916,9 @@
     "type": "wms",
     "server_layer_name": "mxd13a2_vim_dekad",
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "additional_query_params": {
+      "styles": "vim_14_01_09"
+    },
     "date_interval": "days",
     "wcsConfig": {
       "scale": 0.0001,
@@ -1312,42 +928,20 @@
     "opacity": 0.7,
     "legend_text": "Normalized Difference Vegetation Index (NDVI) derived from MODIS TERRA/AQUA",
     "legend": [
-      {
-        "label": "-1.00",
-        "color": "#a50026"
-      },
-      {
-        "label": "-0.75",
-        "color": "#de3f2e"
-      },
-      {
-        "label": "-0.50",
-        "color": "#f88d52"
-      },
-      {
-        "label": "-0.25",
-        "color": "#fed380"
-      },
-      {
-        "label": "0.00",
-        "color": "#ffffbf"
-      },
-      {
-        "label": "0.25",
-        "color": "#ccea83"
-      },
-      {
-        "label": "0.50",
-        "color": "#86cb66"
-      },
-      {
-        "label": "0.75",
-        "color": "#2da155"
-      },
-      {
-        "label": "1.00",
-        "color": "#006837"
-      }
+      { "value": 0, "label": "< 0.10", "color": "#fffae6" },
+      { "value": 0.1, "label": "0.10 - 0.15", "color": "#fff0be" },
+      { "value": 0.15, "label": "0.15 - 0.20", "color": "#dae3a1" },
+      { "value": 0.20, "label": "0.20 - 0.25", "color": "#ccea83" },
+      { "value": 0.25, "label": "0.25 - 0.30", "color": "#cbff1f" },
+      { "value": 0.30, "label": "0.30 - 0.35", "color": "#86cb66" },
+      { "value": 0.35, "label": "0.35 - 0.40", "color": "#2da155" },
+      { "value": 0.40, "label": "0.40 - 0.50", "color": "#009600" },
+      { "value": 0.50, "label": "0.50 - 0.60", "color": "#006400" },
+      { "value": 0.60, "label": "0.60 - 0.70", "color": "#64a77e" },
+      { "value": 0.70, "label": "0.70 - 0.80", "color": "#328968" },
+      { "value": 0.80, "label": "0.80 - 0.85", "color": "#006b52" },
+      { "value": 0.85, "label": "0.85 - 0.90", "color": "#004e33" },
+      { "value": 0.90, "label": "> 0.90", "color": "#002a1e" }
     ]
   },
   "ndvi_dekad_anomaly": {
@@ -1357,47 +951,24 @@
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "additional_query_params": {
-      "styles": "viq"
+      "styles": "viq_13_50_150"
     },
     "opacity": 0.7,
     "legend_text": "NDVI Anomaly compared to LTA",
     "legend": [
-      {
-        "label": "50%",
-        "color": "#732600"
-      },
-      {
-        "label": "70%",
-        "color": "#f06405"
-      },
-      {
-        "label": "80%",
-        "color": "#f5af28"
-      },
-      {
-        "label": "90%",
-        "color": "#e6dc96"
-      },
-      {
-        "label": "110%",
-        "color": "#f5f5f5"
-      },
-      {
-        "label": "120%",
-        "color": "#cbff1f"
-      },
-      {
-        "label": "130%",
-        "color": "#00f200"
-      },
-      {
-        "label": "150%",
-        "color": "#008f00"
-      },
-      {
-        "label": "200%",
-        "color": "#004d00"
-      }
+      { "value": 0, "label": "< 50%", "color": "#732600" },
+      { "value": 50, "label": "50-60%", "color": "#d73027" },
+      { "value": 60, "label": "60-70%", "color": "#f06405" },
+      { "value": 70, "label": "70-80%", "color": "#fdae61" },
+      { "value": 80, "label": "80-90%", "color": "#fed380" },
+      { "value": 90, "label": "90-95%", "color": "#ffffbf" },
+      { "value": 95, "label": "95-105%", "color": "#fafafa" },
+      { "value": 105, "label": "105-110%", "color": "#cbff1f" },
+      { "value": 110, "label": "110-120%", "color": "#00ff00" },
+      { "value": 120, "label": "120-130%", "color": "#00c900" },
+      { "value": 130, "label": "130-140%", "color": "#009600" },
+      { "value": 140, "label": "140-150%", "color": "#006400" },
+      { "value": 150, "label": "> 150%", "color": "#003200" }
     ]
   },
   "lst_amplitude": {
@@ -1410,42 +981,34 @@
       "offset": 0,
       "pixelResolution": 64
     },
+    "additional_query_params": {
+      "styles": "taa_21_1_48"
+    },
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Land Surface Temperature Amplitude refers to the difference between the maximum and minimum temperature in degrees Celsius",
     "legend": [
-      {
-        "label": "1°",
-        "color": "#ffffd9"
-      },
-      {
-        "label": "4°",
-        "color": "#e8f6b1"
-      },
-      {
-        "label": "8°",
-        "color": "#b2e1b6"
-      },
-      {
-        "label": "12°",
-        "color": "#64c3bf"
-      },
-      {
-        "label": "16°",
-        "color": "#2ca1c2"
-      },
-      {
-        "label": "20°",
-        "color": "#216daf"
-      },
-      {
-        "label": "24°",
-        "color": "#253a97"
-      },
-      {
-        "label": "28°",
-        "color": "#081d58"
-      }
+      { "value": 1, "label": "< 1C", "color": "#05284b" },
+      { "value": 50, "label": "1C to 2C", "color": "#0031ac" },
+      { "value": 100, "label": "2C to 3C", "color": "#0564c3" },
+      { "value": 150, "label": "3C to 4C", "color": "#1d8dbe" },
+      { "value": 200, "label": "4C to 5C", "color": "#57bec1" },
+      { "value": 250, "label": "5C to 6C", "color": "#004231" },
+      { "value": 300, "label": "6C to 8C", "color": "#006b52" },
+      { "value": 400, "label": "8C to 10C", "color": "#64a77e" },
+      { "value": 500, "label": "10C to 12C", "color": "#86cb66" },
+      { "value": 600, "label": "12C to 14C", "color": "#ccea83" },
+      { "value": 700, "label": "14C to 16C", "color": "#dcf1b2" },
+      { "value": 800, "label": "16C to 18C", "color": "#ffffbf" },
+      { "value": 900, "label": "18C to 20C", "color": "#ffeebd" },
+      { "value": 1000, "label": "20C to 24C", "color": "#ffec81" },
+      { "value": 1200, "label": "24C to 28C", "color": "#fed380" },
+      { "value": 1400, "label": "28C to 32C", "color": "#fec754" },
+      { "value": 1600, "label": "32C to 36C", "color": "#f5af28" },
+      { "value": 1800, "label": "36C to 40C", "color": "#d79b0b" },
+      { "value": 2000, "label": "40C to 44C", "color": "#d5a45f" },
+      { "value": 2200, "label": "44C to 48C", "color": "#bf7f2f" },
+      { "value": 2400, "label": "> +48C", "color": "#aa5a00" }
     ]
   },
   "lst_daytime": {
@@ -1460,158 +1023,65 @@
       "pixelResolution": 64
     },
     "opacity": 0.7,
-    "legend_text": "LEGEND",
+    "legend_text": "10-day daytime land surface temperature derived from MODIS AQUA",
     "additional_query_params": {
-      "styles": "lst_day"
+      "styles": "tda_42_n24_70"
     },
     "legend": [
-      {
-        "label": "0°",
-        "color": "#f0f9ba"
-      },
-      {
-        "label": "5°",
-        "color": "#edeba4"
-      },
-      {
-        "label": "10°",
-        "color": "#ebdd8f"
-      },
-      {
-        "label": "15°",
-        "color": "#eace7c"
-      },
-      {
-        "label": "20°",
-        "color": "#e9bf6a"
-      },
-      {
-        "label": "25°",
-        "color": "#e9af59"
-      },
-      {
-        "label": "30°",
-        "color": "#e99e4c"
-      },
-      {
-        "label": "35°",
-        "color": "#e98d41"
-      },
-      {
-        "label": "40°",
-        "color": "#e87a3a"
-      },
-      {
-        "label": "45°",
-        "color": "#e76636"
-      },
-      {
-        "label": "50°",
-        "color": "#e54f35"
-      }
+      { "value": 10, "label": "10C - 12C", "color": "#34a9c3" },
+      { "value": 12, "label": "12C - 14C", "color": "#005867" },
+      { "value": 14, "label": "14C - 16C", "color": "#378a95" },
+      { "value": 16, "label": "16C - 18C", "color": "#6c9fa4" },
+      { "value": 18, "label": "18C - 20C", "color": "#7ab2b9" },
+      { "value": 20, "label": "20C - 22C", "color": "#57bec1" },
+      { "value": 22, "label": "22C - 24C", "color": "#85cfba" },
+      { "value": 24, "label": "24C - 26C", "color": "#aee0c4" },
+      { "value": 26, "label": "26C - 28C", "color": "#bbe4b5" },
+      { "value": 28, "label": "28C - 30C", "color": "#dcf1b2" },
+      { "value": 30, "label": "30C - 32C", "color": "#e8ffde" },
+      { "value": 32, "label": "32C - 34C", "color": "#f2fabc" },
+      { "value": 34, "label": "34C - 36C", "color": "#ffffbf" },
+      { "value": 36, "label": "36C - 38C", "color": "#ffec81" },
+      { "value": 38, "label": "38C - 40C", "color": "#fed380" },
+      { "value": 40, "label": "40C - 42C", "color": "#f5af28" },
+      { "value": 42, "label": "42C - 44C", "color": "#eac98e" },
+      { "value": 44, "label": "44C - 46C", "color": "#d5a45f" }
     ]
   },
   "lst_anomaly": {
-    "title": "Land Surface Temperature - 10-day Anomaly (MODIS)",
+    "title": "Daytime Land Surface Temperature - 10-day Anomaly (MODIS)",
     "type": "wms",
     "server_layer_name": "myd11a2_txd_dekad",
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
     "additional_query_params": {
-      "styles": "lst_day"
+      "styles": "tdd_21_m12_12"
     },
-    "legend_text": "LEGEND",
+    "legend_text": "10-day daytime land surface temperature anomaly derived from MODIS AQUA",
     "legend": [
-      {
-        "label": "-300%",
-        "color": "#000004"
-      },
-      {
-        "label": "-200%",
-        "color": "#210c4a"
-      },
-      {
-        "label": "-100%",
-        "color": "#57106e"
-      },
-      {
-        "label": "-50%",
-        "color": "#8a226a"
-      },
-      {
-        "label": "50%",
-        "color": "#bc3754"
-      },
-      {
-        "label": "100%",
-        "color": "#e45a31"
-      },
-      {
-        "label": "200%",
-        "color": "#f98e09"
-      },
-      {
-        "label": "300%",
-        "color": "#f9cb35"
-      },
-      {
-        "label": "> 300%",
-        "color": "#fcffa4"
-      }
+      { "value": -100, "label": "< -12C", "color": "#05284b" },
+      { "value": -12, "label": "-12C to -10C", "color": "#1d2e83" },
+      { "value": -10, "label": "-10C to -8C", "color": "#24479d" },
+      { "value": -8, "label": "-8C to -7C", "color": "#2166ac" },
+      { "value": -7, "label": "-7C to -6C", "color": "#1d8dbe" },
+      { "value": -6, "label": "-6C to -5C", "color": "#34a9c3" },
+      { "value": -5, "label": "-5C to -4C", "color": "#6cb4de" },
+      { "value": -4, "label": "-4C to -3C", "color": "#7ecae7" },
+      { "value": -3, "label": "-3C to -2C", "color": "#90e0ef" },
+      { "value": -2, "label": "-2C to -1C", "color": "#c3f6ff" },
+      { "value": -1, "label": "-1C to +1C", "color": "#fafafa" },
+      { "value": 1, "label": "+1C to +2C", "color": "#fddbc7" },
+      { "value": 2, "label": "+2C to +3C", "color": "#fcbba1" },
+      { "value": 3, "label": "+3C to +4C", "color": "#fc9272" },
+      { "value": 4, "label": "+4C to +5C", "color": "#fb6a4a" },
+      { "value": 5, "label": "+5C to +6C", "color": "#ef3b2c" },
+      { "value": 6, "label": "+6C to +7C", "color": "#d73027" },
+      { "value": 7, "label": "+7C to +8C", "color": "#cb181d" },
+      { "value": 8, "label": "+8C to +10C", "color": "#b2182b" },
+      { "value": 10, "label": "+10C to +12C", "color": "#a50026" },
+      { "value": 12, "label": "> +12C", "color": "#67000d" }
     ]
-  },
-  "adamts_nodes": {
-    "title": "Tropical storm - nodes",
-    "type": "wms",
-    "server_layer_name": "wld_gdacs_tc_events_nodes",
-    "opacity": 0.7,
-    "legend": [],
-    "legend_text": "Tropical storm - nodes",
-    "base_url": "https://geonode.wfp.org/geoserver",
-    "feature_info_props": {
-      "event_name": {
-        "type": "text",
-        "label": "Event name"
-      },
-      "timestamp": {
-        "type": "date",
-        "label": "Publication date"
-      },
-      "wind_speed": {
-        "type": "text",
-        "label": "Estimated wind speed"
-      }
-    },
-    "geometry": "point"
-  },
-  "adamts_buffers": {
-    "title": "Tropical Storms - Wind buffers",
-    "type": "wms",
-    "server_layer_name": "mmr_gdacs_buffers",
-    "opacity": 0.7,
-    "legend": [],
-    "legend_text": "Wind buffers (radii) estimate potential wind speeds along the path of a storm with a buffer estimating the area exposed to each wind speed category. Source: GDACS",
-    "base_url": "https://geonode.wfp.org/geoserver",
-    "feature_info_props": {
-      "event_name": {
-        "type": "text",
-        "label": "Event name"
-      },
-      "timestamp": {
-        "type": "date",
-        "label": "Publication date"
-      },
-      "wcsConfig": {
-        "scale": 0.1,
-        "offset": 0
-      }
-    },
-    "exposure": {
-      "id": "wp_pop_cicunadj",
-      "key": "label"
-    },
-    "geometry": "polygon"
   },
   "wp_pop_cicunadj": {
     "title": "population",
@@ -1626,16 +1096,6 @@
     "opacity": 0,
     "legend_text": "",
     "legend": []
-  },
-  "adamts_tracks": {
-    "title": "Tropical storm - track",
-    "type": "wms",
-    "server_layer_name": "wld_gdacs_tc_events_tracks",
-    "opacity": 0.7,
-    "legend": [],
-    "legend_text": "Tracks visualize the projected path of a storm based on the forecasted position of it's center at various points in time. Source: GDACS",
-    "base_url": "https://geonode.wfp.org/geoserver",
-    "geometry": "linestring"
   },
   "poverty_hc": {
     "type": "admin_level_data",

--- a/src/config/srilanka/prism.json
+++ b/src/config/srilanka/prism.json
@@ -11,7 +11,6 @@
   },
   "serversUrls": {
     "wms": [
-      "https://geonode.wfp.org/geoserver/prism/wms/",
       "https://api.earthobservation.vam.wfp.org/ows/wms"
     ]
   },
@@ -28,36 +27,152 @@
   "categories": {
     "rainfall": {
       "rainfall_amount": [
-        "rainfall_dekad",
-        "rainfall_agg_month",
-        "rainfall_agg_3month",
-        "rainfall_agg_6month",
-        "rainfall_agg_9month",
-        "rainfall_agg_1year"
+        {
+          "group_title": "Rainfall Aggregate",
+          "activate_all": false,
+          "layers": [
+            {
+              "id": "rainfall_dekad",
+              "label": "10-day",
+              "main": true
+            },
+            {
+              "id": "rainfall_agg_1month",
+              "label": "1-month"
+            },
+            {
+              "id": "rainfall_agg_3month",
+              "label": "3-month"
+            },
+            {
+              "id": "rainfall_agg_6month",
+              "label": "6-month"
+            },
+            {
+              "id": "rainfall_agg_9month",
+              "label": "9-month"
+            },
+            {
+              "id": "rainfall_agg_1year",
+              "label": "1-year"
+            }
+          ]
+        }
       ],
       "rainfall_anomalies": [
-        "spi_1m",
-        "spi_3m",
-        "spi_6m",
-        "spi_9m",
-        "spi_1y",
-        "rain_anomaly_dekad",
-        "rain_anomaly_monthly",
-        "rain_anomaly_3month",
-        "rain_anomaly_6month",
-        "rain_anomaly_9month",
-        "rain_anomaly_1year"
+        {
+          "group_title": "Rainfall Anomaly",
+          "activate_all": false,
+          "layers": [
+            {
+              "id": "rain_anomaly_dekad",
+              "label": "10-day",
+              "main": true
+            },
+            {
+              "id": "rain_anomaly_1month",
+              "label": "1-month"
+            },
+            {
+              "id": "rain_anomaly_3month",
+              "label": "3-month"
+            },
+            {
+              "id": "rain_anomaly_6month",
+              "label": "6-month"
+            },
+            {
+              "id": "rain_anomaly_9month",
+              "label": "9-month"
+            },
+            {
+              "id": "rain_anomaly_1year",
+              "label": "1-year"
+            }
+          ]
+        },
+        {
+          "group_title": "SPI",
+          "activate_all": false,
+          "layers": [
+            {
+              "id": "spi_1m",
+              "label": "1-month",
+              "main": true
+            },
+            {
+              "id": "spi_3m",
+              "label": "3-month"
+            },
+            {
+              "id": "spi_6m",
+              "label": "6-month"
+            },
+            {
+              "id": "spi_9m",
+              "label": "9-month"
+            },
+            {
+              "id": "spi_1y",
+              "label": "1-year"
+            }
+          ]
+        }
       ],
-      "dry_periods": ["days_dry", "streak_dry_days"],
-      "heavy_rain": [
-        "days_heavy_rain",
-        "days_intense_rain",
-        "days_extreme_rain",
-        "streak_heavy_rain"
+      "dry_periods": [
+        "days_dry",
+        "streak_dry_days"
+      ],
+      "extreme_rain_events": [
+        {
+          "group_title": "Rainfall categories:",
+          "activate_all": false,
+          "layers": [
+            {
+              "id": "days_heavy_rain",
+              "label": "Heavy (>75th percentile)",
+              "main": true
+            },
+            {
+              "id": "days_intense_rain",
+              "label": "Intense (>90th percentile)",
+              "main": true
+            },
+            {
+              "id": "days_extreme_rain",
+              "label": "Extreme (>95th percentile)",
+              "main": true
+            }
+          ]
+        },
+        {
+          "group_title": "Consecutive days of rainfall:",
+          "activate_all": false,
+          "layers": [
+            {
+              "id": "streak_heavy_rain",
+              "label": "Heavy (>75th percentile)",
+              "main": true
+            },
+            {
+              "id": "streak_intense_rain",
+              "label": "Intense (>90th percentile)",
+              "main": true
+            },
+            {
+              "id": "streak_extreme_rain",
+              "label": "Extreme (>95th percentile)",
+              "main": true
+            }
+          ]
+        }
       ]
     },
     "vegetation": {
-      "vegetation_conditions": ["ndvi_dekad", "ndvi_dekad_anomaly"]
+      "vegetation_conditions": [
+        "ndvi_dekad",
+        "ndvi_dekad_anomaly"
+      ]
     },
     "temperature": {
       "land_surface_temperature": [


### PR DESCRIPTION
This PR updates the demo version for PRISM Sri Lanka to make use of updated color ramps and styles from WFP's Humanitarian Data Cube. It also reorganizes prism.json to make use of layer grouping.

Surge deployment here:
https://prism-lka.surge.sh/

<img width="1435" alt="Screen Shot 2022-10-13 at 20 59 42" src="https://user-images.githubusercontent.com/3343536/195759429-13e35010-7a12-4cdd-9f4b-4c5bf7c46cee.png">
