### PR TITLE
Handle error if raster GeoTiff is not downloadable

### DIFF
--- a/frontend/src/components/MapView/Layers/raster-utils.ts
+++ b/frontend/src/components/MapView/Layers/raster-utils.ts
@@ -314,7 +314,7 @@ export async function downloadGeotiff(
       if (response.status !== 200) {
         dispatch(
           addNotification({
-            message: `${collection} Geotiff couldn't be generated`,
+            message: `The raster layer ${collection} could not be generated. Please try your download again later.`,
             type: 'warning',
           }),
         );
@@ -328,7 +328,7 @@ export async function downloadGeotiff(
     } catch {
       dispatch(
         addNotification({
-          message: `${collection} Geotiff couldn't be generated`,
+          message: `The raster layer ${collection} could not be generated. Please try your download again later.`,
           type: 'warning',
         }),
       );

--- a/frontend/src/components/MapView/Layers/raster-utils.ts
+++ b/frontend/src/components/MapView/Layers/raster-utils.ts
@@ -300,30 +300,40 @@ export async function downloadGeotiff(
       long_max: boundingBox[3],
       date,
     };
-    const response = await fetch(`${BACKEND_URL}/raster_geotiff`, {
-      method: 'POST',
-      cache: 'no-cache',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      // body data type must match "Content-Type" header
-      body: JSON.stringify(body),
-    });
-    if (response.status !== 200) {
+    try {
+      const response = await fetch(`${BACKEND_URL}/raster_geotiff`, {
+        method: 'POST',
+        cache: 'no-cache',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        // body data type must match "Content-Type" header
+        body: JSON.stringify(body),
+      });
+      if (response.status !== 200) {
+        dispatch(
+          addNotification({
+            message: `${collection} Geotiff couldn't be generated`,
+            type: 'warning',
+          }),
+        );
+      } else {
+        const responseJson = await response.json();
+
+        const link = document.createElement('a');
+        link.setAttribute('href', responseJson.download_url);
+        link.click();
+      }
+    } catch {
       dispatch(
         addNotification({
           message: `${collection} Geotiff couldn't be generated`,
           type: 'warning',
         }),
       );
-    } else {
-      const responseJson = await response.json();
-
-      const link = document.createElement('a');
-      link.setAttribute('href', responseJson.download_url);
-      link.click();
+    } finally {
+      callback();
     }
-    callback();
   }
 }


### PR DESCRIPTION
[This fixes issue [702].](https://github.com/WFP-VAM/prism-app/issues/702)

How to test the feature:

- [ ] Test downloading a raster using the download button for the layer: rainfall > global rainfall products > rainfall aggregate 10-day
- [ ] the app should not crash and you should see a popup saying that the raster cannot be downloaded

Screenshot/video of feature:
![image](https://user-images.githubusercontent.com/44159363/212181950-d53a0e12-7130-4be8-b8e1-415c66f1e957.png)
