### PR TITLE
circle color based on non-numeric value for PointDataLayer type COUNTRY=myanmar

### DIFF
--- a/frontend/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -166,7 +166,7 @@ function PointDataLayer({ layer, before }: LayersProps) {
       id={layerId}
       data={features}
       circleLayout={circleLayout}
-      circlePaint={circlePaint(layer, layer.dataField)}
+      circlePaint={circlePaint(layer)}
       circleOnClick={onClickFunc}
     />
   );

--- a/frontend/src/components/MapView/Layers/styles.ts
+++ b/frontend/src/components/MapView/Layers/styles.ts
@@ -1,19 +1,40 @@
 import * as MapboxGL from 'mapbox-gl';
-import { CommonLayerProps } from '../../../config/types';
+import {
+  CommonLayerProps,
+  DataFieldType,
+  PointDataLayerProps,
+} from '../../../config/types';
 import { legendToStops } from './layer-utils';
 
 export const circleLayout: MapboxGL.CircleLayout = { visibility: 'visible' };
-export const circlePaint = (
-  { opacity, legend }: CommonLayerProps,
-  property: string = 'data',
-): MapboxGL.CirclePaint => ({
-  'circle-radius': 8,
-  'circle-opacity': opacity || 0.3,
-  'circle-color': {
-    property,
-    stops: legendToStops(legend),
-  },
-});
+
+export const circlePaint = ({
+  opacity,
+  legend,
+  dataField,
+  dataFieldType,
+}: PointDataLayerProps): MapboxGL.CirclePaint => {
+  const circleColor =
+    dataFieldType === DataFieldType.TEXT
+      ? [
+          'match',
+          ['get', dataField],
+          ...legend
+            .map(legendItem => [legendItem.label, legendItem.color])
+            .reduce((acc, item) => [...acc, ...item]),
+          '#CCC',
+        ]
+      : {
+          property: dataField,
+          stops: legendToStops(legend),
+        };
+
+  return {
+    'circle-radius': 8,
+    'circle-opacity': opacity || 0.3,
+    'circle-color': circleColor as MapboxGL.Expression,
+  };
+};
 
 // We use the legend values from the config to define "intervals".
 export const fillPaintData = (

--- a/frontend/src/config/myanmar/layers.json
+++ b/frontend/src/config/myanmar/layers.json
@@ -2287,8 +2287,8 @@
       "limit": 0
     },
     "type": "point_data",
-    "data": "https://prism-api.ovio.org/acled",
-    "date_url": "https://prism-api.ovio.org/acled",
+    "data": "http://localhost/acled",
+    "date_url": "http://localhost/acled",
     "data_field": "fatalities",
     "opacity": 1,
     "legend_text": "Number of fatalities in an armed conflict incident. Provided by ACLED (Armed Conflict Location & Event Data Project): https://acleddata.com/",
@@ -2331,6 +2331,7 @@
     "data": "http://localhost/acled",
     "date_url": "http://localhost/acled",
     "data_field": "event_type",
+    "data_field_type": "text",
     "opacity": 1,
     "legend_text": "Types of armed conflict incident. Provided by ACLED (Armed Conflict Location & Event Data Project): https://acleddata.com/",
     "legend": [

--- a/frontend/src/config/types.ts
+++ b/frontend/src/config/types.ts
@@ -431,6 +431,11 @@ export class StaticRasterLayerProps extends CommonLayerProps {
   maxZoom: number;
 }
 
+export enum DataFieldType {
+  NUMBER = 'number',
+  TEXT = 'text',
+}
+
 export class AdminLevelDataLayerProps extends CommonLayerProps {
   type: 'admin_level_data';
   path: string;
@@ -554,6 +559,9 @@ export class PointDataLayerProps extends CommonLayerProps {
 
   @optional
   authRequired: boolean = false;
+
+  @optional
+  dataFieldType?: DataFieldType = DataFieldType.NUMBER;
 }
 
 export type RequiredKeys<T> = {


### PR DESCRIPTION
This fixes issue [enter issue number]. Closes #713. 

This Pull request includes a new type for the PointDataLayer type **DataFieldType** which is used to check the type of the data present within the dataset. Then, the mapbox layer will be colored based on the legend and data field type used. The default is set to NUMBER

How to test the feature:
- Using deployment myanmar.
- Select the **Types of armed conflict incident** layer.

Screenshot/video of feature:
<img width="1301" alt="image" src="https://user-images.githubusercontent.com/3285923/215440956-85aab262-95b6-4eeb-90ed-2bd94a9534b8.png">


