### PR TITLE
Scrollable popup COUNTRY=myanmar

### DIFF
--- a/frontend/src/components/MapView/MapTooltip/index.tsx
+++ b/frontend/src/components/MapView/MapTooltip/index.tsx
@@ -49,9 +49,9 @@ const styles = () =>
         background: 'black',
         color: 'white',
         padding: '10px 10px 10px',
-        maxWidth: '20em',
+        maxWidth: '30em',
         maxHeight: '12em',
-        overflow: 'scroll',
+        overflow: 'auto',
       },
       '& div.mapboxgl-popup-tip': {
         'border-top-color': 'black',

--- a/frontend/src/components/MapView/MapTooltip/index.tsx
+++ b/frontend/src/components/MapView/MapTooltip/index.tsx
@@ -49,6 +49,9 @@ const styles = () =>
         background: 'black',
         color: 'white',
         padding: '10px 10px 10px',
+        maxWidth: '20em',
+        maxHeight: '12em',
+        overflow: 'scroll',
       },
       '& div.mapboxgl-popup-tip': {
         'border-top-color': 'black',


### PR DESCRIPTION
This fixes issue [enter issue number]. Closes #712 

Popup has maximum width and height. Also set overflow as scroll.

How to test the feature:
- Set up prism instance for myanmar and modify ACLED layer to point to localhost.
- Select conflict fatalities layer.
- Select date 12 of january.

Screenshot/video of feature:

<img width="548" alt="image" src="https://user-images.githubusercontent.com/3285923/214061501-299ccfb5-bb33-40dc-94ac-11cd80a39bf7.png">

