### PR TITLE
Configuration updates for HDC blended products

### DIFF
--- a/src/config/cuba/layers.json
+++ b/src/config/cuba/layers.json
@@ -683,6 +683,354 @@
       { "value": 2400, "label": "> 2400 mm", "color": "#ffc4ee" }
     ]
   },
+  "precip_blended_dekad": {
+    "title": "Blended rainfall aggregate (10-day)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "rfb_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-2 mm", "color": "#fffadf" },
+      { "value": 2, "label": "2-5 mm", "color": "#d3f9d0" },
+      { "value": 5, "label": "5-10 mm", "color": "#a9e4a3" },
+      { "value": 10, "label": "10-20 mm", "color": "#7cc594" },
+      { "value": 20, "label": "20-30 mm", "color": "#5eab91" },
+      { "value": 30, "label": "30-40 mm", "color": "#9fffe8" },
+      { "value": 40, "label": "40-50 mm", "color": "#90e0ef" },
+      { "value": 50, "label": "50-60 mm", "color": "#00b1de" },
+      { "value": 60, "label": "60-80 mm", "color": "#0083f3" },
+      { "value": 80, "label": "80-100 mm", "color": "#0052cd" },
+      { "value": 100, "label": "100-120 mm", "color": "#0000c8" },
+      { "value": 120, "label": "120-150 mm", "color": "#6003b8" },
+      { "value": 150, "label": "150-200 mm", "color": "#a002fa" },
+      { "value": 200, "label": "200-300 mm", "color": "#fa78fa" },
+      { "value": 300, "label": ">= 300 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_1m": {
+    "title": "Blended rainfall aggregate (1-month)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "r1b_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-5 mm", "color": "#fffadf" },
+      { "value": 5, "label": "5-10 mm", "color": "#d3f9d0" },
+      { "value": 10, "label": "10-20 mm", "color": "#a9e4a3" },
+      { "value": 20, "label": "20-30 mm", "color": "#7cc594" },
+      { "value": 30, "label": "30-40 mm", "color": "#5eab91" },
+      { "value": 40, "label": "40-60 mm", "color": "#9fffe8" },
+      { "value": 60, "label": "60-90 mm", "color": "#90e0ef" },
+      { "value": 90, "label": "90-120 mm", "color": "#00b1de" },
+      { "value": 120, "label": "120-150 mm", "color": "#0083f3" },
+      { "value": 150, "label": "150-200 mm", "color": "#0052cd" },
+      { "value": 200, "label": "200-250 mm", "color": "#0000c8" },
+      { "value": 250, "label": "250-300 mm", "color": "#6003b8" },
+      { "value": 300, "label": "300-350 mm", "color": "#a002fa" },
+      { "value": 350, "label": "350-400 mm", "color": "#fa78fa" },
+      { "value": 400, "label": ">= 400 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_3m": {
+    "title": "Blended rainfall aggregate (3-month)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "r3b_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-10 mm", "color": "#fffadf" },
+      { "value": 10, "label": "10-20 mm", "color": "#d3f9d0" },
+      { "value": 20, "label": "20-30 mm", "color": "#a9e4a3" },
+      { "value": 30, "label": "30-50 mm", "color": "#7cc594" },
+      { "value": 50, "label": "50-80 mm", "color": "#5eab91" },
+      { "value": 80, "label": "80-100 mm", "color": "#9fffe8" },
+      { "value": 100, "label": "100-150 mm", "color": "#90e0ef" },
+      { "value": 150, "label": "150-200 mm", "color": "#00b1de" },
+      { "value": 200, "label": "200-300 mm", "color": "#0083f3" },
+      { "value": 300, "label": "300-400 mm", "color": "#0052cd" },
+      { "value": 400, "label": "400-500 mm", "color": "#0000c8" },
+      { "value": 500, "label": "500-600 mm", "color": "#6003b8" },
+      { "value": 600, "label": "600-700 mm", "color": "#a002fa" },
+      { "value": 700, "label": "700-800 mm", "color": "#fa78fa" },
+      { "value": 800, "label": "> 800 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_6m": {
+    "title": "Blended rainfall aggregate (6-month)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "r6b_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-10 mm", "color": "#fffadf" },
+      { "value": 10, "label": "10-20 mm", "color": "#d3f9d0" },
+      { "value": 20, "label": "20-50 mm", "color": "#a9e4a3" },
+      { "value": 50, "label": "50-100 mm", "color": "#7cc594" },
+      { "value": 100, "label": "100-200 mm", "color": "#5eab91" },
+      { "value": 200, "label": "200-300 mm", "color": "#9fffe8" },
+      { "value": 300, "label": "300-400 mm", "color": "#90e0ef" },
+      { "value": 400, "label": "400-600 mm", "color": "#00b1de" },
+      { "value": 600, "label": "600-800 mm", "color": "#0083f3" },
+      { "value": 800, "label": "800-900 mm", "color": "#0052cd" },
+      { "value": 900, "label": "900-1000 mm", "color": "#0000c8" },
+      { "value": 1000, "label": "1000-1200 mm", "color": "#6003b8" },
+      { "value": 1200, "label": "1200-1400 mm", "color": "#a002fa" },
+      { "value": 1400, "label": "1400-1600 mm", "color": "#fa78fa" },
+      { "value": 1600, "label": "> 1600 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_9m": {
+    "title": "Blended rainfall aggregate (9-month)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "r9b_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-10 mm", "color": "#fffadf" },
+      { "value": 10, "label": "10-50 mm", "color": "#d3f9d0" },
+      { "value": 50, "label": "50-100 mm", "color": "#a9e4a3" },
+      { "value": 100, "label": "100-200 mm", "color": "#7cc594" },
+      { "value": 200, "label": "200-400 mm", "color": "#5eab91" },
+      { "value": 400, "label": "400-600 mm", "color": "#9fffe8" },
+      { "value": 600, "label": "600-800 mm", "color": "#90e0ef" },
+      { "value": 800, "label": "800-1000 mm", "color": "#00b1de" },
+      { "value": 1000, "label": "1000-1200 mm", "color": "#0083f3" },
+      { "value": 1200, "label": "1200-1400 mm", "color": "#0052cd" },
+      { "value": 1400, "label": "1400-1600 mm", "color": "#0000c8" },
+      { "value": 1600, "label": "1600-1800 mm", "color": "#6003b8" },
+      { "value": 1800, "label": "1800-2000 mm", "color": "#a002fa" },
+      { "value": 2000, "label": "2000-2400 mm", "color": "#fa78fa" },
+      { "value": 2400, "label": "> 2400 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_1y": {
+    "title": "Blended rainfall aggregate (1-year)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "ryb_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-10 mm", "color": "#fffadf" },
+      { "value": 10, "label": "10-50 mm", "color": "#d3f9d0" },
+      { "value": 50, "label": "50-100 mm", "color": "#a9e4a3" },
+      { "value": 100, "label": "100-200 mm", "color": "#7cc594" },
+      { "value": 200, "label": "200-400 mm", "color": "#5eab91" },
+      { "value": 400, "label": "400-600 mm", "color": "#9fffe8" },
+      { "value": 600, "label": "600-800 mm", "color": "#90e0ef" },
+      { "value": 800, "label": "800-1000 mm", "color": "#00b1de" },
+      { "value": 1000, "label": "1000-1200 mm", "color": "#0083f3" },
+      { "value": 1200, "label": "1200-1400 mm", "color": "#0052cd" },
+      { "value": 1400, "label": "1400-1600 mm", "color": "#0000c8" },
+      { "value": 1600, "label": "1600-1800 mm", "color": "#6003b8" },
+      { "value": 1800, "label": "1800-2000 mm", "color": "#a002fa" },
+      { "value": 2000, "label": "2000-2400 mm", "color": "#fa78fa" },
+      { "value": 2400, "label": "> 2400 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_dekad_anomaly": {
+    "title": "Blended rainfall anomaly (10-day)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "rfq_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 20%", "color": "#8c4800" },
+      { "value": 20, "label": "20-40%", "color": "#af6b27" },
+      { "value": 40, "label": "40-60%", "color": "#d58c3e" },
+      { "value": 60, "label": "60-70%", "color": "#eaa83d" },
+      { "value": 70, "label": "70-80%", "color": "#f5c878" },
+      { "value": 80, "label": "80-90%", "color": "#fff0c4" },
+      { "value": 90, "label": "90-110%", "color": "#fafafa" },
+      { "value": 110, "label": "110-120%", "color": "#befafa" },
+      { "value": 120, "label": "120-130%", "color": "#78e2f0" },
+      { "value": 130, "label": "130-150%", "color": "#00b9de" },
+      { "value": 150, "label": "150-200%", "color": "#0083f3" },
+      { "value": 200, "label": "200-300%", "color": "#0052cd" },
+      { "value": 300, "label": "300-400%", "color": "#0000c8" },
+      { "value": 400, "label": "> 400%", "color": "#a002fa" }
+    ]
+  },
+  "precip_blended_anomaly_1m": {
+    "title": "Blended rainfall anomaly (1-month)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "r1q_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 20%", "color": "#8c4800" },
+      { "value": 20, "label": "20-40%", "color": "#af6b27" },
+      { "value": 40, "label": "40-60%", "color": "#d58c3e" },
+      { "value": 60, "label": "60-70%", "color": "#eaa83d" },
+      { "value": 70, "label": "70-80%", "color": "#f5c878" },
+      { "value": 80, "label": "80-90%", "color": "#fff0c4" },
+      { "value": 90, "label": "90-110%", "color": "#fafafa" },
+      { "value": 110, "label": "110-120%", "color": "#befafa" },
+      { "value": 120, "label": "120-130%", "color": "#78e2f0" },
+      { "value": 130, "label": "130-150%", "color": "#00b9de" },
+      { "value": 150, "label": "150-200%", "color": "#0083f3" },
+      { "value": 200, "label": "200-300%", "color": "#0052cd" },
+      { "value": 300, "label": "300-400%", "color": "#0000c8" },
+      { "value": 400, "label": "> 400%", "color": "#a002fa" }
+    ]
+  },
+  "precip_blended_anomaly_3m": {
+    "title": "Blended rainfall anomaly (3-month)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "r3q_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 20%", "color": "#8c4800" },
+      { "value": 20, "label": "20-40%", "color": "#af6b27" },
+      { "value": 40, "label": "40-60%", "color": "#d58c3e" },
+      { "value": 60, "label": "60-70%", "color": "#eaa83d" },
+      { "value": 70, "label": "70-80%", "color": "#f5c878" },
+      { "value": 80, "label": "80-90%", "color": "#fff0c4" },
+      { "value": 90, "label": "90-110%", "color": "#fafafa" },
+      { "value": 110, "label": "110-120%", "color": "#befafa" },
+      { "value": 120, "label": "120-130%", "color": "#78e2f0" },
+      { "value": 130, "label": "130-150%", "color": "#00b9de" },
+      { "value": 150, "label": "150-200%", "color": "#0083f3" },
+      { "value": 200, "label": "200-300%", "color": "#0052cd" },
+      { "value": 300, "label": "300-400%", "color": "#0000c8" },
+      { "value": 400, "label": "> 400%", "color": "#a002fa" }
+    ]
+  },
+  "precip_blended_anomaly_6m": {
+    "title": "Blended rainfall anomaly (6-month)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "r6q_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 50%", "color": "#8c4800" },
+      { "value": 50, "label": "50-60%", "color": "#af6b27" },
+      { "value": 60, "label": "60-70%", "color": "#d58c3e" },
+      { "value": 70, "label": "70-80%", "color": "#eaa83d" },
+      { "value": 80, "label": "80-90%", "color": "#f5c878" },
+      { "value": 90, "label": "90-95%", "color": "#fff0c4" },
+      { "value": 95, "label": "95-105%", "color": "#fafafa" },
+      { "value": 105, "label": "105-110%", "color": "#befafa" },
+      { "value": 110, "label": "110-120%", "color": "#78e2f0" },
+      { "value": 120, "label": "120-130%", "color": "#00b9de" },
+      { "value": 130, "label": "130-150%", "color": "#0083f3" },
+      { "value": 150, "label": "150-170%", "color": "#0052cd" },
+      { "value": 170, "label": "170-200%", "color": "#0000c8" },
+      { "value": 200, "label": "> 200%", "color": "#a002fa" }
+    ]
+  },
+  "precip_blended_anomaly_9m": {
+    "title": "Blended rainfall anomaly (9-month)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "r9q_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 50%", "color": "#8c4800" },
+      { "value": 50, "label": "50-60%", "color": "#af6b27" },
+      { "value": 60, "label": "60-70%", "color": "#d58c3e" },
+      { "value": 70, "label": "70-80%", "color": "#eaa83d" },
+      { "value": 80, "label": "80-90%", "color": "#f5c878" },
+      { "value": 90, "label": "90-95%", "color": "#fff0c4" },
+      { "value": 95, "label": "95-105%", "color": "#fafafa" },
+      { "value": 105, "label": "105-110%", "color": "#befafa" },
+      { "value": 110, "label": "110-120%", "color": "#78e2f0" },
+      { "value": 120, "label": "120-130%", "color": "#00b9de" },
+      { "value": 130, "label": "130-150%", "color": "#0083f3" },
+      { "value": 150, "label": "150-170%", "color": "#0052cd" },
+      { "value": 170, "label": "170-200%", "color": "#0000c8" },
+      { "value": 200, "label": "> 200%", "color": "#a002fa" }
+    ]
+  },
+  "precip_blended_anomaly_1y": {
+    "title": "Blended rainfall anomaly (1-year)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_cub_dekad",
+    "additional_query_params": {
+      "styles": "ryq_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data from INSMET blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 50%", "color": "#8c4800" },
+      { "value": 50, "label": "50-60%", "color": "#af6b27" },
+      { "value": 60, "label": "60-70%", "color": "#d58c3e" },
+      { "value": 70, "label": "70-80%", "color": "#eaa83d" },
+      { "value": 80, "label": "80-90%", "color": "#f5c878" },
+      { "value": 90, "label": "90-95%", "color": "#fff0c4" },
+      { "value": 95, "label": "95-105%", "color": "#fafafa" },
+      { "value": 105, "label": "105-110%", "color": "#befafa" },
+      { "value": 110, "label": "110-120%", "color": "#78e2f0" },
+      { "value": 120, "label": "120-130%", "color": "#00b9de" },
+      { "value": 130, "label": "130-150%", "color": "#0083f3" },
+      { "value": 150, "label": "150-170%", "color": "#0052cd" },
+      { "value": 170, "label": "170-200%", "color": "#0000c8" },
+      { "value": 200, "label": "> 200%", "color": "#a002fa" }
+    ]
+  },
   "days_dry": {
     "title": "Days since last rain",
     "type": "wms",

--- a/src/config/cuba/prism.json
+++ b/src/config/cuba/prism.json
@@ -23,7 +23,71 @@
   },
   "categories": {
     "rainfall": {
-      "rainfall_amount": [
+      "INSMET_rainfall_data": [
+        {
+          "group_title": "Rainfall aggregate",
+          "activate_all": false,
+          "layers": [
+            {
+              "id": "precip_blended_dekad",
+              "label": "10-day",
+              "main": true
+            },
+            {
+              "id": "precip_blended_1m",
+              "label": "1-month"
+            },
+            {
+              "id": "precip_blended_3m",
+              "label": "3-month"
+            },
+            {
+              "id": "precip_blended_6m",
+              "label": "6-month"
+            },
+            {
+              "id": "precip_blended_9m",
+              "label": "9-month"
+            },
+            {
+              "id": "precip_blended_1y",
+              "label": "1-year"
+            }
+          ]
+        },
+        {
+          "group_title": "Rainfall anomaly",
+          "activate_all": false,
+          "layers": [
+            {
+              "id": "precip_blended_dekad_anomaly",
+              "label": "10-day",
+              "main": true
+            },
+            {
+              "id": "precip_blended_anomaly_1m",
+              "label": "1-month"
+            },
+            {
+              "id": "precip_blended_anomaly_3m",
+              "label": "3-month"
+            },
+            {
+              "id": "precip_blended_anomaly_6m",
+              "label": "6-month"
+            },
+            {
+              "id": "precip_blended_anomaly_9m",
+              "label": "9-month"
+            },
+            {
+              "id": "precip_blended_anomaly_1y",
+              "label": "1-year"
+            }
+          ]
+        }
+      ],
+      "global_rainfall_products": [
         {
           "group_title": "Rainfall Aggregate",
           "activate_all": false,
@@ -59,9 +123,7 @@
               "main": false
             }
           ]
-        }
-      ],
-      "rainfall_anomalies": [
+        },
         {
           "group_title": "Rainfall Anomaly",
           "activate_all": false,

--- a/src/config/mozambique/layers.json
+++ b/src/config/mozambique/layers.json
@@ -1014,7 +1014,7 @@
   "lst_daytime_blended": {
     "title": "INAM mean maximum air temperature (10-day)",
     "type": "wms",
-    "server_layer_name": "myd11a2_blended_txb_dekad",
+    "server_layer_name": "myd11a2_blended_txb_moz_dekad",
     "additional_query_params": {
       "styles": "tair_42_n24_70"
     },
@@ -1119,7 +1119,7 @@
   "lst_day_anomaly_blended": {
     "title": "INAM mean maximum air temperature anomaly (10-day)",
     "type": "wms",
-    "server_layer_name": "myd11a2_blended_txd_dekad",
+    "server_layer_name": "myd11a2_blended_txd_moz_dekad",
     "additional_query_params": {
       "styles": "txd_tud_21_m12_12"
     },

--- a/src/config/mozambique/layers.json
+++ b/src/config/mozambique/layers.json
@@ -1154,9 +1154,9 @@
   "precip_blended_dekad": {
     "title": "Blended rainfall aggregate (10-day)",
     "type": "wms",
-    "server_layer_name": "rfb_blended_dekad",
+    "server_layer_name": "rfb_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_300"
+      "styles": "rfb_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1184,9 +1184,9 @@
   "precip_blended_1m": {
     "title": "Blended rainfall aggregate (1-month)",
     "type": "wms",
-    "server_layer_name": "r1b_blended_dekad",
+    "server_layer_name": "rfb_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_400"
+      "styles": "r1b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1214,9 +1214,9 @@
   "precip_blended_3m": {
     "title": "Blended rainfall aggregate (3-month)",
     "type": "wms",
-    "server_layer_name": "r3b_blended_dekad",
+    "server_layer_name": "rfb_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_800"
+      "styles": "r3b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1244,9 +1244,9 @@
   "precip_blended_6m": {
     "title": "Blended rainfall aggregate (6-month)",
     "type": "wms",
-    "server_layer_name": "r6b_blended_dekad",
+    "server_layer_name": "rfb_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_1600"
+      "styles": "r6b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1274,9 +1274,9 @@
   "precip_blended_9m": {
     "title": "Blended rainfall aggregate (9-month)",
     "type": "wms",
-    "server_layer_name": "r9b_blended_dekad",
+    "server_layer_name": "rfb_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_2400"
+      "styles": "r9b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1304,9 +1304,9 @@
   "precip_blended_1y": {
     "title": "Blended rainfall aggregate (1-year)",
     "type": "wms",
-    "server_layer_name": "ryb_blended_dekad",
+    "server_layer_name": "rfb_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_2400"
+      "styles": "ryb_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1334,9 +1334,9 @@
   "precip_blended_dekad_anomaly": {
     "title": "Blended rainfall anomaly (10-day)",
     "type": "wms",
-    "server_layer_name": "rfq_blended_dekad",
+    "server_layer_name": "rfq_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "rfq_14_20_400"
+      "styles": "rfq_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1362,9 +1362,9 @@
   "precip_blended_anomaly_1m": {
     "title": "Blended rainfall anomaly (1-month)",
     "type": "wms",
-    "server_layer_name": "r1q_blended_dekad",
+    "server_layer_name": "rfq_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "rfq_14_20_400"
+      "styles": "r1q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1390,9 +1390,9 @@
   "precip_blended_anomaly_3m": {
     "title": "Blended rainfall anomaly (3-month)",
     "type": "wms",
-    "server_layer_name": "r3q_blended_dekad",
+    "server_layer_name": "rfq_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "rfq_14_20_400"
+      "styles": "r3q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1418,9 +1418,9 @@
   "precip_blended_anomaly_6m": {
     "title": "Blended rainfall anomaly (6-month)",
     "type": "wms",
-    "server_layer_name": "r6q_blended_dekad",
+    "server_layer_name": "rfq_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "ryq_14_50_200"
+      "styles": "r6q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1446,9 +1446,9 @@
   "precip_blended_anomaly_9m": {
     "title": "Blended rainfall anomaly (9-month)",
     "type": "wms",
-    "server_layer_name": "r9q_blended_dekad",
+    "server_layer_name": "rfq_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "ryq_14_50_200"
+      "styles": "r9q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1474,9 +1474,9 @@
   "precip_blended_anomaly_1y": {
     "title": "Blended rainfall anomaly (1-year)",
     "type": "wms",
-    "server_layer_name": "ryq_blended_dekad",
+    "server_layer_name": "rfq_blended_moz_dekad",
     "additional_query_params": {
-      "styles": "ryq_14_50_200"
+      "styles": "ryq_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",

--- a/src/config/namibia/layers.json
+++ b/src/config/namibia/layers.json
@@ -716,9 +716,9 @@
     "precip_blended_dekad": {
     "title": "Blended rainfall estimates (10-day)",
     "type": "wms",
-    "server_layer_name": "rfb_blended_dekad",
+    "server_layer_name": "rfb_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_300"
+      "styles": "rfb_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -746,9 +746,9 @@
   "precip_blended_1m": {
     "title": "Blended rainfall aggregate (1-month)",
     "type": "wms",
-    "server_layer_name": "r1b_blended_dekad",
+    "server_layer_name": "rfb_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_400"
+      "styles": "r1b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -776,9 +776,9 @@
   "precip_blended_3m": {
     "title": "Blended rainfall aggregate (3-month)",
     "type": "wms",
-    "server_layer_name": "r3b_blended_dekad",
+    "server_layer_name": "rfb_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_800"
+      "styles": "r3b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -806,9 +806,9 @@
   "precip_blended_6m": {
     "title": "Blended rainfall aggregate (6-month)",
     "type": "wms",
-    "server_layer_name": "r6b_blended_dekad",
+    "server_layer_name": "rfb_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_1600"
+      "styles": "r6b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -836,9 +836,9 @@
   "precip_blended_9m": {
     "title": "Blended rainfall aggregate (9-month)",
     "type": "wms",
-    "server_layer_name": "r9b_blended_dekad",
+    "server_layer_name": "rfb_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_2400"
+      "styles": "r9b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -866,9 +866,9 @@
   "precip_blended_1y": {
     "title": "Blended rainfall aggregate (1-year)",
     "type": "wms",
-    "server_layer_name": "ryb_blended_dekad",
+    "server_layer_name": "rfb_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_2400"
+      "styles": "ryb_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -896,9 +896,9 @@
   "precip_blended_dekad_anomaly": {
     "title": "Blended rainfall anomaly (10-day)",
     "type": "wms",
-    "server_layer_name": "rfq_blended_dekad",
+    "server_layer_name": "rfq_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "rfq_14_20_400"
+      "styles": "rfq_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -924,9 +924,9 @@
   "precip_blended_anomaly_1m": {
     "title": "Blended rainfall anomaly (1-month)",
     "type": "wms",
-    "server_layer_name": "r1q_blended_dekad",
+    "server_layer_name": "rfq_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "rfq_14_20_400"
+      "styles": "r1q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -952,9 +952,9 @@
   "precip_blended_anomaly_3m": {
     "title": "Blended rainfall anomaly (3-month)",
     "type": "wms",
-    "server_layer_name": "r3q_blended_dekad",
+    "server_layer_name": "rfq_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "rfq_14_20_400"
+      "styles": "r3q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -980,9 +980,9 @@
   "precip_blended_anomaly_6m": {
     "title": "Blended rainfall anomaly (6-month)",
     "type": "wms",
-    "server_layer_name": "r6q_blended_dekad",
+    "server_layer_name": "rfq_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "ryq_14_50_200"
+      "styles": "r6q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1008,9 +1008,9 @@
   "precip_blended_anomaly_9m": {
     "title": "Blended rainfall anomaly (9-month)",
     "type": "wms",
-    "server_layer_name": "r9q_blended_dekad",
+    "server_layer_name": "rfq_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "ryq_14_50_200"
+      "styles": "r9q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1036,9 +1036,9 @@
   "precip_blended_anomaly_1y": {
     "title": "Blended rainfall anomaly (1-year)",
     "type": "wms",
-    "server_layer_name": "ryq_blended_dekad",
+    "server_layer_name": "rfq_blended_nam_dekad",
     "additional_query_params": {
-      "styles": "ryq_14_50_200"
+      "styles": "ryq_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",

--- a/src/config/namibia/prism.json
+++ b/src/config/namibia/prism.json
@@ -38,6 +38,22 @@
             {
               "id": "precip_blended_1m",
               "label": "1-month"
+            },
+            {
+              "id": "precip_blended_3m",
+              "label": "3-month"
+            },
+            {
+              "id": "precip_blended_6m",
+              "label": "6-month"
+            },
+            {
+              "id": "precip_blended_9m",
+              "label": "9-month"
+            },
+            {
+              "id": "precip_blended_1y",
+              "label": "1-year"
             }
           ]
         },
@@ -53,6 +69,22 @@
             {
               "id": "precip_blended_anomaly_1m",
               "label": "1-month"
+            },
+            {
+              "id": "precip_blended_anomaly_3m",
+              "label": "3-month"
+            },
+            {
+              "id": "precip_blended_anomaly_6m",
+              "label": "6-month"
+            },
+            {
+              "id": "precip_blended_anomaly_9m",
+              "label": "9-month"
+            },
+            {
+              "id": "precip_blended_anomaly_1y",
+              "label": "1-year"
             }
           ]
         }

--- a/src/config/srilanka/layers.json
+++ b/src/config/srilanka/layers.json
@@ -401,6 +401,379 @@
       { "value": 4000, "label": "> 4000 mm", "color": "#ffc4ee" }
     ]
   },
+  "precip_blended_dekad": {
+    "title": "Blended rainfall estimates (10-day)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "rfb_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-2 mm", "color": "#fffadf" },
+      { "value": 2, "label": "2-5 mm", "color": "#d3f9d0" },
+      { "value": 5, "label": "5-10 mm", "color": "#a9e4a3" },
+      { "value": 10, "label": "10-20 mm", "color": "#7cc594" },
+      { "value": 20, "label": "20-30 mm", "color": "#5eab91" },
+      { "value": 30, "label": "30-40 mm", "color": "#9fffe8" },
+      { "value": 40, "label": "40-50 mm", "color": "#90e0ef" },
+      { "value": 50, "label": "50-60 mm", "color": "#00b1de" },
+      { "value": 60, "label": "60-80 mm", "color": "#0083f3" },
+      { "value": 80, "label": "80-100 mm", "color": "#0052cd" },
+      { "value": 100, "label": "100-120 mm", "color": "#0000c8" },
+      { "value": 120, "label": "120-150 mm", "color": "#6003b8" },
+      { "value": 150, "label": "150-200 mm", "color": "#a002fa" },
+      { "value": 200, "label": "200-300 mm", "color": "#fa78fa" },
+      { "value": 300, "label": ">= 300 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_1m": {
+    "title": "Blended rainfall aggregate (1-month)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "r1b_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-5 mm", "color": "#fffadf" },
+      { "value": 5, "label": "5-10 mm", "color": "#d3f9d0" },
+      { "value": 10, "label": "10-20 mm", "color": "#a9e4a3" },
+      { "value": 20, "label": "20-30 mm", "color": "#7cc594" },
+      { "value": 30, "label": "30-40 mm", "color": "#5eab91" },
+      { "value": 40, "label": "40-60 mm", "color": "#9fffe8" },
+      { "value": 60, "label": "60-90 mm", "color": "#90e0ef" },
+      { "value": 90, "label": "90-120 mm", "color": "#00b1de" },
+      { "value": 120, "label": "120-150 mm", "color": "#0083f3" },
+      { "value": 150, "label": "150-200 mm", "color": "#0052cd" },
+      { "value": 200, "label": "200-250 mm", "color": "#0000c8" },
+      { "value": 250, "label": "250-300 mm", "color": "#6003b8" },
+      { "value": 300, "label": "300-350 mm", "color": "#a002fa" },
+      { "value": 350, "label": "350-400 mm", "color": "#fa78fa" },
+      { "value": 400, "label": ">= 400 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_3m": {
+    "title": "Blended rainfall aggregate (3-month)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "r3b_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-10 mm", "color": "#fffadf" },
+      { "value": 10, "label": "10-20 mm", "color": "#d3f9d0" },
+      { "value": 20, "label": "20-30 mm", "color": "#a9e4a3" },
+      { "value": 30, "label": "30-50 mm", "color": "#7cc594" },
+      { "value": 50, "label": "50-80 mm", "color": "#5eab91" },
+      { "value": 80, "label": "80-100 mm", "color": "#9fffe8" },
+      { "value": 100, "label": "100-150 mm", "color": "#90e0ef" },
+      { "value": 150, "label": "150-200 mm", "color": "#00b1de" },
+      { "value": 200, "label": "200-300 mm", "color": "#0083f3" },
+      { "value": 300, "label": "300-400 mm", "color": "#0052cd" },
+      { "value": 400, "label": "400-500 mm", "color": "#0000c8" },
+      { "value": 500, "label": "500-600 mm", "color": "#6003b8" },
+      { "value": 600, "label": "600-700 mm", "color": "#a002fa" },
+      { "value": 700, "label": "700-800 mm", "color": "#fa78fa" },
+      { "value": 800, "label": "> 800 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_6m": {
+    "title": "Blended rainfall aggregate (6-month)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "r6b_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-10 mm", "color": "#fffadf" },
+      { "value": 10, "label": "10-20 mm", "color": "#d3f9d0" },
+      { "value": 20, "label": "20-50 mm", "color": "#a9e4a3" },
+      { "value": 50, "label": "50-100 mm", "color": "#7cc594" },
+      { "value": 100, "label": "100-200 mm", "color": "#5eab91" },
+      { "value": 200, "label": "200-300 mm", "color": "#9fffe8" },
+      { "value": 300, "label": "300-400 mm", "color": "#90e0ef" },
+      { "value": 400, "label": "400-600 mm", "color": "#00b1de" },
+      { "value": 600, "label": "600-800 mm", "color": "#0083f3" },
+      { "value": 800, "label": "800-900 mm", "color": "#0052cd" },
+      { "value": 900, "label": "900-1000 mm", "color": "#0000c8" },
+      { "value": 1000, "label": "1000-1200 mm", "color": "#6003b8" },
+      { "value": 1200, "label": "1200-1400 mm", "color": "#a002fa" },
+      { "value": 1400, "label": "1400-1600 mm", "color": "#fa78fa" },
+      { "value": 1600, "label": "> 1600 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_9m": {
+    "title": "Blended rainfall aggregate (9-month)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "r9b_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-10 mm", "color": "#fffadf" },
+      { "value": 10, "label": "10-50 mm", "color": "#d3f9d0" },
+      { "value": 50, "label": "50-100 mm", "color": "#a9e4a3" },
+      { "value": 100, "label": "100-200 mm", "color": "#7cc594" },
+      { "value": 200, "label": "200-400 mm", "color": "#5eab91" },
+      { "value": 400, "label": "400-600 mm", "color": "#9fffe8" },
+      { "value": 600, "label": "600-800 mm", "color": "#90e0ef" },
+      { "value": 800, "label": "800-1000 mm", "color": "#00b1de" },
+      { "value": 1000, "label": "1000-1200 mm", "color": "#0083f3" },
+      { "value": 1200, "label": "1200-1400 mm", "color": "#0052cd" },
+      { "value": 1400, "label": "1400-1600 mm", "color": "#0000c8" },
+      { "value": 1600, "label": "1600-1800 mm", "color": "#6003b8" },
+      { "value": 1800, "label": "1800-2000 mm", "color": "#a002fa" },
+      { "value": 2000, "label": "2000-2400 mm", "color": "#fa78fa" },
+      { "value": 2400, "label": "> 2400 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_1y": {
+    "title": "Blended rainfall aggregate (1-year)",
+    "type": "wms",
+    "server_layer_name": "rfb_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "ryb_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "0 mm", "color": "#fafafa" },
+      { "value": 0.01, "label": "1-10 mm", "color": "#fffadf" },
+      { "value": 10, "label": "10-50 mm", "color": "#d3f9d0" },
+      { "value": 50, "label": "50-100 mm", "color": "#a9e4a3" },
+      { "value": 100, "label": "100-200 mm", "color": "#7cc594" },
+      { "value": 200, "label": "200-400 mm", "color": "#5eab91" },
+      { "value": 400, "label": "400-600 mm", "color": "#9fffe8" },
+      { "value": 600, "label": "600-800 mm", "color": "#90e0ef" },
+      { "value": 800, "label": "800-1000 mm", "color": "#00b1de" },
+      { "value": 1000, "label": "1000-1200 mm", "color": "#0083f3" },
+      { "value": 1200, "label": "1200-1400 mm", "color": "#0052cd" },
+      { "value": 1400, "label": "1400-1600 mm", "color": "#0000c8" },
+      { "value": 1600, "label": "1600-1800 mm", "color": "#6003b8" },
+      { "value": 1800, "label": "1800-2000 mm", "color": "#a002fa" },
+      { "value": 2000, "label": "2000-2400 mm", "color": "#fa78fa" },
+      { "value": 2400, "label": "> 2400 mm", "color": "#ffc4ee" }
+    ]
+  },
+  "precip_blended_dekad_anomaly": {
+    "title": "Blended rainfall anomaly (10-day)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "rfq_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 20%", "color": "#8c4800" },
+      { "value": 20, "label": "20-40%", "color": "#af6b27" },
+      { "value": 40, "label": "40-60%", "color": "#d58c3e" },
+      { "value": 60, "label": "60-70%", "color": "#eaa83d" },
+      { "value": 70, "label": "70-80%", "color": "#f5c878" },
+      { "value": 80, "label": "80-90%", "color": "#fff0c4" },
+      { "value": 90, "label": "90-110%", "color": "#fafafa" },
+      { "value": 110, "label": "110-120%", "color": "#befafa" },
+      { "value": 120, "label": "120-130%", "color": "#78e2f0" },
+      { "value": 130, "label": "130-150%", "color": "#00b9de" },
+      { "value": 150, "label": "150-200%", "color": "#0083f3" },
+      { "value": 200, "label": "200-300%", "color": "#0052cd" },
+      { "value": 300, "label": "300-400%", "color": "#0000c8" },
+      { "value": 400, "label": "> 400%", "color": "#a002fa" }
+    ]
+  },
+  "precip_blended_anomaly_1m": {
+    "title": "Blended rainfall anomaly (1-month)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "r1q_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 20%", "color": "#8c4800" },
+      { "value": 20, "label": "20-40%", "color": "#af6b27" },
+      { "value": 40, "label": "40-60%", "color": "#d58c3e" },
+      { "value": 60, "label": "60-70%", "color": "#eaa83d" },
+      { "value": 70, "label": "70-80%", "color": "#f5c878" },
+      { "value": 80, "label": "80-90%", "color": "#fff0c4" },
+      { "value": 90, "label": "90-110%", "color": "#fafafa" },
+      { "value": 110, "label": "110-120%", "color": "#befafa" },
+      { "value": 120, "label": "120-130%", "color": "#78e2f0" },
+      { "value": 130, "label": "130-150%", "color": "#00b9de" },
+      { "value": 150, "label": "150-200%", "color": "#0083f3" },
+      { "value": 200, "label": "200-300%", "color": "#0052cd" },
+      { "value": 300, "label": "300-400%", "color": "#0000c8" },
+      { "value": 400, "label": "> 400%", "color": "#a002fa" }
+    ]
+  },
+  "precip_blended_anomaly_3m": {
+    "title": "Blended rainfall anomaly (3-month)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "r3q_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 20%", "color": "#8c4800" },
+      { "value": 20, "label": "20-40%", "color": "#af6b27" },
+      { "value": 40, "label": "40-60%", "color": "#d58c3e" },
+      { "value": 60, "label": "60-70%", "color": "#eaa83d" },
+      { "value": 70, "label": "70-80%", "color": "#f5c878" },
+      { "value": 80, "label": "80-90%", "color": "#fff0c4" },
+      { "value": 90, "label": "90-110%", "color": "#fafafa" },
+      { "value": 110, "label": "110-120%", "color": "#befafa" },
+      { "value": 120, "label": "120-130%", "color": "#78e2f0" },
+      { "value": 130, "label": "130-150%", "color": "#00b9de" },
+      { "value": 150, "label": "150-200%", "color": "#0083f3" },
+      { "value": 200, "label": "200-300%", "color": "#0052cd" },
+      { "value": 300, "label": "300-400%", "color": "#0000c8" },
+      { "value": 400, "label": "> 400%", "color": "#a002fa" }
+    ]
+  },
+  "precip_blended_anomaly_6m": {
+    "title": "Blended rainfall anomaly (6-month)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "r6q_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 50%", "color": "#8c4800" },
+      { "value": 50, "label": "50-60%", "color": "#af6b27" },
+      { "value": 60, "label": "60-70%", "color": "#d58c3e" },
+      { "value": 70, "label": "70-80%", "color": "#eaa83d" },
+      { "value": 80, "label": "80-90%", "color": "#f5c878" },
+      { "value": 90, "label": "90-95%", "color": "#fff0c4" },
+      { "value": 95, "label": "95-105%", "color": "#fafafa" },
+      { "value": 105, "label": "105-110%", "color": "#befafa" },
+      { "value": 110, "label": "110-120%", "color": "#78e2f0" },
+      { "value": 120, "label": "120-130%", "color": "#00b9de" },
+      { "value": 130, "label": "130-150%", "color": "#0083f3" },
+      { "value": 150, "label": "150-170%", "color": "#0052cd" },
+      { "value": 170, "label": "170-200%", "color": "#0000c8" },
+      { "value": 200, "label": "> 200%", "color": "#a002fa" }
+    ]
+  },
+  "precip_blended_anomaly_9m": {
+    "title": "Blended rainfall anomaly (9-month)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "r9q_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 50%", "color": "#8c4800" },
+      { "value": 50, "label": "50-60%", "color": "#af6b27" },
+      { "value": 60, "label": "60-70%", "color": "#d58c3e" },
+      { "value": 70, "label": "70-80%", "color": "#eaa83d" },
+      { "value": 80, "label": "80-90%", "color": "#f5c878" },
+      { "value": 90, "label": "90-95%", "color": "#fff0c4" },
+      { "value": 95, "label": "95-105%", "color": "#fafafa" },
+      { "value": 105, "label": "105-110%", "color": "#befafa" },
+      { "value": 110, "label": "110-120%", "color": "#78e2f0" },
+      { "value": 120, "label": "120-130%", "color": "#00b9de" },
+      { "value": 130, "label": "130-150%", "color": "#0083f3" },
+      { "value": 150, "label": "150-170%", "color": "#0052cd" },
+      { "value": 170, "label": "170-200%", "color": "#0000c8" },
+      { "value": 200, "label": "> 200%", "color": "#a002fa" }
+    ]
+  },
+  "precip_blended_anomaly_1y": {
+    "title": "Blended rainfall anomaly (1-year)",
+    "type": "wms",
+    "server_layer_name": "rfq_blended_lka_dekad",
+    "additional_query_params": {
+      "styles": "ryq_blended"
+    },
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "legend_text": "Rainfall anomaly based on long term averaged from local station data blended with CHIRP rainfall estimates",
+    "legend": [
+      { "value": 0, "label": "< 50%", "color": "#8c4800" },
+      { "value": 50, "label": "50-60%", "color": "#af6b27" },
+      { "value": 60, "label": "60-70%", "color": "#d58c3e" },
+      { "value": 70, "label": "70-80%", "color": "#eaa83d" },
+      { "value": 80, "label": "80-90%", "color": "#f5c878" },
+      { "value": 90, "label": "90-95%", "color": "#fff0c4" },
+      { "value": 95, "label": "95-105%", "color": "#fafafa" },
+      { "value": 105, "label": "105-110%", "color": "#befafa" },
+      { "value": 110, "label": "110-120%", "color": "#78e2f0" },
+      { "value": 120, "label": "120-130%", "color": "#00b9de" },
+      { "value": 130, "label": "130-150%", "color": "#0083f3" },
+      { "value": 150, "label": "150-170%", "color": "#0052cd" },
+      { "value": 170, "label": "170-200%", "color": "#0000c8" },
+      { "value": 200, "label": "> 200%", "color": "#a002fa" }
+    ]
+  },
+  "precip_blended_dekad_agg": {
+    "title": "Blended monthly aggregate rainfall",
+    "type": "wms",
+    "server_layer_name": "rnb_blended_dekad",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "opacity": 0.7,
+    "additional_query_params": {
+      "styles": "r1b"
+    },
+    "legend_text": "Monthly aggregate rainfall based on local station data blended with CHIRP estimates",
+    "legend": [
+      { "value": "50", "color": "#faf3d2" },
+      { "value": "100", "color": "#dae3a1" },
+      { "value": "150", "color": "#a0c787" },
+      { "value": "200", "color": "#68ab79" },
+      { "value": "250", "color": "#9beafa" },
+      { "value": "300", "color": "#00b1de" },
+      { "value": "400", "color": "#005ae6" },
+      { "value": "500", "color": "#0000c8" },
+      { "value": "600", "color": "#a000fa" },
+      { "value": "800", "color": "#fa78fa" },
+      { "value": "> 800", "color": "#ffc4ee" }
+    ]
+  },
   "spi_1m": {
     "title": "SPI - 1-month",
     "type": "wms",

--- a/src/config/srilanka/prism.json
+++ b/src/config/srilanka/prism.json
@@ -26,9 +26,73 @@
   ],
   "categories": {
     "rainfall": {
-      "rainfall_amount": [
+      "Met_Dept_rainfall_data": [
         {
-          "group_title": "Rainfall Aggregate",
+          "group_title": "Rainfall aggregate",
+          "activate_all": false,
+          "layers": [
+            {
+              "id": "precip_blended_dekad",
+              "label": "10-day",
+              "main": true
+            },
+            {
+              "id": "precip_blended_1m",
+              "label": "1-month"
+            },
+            {
+              "id": "precip_blended_3m",
+              "label": "3-month"
+            },
+            {
+              "id": "precip_blended_6m",
+              "label": "6-month"
+            },
+            {
+              "id": "precip_blended_9m",
+              "label": "9-month"
+            },
+            {
+              "id": "precip_blended_1y",
+              "label": "1-year"
+            }
+          ]
+        },
+        {
+          "group_title": "Rainfall anomaly",
+          "activate_all": false,
+          "layers": [
+            {
+              "id": "precip_blended_dekad_anomaly",
+              "label": "10-day",
+              "main": true
+            },
+            {
+              "id": "precip_blended_anomaly_1m",
+              "label": "1-month"
+            },
+            {
+              "id": "precip_blended_anomaly_3m",
+              "label": "3-month"
+            },
+            {
+              "id": "precip_blended_anomaly_6m",
+              "label": "6-month"
+            },
+            {
+              "id": "precip_blended_anomaly_9m",
+              "label": "9-month"
+            },
+            {
+              "id": "precip_blended_anomaly_1y",
+              "label": "1-year"
+            }
+          ]
+        }
+      ],
+      "global_rainfall_products": [
+        {
+          "group_title": "Rainfall aggregate",
           "activate_all": false,
           "layers": [
             {
@@ -57,11 +121,9 @@
               "label": "1-year"
             }
           ]
-        }
-      ],
-      "rainfall_anomalies": [
+        },
         {
-          "group_title": "Rainfall Anomaly",
+          "group_title": "Rainfall anomaly",
           "activate_all": false,
           "layers": [
             {

--- a/src/config/zimbabwe/layers.json
+++ b/src/config/zimbabwe/layers.json
@@ -445,6 +445,31 @@
     "additional_query_params": {
       "styles": "rfq_14_20_400"
     },
+    "chart_data": {
+      "url": "https://api.earthobservation.vam.wfp.org/stats/admin/fetch",
+      "fields": [
+        { "key": "r1q", "label": "Rainfall anomaly", "color": "#375692" },
+        {
+          "key": "rfq_avg",
+          "label": "Normal",
+          "fallback": 100,
+          "color": "#eb3223"
+        }
+      ],
+      "levels": [
+        {
+          "level": "1",
+          "id": "dataviz_adm1_id",
+          "name": "PROVNAMEFU"
+        },
+        {
+          "level": "2",
+          "id": "dataviz_adm2_id",
+          "name": "DIST_NAME_"
+        }
+      ],
+      "type": "line"
+    },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
     "opacity": 0.7,
@@ -471,6 +496,31 @@
     "type": "wms",
     "server_layer_name": "r3q_dekad",
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "chart_data": {
+      "url": "https://api.earthobservation.vam.wfp.org/stats/admin/fetch",
+      "fields": [
+        { "key": "r3q", "label": "Rainfall anomaly", "color": "#375692" },
+        {
+          "key": "rfq_avg",
+          "label": "Normal",
+          "fallback": 100,
+          "color": "#eb3223"
+        }
+      ],
+      "levels": [
+        {
+          "level": "1",
+          "id": "dataviz_adm1_id",
+          "name": "PROVNAMEFU"
+        },
+        {
+          "level": "2",
+          "id": "dataviz_adm2_id",
+          "name": "DIST_NAME_"
+        }
+      ],
+      "type": "line"
+    },
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "3-month precipitation anomaly compared to the long term average. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -662,6 +712,26 @@
     "additional_query_params": {
       "styles": "rfh_16_0_400"
     },
+    "chart_data": {
+      "url": "https://api.earthobservation.vam.wfp.org/stats/admin/fetch",
+      "fields": [
+        { "key": "r1h", "label": "Rainfall", "color": "#233f5f" },
+        { "key": "r1h_avg", "label": "Average", "color": "#bdf2e6" }
+      ],
+      "levels": [
+        {
+          "level": "1",
+          "id": "dataviz_adm1_id",
+          "name": "PROVNAMEFU"
+        },
+        {
+          "level": "2",
+          "id": "dataviz_adm2_id",
+          "name": "DIST_NAME_"
+        }
+      ],
+      "type": "bar"
+    },
     "date_interval": "days",
     "opacity": 0.7,
     "legend_text": "Total aggregate precipitation over a 1-month period, rolling every 10 days. Derived from CHIRPS (UCSB Climate Hazards Group). https://www.chc.ucsb.edu/data/chirps",
@@ -690,6 +760,26 @@
     "server_layer_name": "r3h_dekad",
     "additional_query_params": {
       "styles": "rfh_16_0_800"
+    },
+    "chart_data": {
+      "url": "https://api.earthobservation.vam.wfp.org/stats/admin/fetch",
+      "fields": [
+        { "key": "r3h", "label": "Rainfall", "color": "#233f5f" },
+        { "key": "r3h_avg", "label": "Average", "color": "#bdf2e6" }
+      ],
+      "levels": [
+        {
+          "level": "1",
+          "id": "dataviz_adm1_id",
+          "name": "PROVNAMEFU"
+        },
+        {
+          "level": "2",
+          "id": "dataviz_adm2_id",
+          "name": "DIST_NAME_"
+        }
+      ],
+      "type": "bar"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",

--- a/src/config/zimbabwe/layers.json
+++ b/src/config/zimbabwe/layers.json
@@ -807,9 +807,9 @@
   "precip_blended_dekad": {
     "title": "Blended rainfall aggregate (10-day)",
     "type": "wms",
-    "server_layer_name": "rfb_blended_dekad",
+    "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_300"
+      "styles": "rfb_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -837,9 +837,9 @@
   "precip_blended_1m": {
     "title": "Blended rainfall aggregate (1-month)",
     "type": "wms",
-    "server_layer_name": "r1b_blended_dekad",
+    "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_400"
+      "styles": "r1b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -867,9 +867,9 @@
   "precip_blended_3m": {
     "title": "Blended rainfall aggregate (3-month)",
     "type": "wms",
-    "server_layer_name": "r3b_blended_dekad",
+    "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_800"
+      "styles": "r3b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -897,9 +897,9 @@
   "precip_blended_6m": {
     "title": "Blended rainfall aggregate (6-month)",
     "type": "wms",
-    "server_layer_name": "r6b_blended_dekad",
+    "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_1600"
+      "styles": "r6b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -927,9 +927,9 @@
   "precip_blended_9m": {
     "title": "Blended rainfall aggregate (9-month)",
     "type": "wms",
-    "server_layer_name": "r9b_blended_dekad",
+    "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_2400"
+      "styles": "r9b_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -957,9 +957,9 @@
   "precip_blended_1y": {
     "title": "Blended rainfall aggregate (1-year)",
     "type": "wms",
-    "server_layer_name": "ryb_blended_dekad",
+    "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "rfh_16_0_2400"
+      "styles": "ryb_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -987,9 +987,9 @@
   "precip_blended_dekad_anomaly": {
     "title": "Blended rainfall anomaly (10-day)",
     "type": "wms",
-    "server_layer_name": "rfq_blended_dekad",
+    "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "rfq_14_20_400"
+      "styles": "rfq_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1015,9 +1015,9 @@
   "precip_blended_anomaly_1m": {
     "title": "Blended rainfall anomaly (1-month)",
     "type": "wms",
-    "server_layer_name": "r1q_blended_dekad",
+    "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "rfq_14_20_400"
+      "styles": "r1q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1043,9 +1043,9 @@
   "precip_blended_anomaly_3m": {
     "title": "Blended rainfall anomaly (3-month)",
     "type": "wms",
-    "server_layer_name": "r3q_blended_dekad",
+    "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "rfq_14_20_400"
+      "styles": "r3q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1071,9 +1071,9 @@
   "precip_blended_anomaly_6m": {
     "title": "Blended rainfall anomaly (6-month)",
     "type": "wms",
-    "server_layer_name": "r6q_blended_dekad",
+    "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "ryq_14_50_200"
+      "styles": "r6q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1099,9 +1099,9 @@
   "precip_blended_anomaly_9m": {
     "title": "Blended rainfall anomaly (9-month)",
     "type": "wms",
-    "server_layer_name": "r9q_blended_dekad",
+    "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "ryq_14_50_200"
+      "styles": "r9q_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",
@@ -1127,9 +1127,9 @@
   "precip_blended_anomaly_1y": {
     "title": "Blended rainfall anomaly (1-year)",
     "type": "wms",
-    "server_layer_name": "ryq_blended_dekad",
+    "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "ryq_14_50_200"
+      "styles": "ryq_blended"
     },
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
     "date_interval": "days",


### PR DESCRIPTION
This PR updates 5 PRISM instances where WFP's Humanitarian Data Cube (HDC) provides 'blended' products which are based on global precipitation and temperature layers combined with local weather station data. 

The update addresses changes in how data layers are distributed through HDC, using a country-level layer and individual styles per date intervals. Note: this new approach in HDC changes how PRISM can access layers as WCS access is no longer included for all time intervals.

The modified instances include: Cuba, Mozambique, Namibia, Sri Lanka and Zimbabwe

The Mozambique deployment has been updated with this new configuration as an example: https://prism-moz.surge.sh/ 