### PR TITLE
Fix CSV shifted columns when data don't exist or they have null values

### DIFF
--- a/frontend/src/components/Common/BoundaryDropdown/index.tsx
+++ b/frontend/src/components/Common/BoundaryDropdown/index.tsx
@@ -92,6 +92,7 @@ const BoundaryDropdown = ({
 
     return relationsToRender.map(item => (
       <MenuItem
+        key={item.name}
         className={setMenuItemStyle(item.level, levels, styles)}
         value={item.bbox.join(',')}
       >

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
@@ -80,6 +80,7 @@ function TimelineItems({
         ) {
           return (
             <TooltipItem
+              key={selectedLayerTitle}
               layerTitle={t(selectedLayerTitle)}
               color={DATE_ITEM_STYLING[layerIndex + 1].color}
             />
@@ -101,7 +102,7 @@ function TimelineItems({
       {dateRange.map((date, index) => (
         <Tooltip
           title={<div>{getTooltipTitle(date)}</div>}
-          key={date.label}
+          key={`Root-${date.label}-${date.value}`}
           TransitionComponent={Fade}
           TransitionProps={{ timeout: 0 }}
           placement="top"
@@ -124,15 +125,18 @@ function TimelineItems({
               <div className={classes.dayItem} />
             )}
             {[formattedIntersectionDates, ...formattedSelectedLayerDates].map(
-              (layerDates, layerIndex) =>
-                layerDates.includes(formatDate(date.value)) && (
-                  <div
-                    key={date.value}
-                    className={DATE_ITEM_STYLING[layerIndex].class}
-                    role="presentation"
-                    onClick={() => click(index)}
-                  />
-                ),
+              (layerDates, layerIndex) => {
+                return (
+                  layerDates.includes(formatDate(date.value)) && (
+                    <div
+                      key={`Nested-${layerDates[layerIndex]}`}
+                      className={DATE_ITEM_STYLING[layerIndex].class}
+                      role="presentation"
+                      onClick={() => click(index)}
+                    />
+                  )
+                );
+              },
             )}
           </Grid>
         </Tooltip>

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -222,6 +222,7 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
       key.endsWith('_avg')
         ? `${snakeCase(chartName)}_avg`
         : snakeCase(chartName);
+
     const columnsNamesPerChart = Object.entries(dataForCsv.current).map(
       ([key, value]) => {
         const first = value[0];
@@ -231,6 +232,7 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
         return Object.fromEntries(mapped.map(x => [x, x]));
       },
     );
+
     const columnsNames = columnsNamesPerChart.reduce(
       (prev, curr) => ({ ...prev, ...curr }),
       { [dateColumn]: dateColumn },
@@ -252,6 +254,7 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
     const objectsArray = Object.entries(grouped).map(([, value]) => {
       return value.reduce((prev, curr) => ({ ...prev, ...curr }), {});
     });
+
     downloadToFile(
       {
         content: castObjectsArrayToCsv(objectsArray, columnsNames, ','),
@@ -448,7 +451,6 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
         onClick={downloadCsv}
         disabled={
           !(
-            adminProperties &&
             selectedDate &&
             tabIndex === tabValue &&
             selectedLayerTitles.length >= 1

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -147,16 +147,16 @@ function LayerDownloadOptions({
         onClose={handleDownloadMenuClose}
       >
         {layer.type === 'admin_level_data' && [
-          <MenuItem onClick={handleDownloadCsv}>
+          <MenuItem key="download-as-csv" onClick={handleDownloadCsv}>
             {t('Download as CSV')}
           </MenuItem>,
-          <MenuItem onClick={handleDownloadGeoJson}>
+          <MenuItem key="download-as-geojson" onClick={handleDownloadGeoJson}>
             {t('Download as GeoJSON')}
           </MenuItem>,
         ]}
         {layer.type === 'wms' &&
           layer.baseUrl.includes('api.earthobservation.vam.wfp.org/ows') && (
-            <MenuItem onClick={handleDownloadGeoTiff}>
+            <MenuItem key="download-as-geotiff" onClick={handleDownloadGeoTiff}>
               {t('Download as GeoTIFF')}
             </MenuItem>
           )}

--- a/frontend/src/utils/csv-utils.ts
+++ b/frontend/src/utils/csv-utils.ts
@@ -1,3 +1,27 @@
+export function fillCSVMissingKeys<T extends { [key: string]: any }>(
+  objectsArray: T[],
+  columnsNames: Partial<Record<keyof T, string>>,
+): { [key: string]: any }[] {
+  // we load a blueprint as initial data in the objects array that we will create the CSV
+  // in order to interpret the missing or null values
+  const initialObjectsArrayBlueprintData = Object.keys(columnsNames).reduce(
+    (acc: { [key: string]: string }, key) => {
+      // eslint-disable-next-line fp/no-mutation
+      acc[key] = '';
+      return acc;
+    },
+    {},
+  );
+  // The actual objects Array to be interpreted in the CSV file that will use the blueprint as
+  // initial data
+  return objectsArray.map(obj => {
+    return {
+      ...initialObjectsArrayBlueprintData,
+      ...obj,
+    };
+  });
+}
+
 export function castObjectsArrayToCsv<T extends { [key: string]: any }>(
   objectsArray: T[],
   columnsNames: Partial<Record<keyof T, string>>,
@@ -7,10 +31,13 @@ export function castObjectsArrayToCsv<T extends { [key: string]: any }>(
 
   const columns = objectKeys.map(key => columnsNames[key] ?? key);
 
+  // If we have missing keys in some data we fill them with empty strings
+  const actualObjectsArray = fillCSVMissingKeys(objectsArray, columnsNames);
+
   return [
     ...(sep === ',' ? [] : [`sep=${sep}`]),
     columns.join(sep),
-    ...objectsArray.map(obj => {
+    ...actualObjectsArray.map(obj => {
       return Object.values(obj).join(sep);
     }),
   ].join('\n');


### PR DESCRIPTION
This fixes issue [#744].

This is a more generalized solution in order to cover all the possible CSV reports if the have missing data

How to test the feature:

This is tested for country=cambodia but it covers missing data in CSV's.

From the charts sidePanel menu select the admin1 `Kampong Cham` and then select the charts `10-day-raifall estimate (mm)`, `1-month railfall aggregate`, `3-month rainfall aggregate (mm)`, `10-day NDVI (MODIS)`, `10-day NDVI anomally (MODIS)`. We will observe that in 1st of March NDVI charts have no data and that was miscalculated in the exported CSV. We had shifted columns and we actually had data in cells that they should be blank.

Screenshot/video of feature:
![Screenshot from 2023-03-15 12-03-50](https://user-images.githubusercontent.com/62129256/225275994-8c4eceb6-f148-4ba8-b79c-25d7fae289cd.png)

Now the data are correctly displayed in the correct column cells

![Screenshot from 2023-03-15 12-05-17](https://user-images.githubusercontent.com/62129256/225276359-9eabd723-0c91-4fb4-a46d-32b947479490.png)

