### PR TITLE
Fix report would not generate for flood_extent COUNTRY=cambodia

### DIFF
--- a/frontend/src/components/MapView/Download/index.tsx
+++ b/frontend/src/components/MapView/Download/index.tsx
@@ -71,8 +71,8 @@ function Download({ classes }: DownloadProps) {
     ({ id }) => id === 'adamts_buffers',
   );
 
-  const isShowingFloodData = selectedLayers.some(({ id }) =>
-    id.includes('hydra_'),
+  const isShowingFloodData = selectedLayers.some(
+    ({ id }) => id.includes('hydra_') || id === 'flood_extent',
   );
 
   const shouldShowReport = isShowingFloodData || isShowingStormData;

--- a/frontend/src/components/MapView/Download/index.tsx
+++ b/frontend/src/components/MapView/Download/index.tsx
@@ -67,6 +67,7 @@ function Download({ classes }: DownloadProps) {
   const selectedLayers = useSelector(layersSelector);
   const previewRef = useRef<HTMLCanvasElement>(null);
 
+  // TODO: Add layers for storm and flood data as configuration options in layers.json
   const isShowingStormData = selectedLayers.some(
     ({ id }) => id === 'adamts_buffers',
   );

--- a/frontend/src/components/MapView/Download/reportDoc.tsx
+++ b/frontend/src/components/MapView/Download/reportDoc.tsx
@@ -167,9 +167,16 @@ interface TableHeadProps {
   name: string;
   cellWidth: string;
   columns: string[];
+  showTotalsColumn: boolean;
 }
 
-const TableHead = ({ theme, name, cellWidth, columns }: TableHeadProps) => {
+const TableHead = ({
+  theme,
+  name,
+  cellWidth,
+  columns,
+  showTotalsColumn,
+}: TableHeadProps) => {
   const styles = makeStyles(theme);
   return (
     <View style={{ backgroundColor: theme.pdf?.table?.darkRowColor }}>
@@ -184,7 +191,9 @@ const TableHead = ({ theme, name, cellWidth, columns }: TableHeadProps) => {
             </Text>
           );
         })}
-        <Text style={[styles.tableCell, { width: cellWidth }]}>Total</Text>
+        {showTotalsColumn && (
+          <Text style={[styles.tableCell, { width: cellWidth }]}>Total</Text>
+        )}
       </View>
     </View>
   );
@@ -197,6 +206,7 @@ interface TableProps {
   columns: string[];
   cellWidth: string;
   showTotal: boolean;
+  showRowTotal: boolean;
   t: TFunction;
 }
 
@@ -207,6 +217,7 @@ const Table = ({
   columns,
   cellWidth,
   showTotal,
+  showRowTotal,
   t,
 }: TableProps) => {
   const styles = makeStyles(theme);
@@ -241,6 +252,7 @@ const Table = ({
               name={name}
               cellWidth={cellWidth}
               columns={columns}
+              showTotalsColumn={showRowTotal}
             />
             {chunkRow.map((rowData, index) => {
               const color =
@@ -264,9 +276,11 @@ const Table = ({
                       {getTableCellVal(rowData, col, t)}
                     </Text>
                   ))}
-                  <Text style={[styles.tableCell, { width: cellWidth }]}>
-                    {Number(total).toLocaleString('en-US')}
-                  </Text>
+                  {showRowTotal && (
+                    <Text style={[styles.tableCell, { width: cellWidth }]}>
+                      {Number(total).toLocaleString('en-US')}
+                    </Text>
+                  )}
                 </View>
               );
             })}
@@ -302,11 +316,13 @@ const Table = ({
               </Text>
             );
           })}
-          <Text style={[styles.tableCell, { width: cellWidth }]}>
-            {totals.reduce((prev, cur) => {
-              return prev + cur;
-            }, 0)}
-          </Text>
+          {showRowTotal && (
+            <Text style={[styles.tableCell, { width: cellWidth }]}>
+              {totals.reduce((prev, cur) => {
+                return prev + cur;
+              }, 0)}
+            </Text>
+          )}
         </View>
       )}
     </>
@@ -331,7 +347,10 @@ const ReportDoc = ({
   }
   const styles = makeStyles(theme);
   const date = new Date().toUTCString();
-  const tableCellWidth = `${100 / (tableData.columns.length + 1)}%`;
+  const showRowTotal = tableData.columns.length > 2;
+  const tableCellWidth = `${
+    100 / (tableData.columns.length + (showRowTotal ? 1 : 0))
+  }%`;
 
   const tableRows = tableData.rows.slice(1);
   const sortedTableRows =
@@ -476,6 +495,7 @@ const ReportDoc = ({
             columns={tableData.columns}
             cellWidth={tableCellWidth}
             showTotal={tableShowTotal}
+            showRowTotal={showRowTotal}
             t={t}
           />
         </View>


### PR DESCRIPTION
This fixes issue [694](https://github.com/WFP-VAM/prism-app/issues/694).

Add `flood_extent` to layers which can generate flood reports. Also adds a condition for having the extra `Total` column

How to test the feature:

- Generate report for flood extent in Cambodia
- Check report generation works for previously existing cases

Screenshot/video of feature:
![Screenshot from 2023-01-17 12-33-36](https://user-images.githubusercontent.com/80451946/212876381-0e7df5aa-6bbd-4c6e-90a3-a879f5042079.png)

