### PR TITLE
Ux revamp/fix polygon analysis style

### DIFF
--- a/api/docker-compose.deploy.yml
+++ b/api/docker-compose.deploy.yml
@@ -10,7 +10,7 @@ services:
     image: 'traefik:v2.4'
     container_name: 'traefik'
     command:
-      - '--log.level=DEBUG'
+      - '--log.level=INFO'
       - '--api.insecure=true'
       - '--providers.docker=true'
       - '--providers.docker.network=traefik_default'

--- a/frontend/src/components/Common/SimpleDropdown/index.tsx
+++ b/frontend/src/components/Common/SimpleDropdown/index.tsx
@@ -1,4 +1,4 @@
-import { FormControl, MenuItem, Select } from '@material-ui/core';
+import { FormControl, MenuItem, Select, Typography } from '@material-ui/core';
 import React from 'react';
 import { useSafeTranslation } from '../../../i18n';
 
@@ -8,11 +8,13 @@ export default function SimpleDropdown<OptionValue extends number | string>({
   options,
   value,
   onChange,
+  textClass,
   ...rest
 }: {
   options: [OptionValue, OptionLabel][];
   value: OptionValue;
   onChange: (value: OptionValue) => void;
+  textClass: string;
 }) {
   const { t } = useSafeTranslation();
   return (
@@ -25,7 +27,7 @@ export default function SimpleDropdown<OptionValue extends number | string>({
       >
         {options.map(([val, text]) => (
           <MenuItem key={val} value={val}>
-            {t(text)}
+            <Typography className={textClass}>{t(text)}</Typography>
           </MenuItem>
         ))}
       </Select>

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
@@ -49,14 +49,7 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
     setIsAscending(newIsAsc);
   };
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
+    <div className={classes.root}>
       <TableContainer className={classes.tableContainer}>
         <Table stickyHeader aria-label="analysis table">
           <TableHead>
@@ -161,8 +154,15 @@ function AnalysisTable({ classes, tableData, columns }: AnalysisTableProps) {
 
 const styles = (theme: Theme) =>
   createStyles({
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      maxHeight: 'inherit',
+      maxWidth: 'inherit',
+    },
     tableContainer: {
-      maxWidth: '90%',
       marginTop: 10,
       zIndex: theme.zIndex.modal + 1,
     },
@@ -184,10 +184,10 @@ const styles = (theme: Theme) =>
       display: 'flex',
       justifyContent: 'center',
       color: 'black',
+      flexShrink: 0,
     },
     select: {
       flex: '1 1 10%',
-      maxWidth: '10%',
       marginRight: 0,
     },
     caption: {

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
@@ -490,7 +490,7 @@ function AnalysisPanel({
                       className={classes.analysisParamTitle}
                       variant="body2"
                     >
-                      Admin Level
+                      {t('Admin Level')}
                     </Typography>
                     <SimpleDropdown
                       value={adminLevel}

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
@@ -486,7 +486,12 @@ function AnalysisPanel({
               {hazardDataType === GeometryType.Polygon && (
                 <>
                   <div className={classes.analysisPanelParamContainer}>
-                    <Typography variant="body2">Admin Level</Typography>
+                    <Typography
+                      className={classes.analysisParamTitle}
+                      variant="body2"
+                    >
+                      Admin Level
+                    </Typography>
                     <SimpleDropdown
                       value={adminLevel}
                       options={range(getAdminLevelCount()).map(i => [
@@ -494,13 +499,24 @@ function AnalysisPanel({
                         `Admin ${i + 1}`,
                       ])}
                       onChange={setAdminLevel}
+                      textClass={classes.analysisParamTitle}
                     />
                   </div>
 
                   <div className={classes.analysisPanelParamContainer}>
-                    <Typography variant="body2">{t('Date Range')}</Typography>
+                    <Typography
+                      className={classes.analysisParamTitle}
+                      variant="body2"
+                    >
+                      {t('Date Range')}
+                    </Typography>
                     <div className={classes.dateRangePicker}>
-                      <Typography variant="body2">{t('Start')}</Typography>
+                      <Typography
+                        className={classes.analysisParamTitle}
+                        variant="body2"
+                      >
+                        {t('Start')}
+                      </Typography>
                       <DatePicker
                         selected={startDate ? new Date(startDate) : null}
                         onChange={date =>
@@ -512,13 +528,20 @@ function AnalysisPanel({
                         showMonthDropdown
                         showYearDropdown
                         dropdownMode="select"
-                        customInput={<Input />}
+                        customInput={
+                          <Input className={classes.analysisPanelParamText} />
+                        }
                         popperClassName={classes.calendarPopper}
                         includeDates={availableHazardDates}
                       />
                     </div>
                     <div className={classes.dateRangePicker}>
-                      <Typography variant="body2">{t('End')}</Typography>
+                      <Typography
+                        className={classes.analysisParamTitle}
+                        variant="body2"
+                      >
+                        {t('End')}
+                      </Typography>
                       <DatePicker
                         selected={endDate ? new Date(endDate) : null}
                         onChange={date =>
@@ -530,7 +553,9 @@ function AnalysisPanel({
                         showMonthDropdown
                         showYearDropdown
                         dropdownMode="select"
-                        customInput={<Input />}
+                        customInput={
+                          <Input className={classes.analysisPanelParamText} />
+                        }
                         popperClassName={classes.calendarPopper}
                         includeDates={availableHazardDates}
                       />
@@ -859,6 +884,7 @@ const styles = (theme: Theme) =>
     dateRangePicker: {
       display: 'inline-block',
       marginRight: '15px',
+      marginTop: '15px',
       minWidth: '125px',
       width: '100px',
     },

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
@@ -756,10 +756,12 @@ function AnalysisPanel({
                 {selectedHazardLayer?.title}
               </Typography>
             </div>
-            <AnalysisTable
-              tableData={analysisResult.tableData}
-              columns={translatedColumns}
-            />
+            <div className={classes.analysisTable}>
+              <AnalysisTable
+                tableData={analysisResult.tableData}
+                columns={translatedColumns}
+              />
+            </div>
           </div>
         )}
       {!isAnalysisLoading &&
@@ -900,6 +902,14 @@ const styles = (theme: Theme) =>
     exposureAnalysisTable: {
       // to remove after refactor: analysis panel should be a flex container and the bottom buttons should not be position absolute
       maxHeight: 'calc(80vh - 143px)',
+    },
+    analysisTable: {
+      maxHeight: '75vh',
+      maxWidth: '96%',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
     },
   });
 

--- a/frontend/src/utils/analysis-utils.ts
+++ b/frontend/src/utils/analysis-utils.ts
@@ -661,7 +661,16 @@ export function getAnalysisTableColumns(
     return [];
   }
   if ('tableColumns' in analysisResult) {
-    return (analysisResult as PolygonAnalysisResult).tableColumns;
+    return [
+      {
+        id: withLocalName ? 'localName' : 'name',
+        label: 'Name',
+      } as Column,
+    ].concat(
+      (analysisResult as PolygonAnalysisResult).tableColumns.filter(
+        column => !['name', 'localName'].includes(column.id as string),
+      ),
+    );
   }
   const { statistic } = analysisResult;
   const baselineLayerTitle = analysisResult.getBaselineLayer().title;


### PR DESCRIPTION
Ux revamp fix polygon analysis font style
and fix display of the table

How to test the feature:

- [ ] got to the analysis table 
- [ ] select a polygon analysis layer
- [ ] the font should be black for all the selectors
- [ ] Check that the table is well displayed
Screenshot/video of feature:

![image](https://user-images.githubusercontent.com/44159363/212114092-289b9ca6-ba7a-491d-a226-00d0d7dd77ac.png)
