### PR TITLE
Prevent prettier from removing "error: any"

### DIFF
--- a/common/src/base/test.ts
+++ b/common/src/base/test.ts
@@ -41,7 +41,8 @@ test("Base.getCapabilities with bad versions", async ({ eq }) => {
   let msg1;
   try {
     await base.getCapabilities({ debug: true, version: "incorrect" });
-  } catch (error) {
+    // eslint-disable-next-line prettier/prettier
+  } catch (error: any) {
     msg1 = error.message;
   }
   eq(msg1.includes("java.lang.ClassCastException"), true);
@@ -49,7 +50,8 @@ test("Base.getCapabilities with bad versions", async ({ eq }) => {
   let msg2;
   try {
     await base.getCapabilities({ debug: true, version: "123" });
-  } catch (error) {
+    // eslint-disable-next-line prettier/prettier
+  } catch (error: any) {
     msg2 = error.message;
   }
   eq(msg2.startsWith("fetch failed"), true);


### PR DESCRIPTION
Fixes the following issue:
<img width="526" alt="Screen Shot 2023-01-10 at 1 49 07 PM" src="https://user-images.githubusercontent.com/4313463/211636438-04d27ed9-23c5-4564-b2b3-04e4cc4743ff.png">

Basically an eslint rule from[ eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) called `prettier/prettier` automatically removes `: any` from `error: any`.  However, typescript doesn't like this.

The fix is to just disable the `prettier/prettier` eslint rule for the two lines with `error: any`.