### PR TITLE
fix: Timezone bug with timeline item positioning

### DIFF
--- a/frontend/src/components/MapView/DateSelector/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/index.tsx
@@ -63,6 +63,12 @@ const Input = forwardRef(
   },
 );
 
+function addUserOffset(dates: number[]) {
+  return dates.map(d => {
+    return d + USER_DATE_OFFSET;
+  });
+}
+
 function DateSelector({
   availableDates = [],
   selectedLayers = [],
@@ -171,9 +177,7 @@ function DateSelector({
   }
 
   function setDatePosition(date: number | undefined, increment: number) {
-    const dates = availableDates.map(d => {
-      return d + USER_DATE_OFFSET;
-    });
+    const dates = addUserOffset(availableDates);
     const selectedIndex = findDateIndex(dates, date);
     if (dates[selectedIndex + increment]) {
       updateStartDate(new Date(dates[selectedIndex + increment]));
@@ -198,9 +202,7 @@ function DateSelector({
 
   // Click on available date to move the pointer
   const clickDate = (index: number) => {
-    const dates = availableDates.map(date => {
-      return date + USER_DATE_OFFSET;
-    });
+    const dates = addUserOffset(availableDates);
     const selectedIndex = findDateIndex(dates, dateRange[index].value);
     if (selectedIndex >= 0 && dates[selectedIndex] !== stateStartDate) {
       setPointerPosition({ x: index * TIMELINE_ITEM_WIDTH, y: 0 });
@@ -219,9 +221,7 @@ function DateSelector({
     if (exactX >= dateRange.length) {
       return;
     }
-    const dates = availableDates.map(date => {
-      return date + USER_DATE_OFFSET;
-    });
+    const dates = addUserOffset(availableDates);
     const selectedIndex = findDateIndex(dates, dateRange[exactX].value);
     if (selectedIndex >= 0 && dates[selectedIndex] !== stateStartDate) {
       setPointerPosition({ x: exactX * TIMELINE_ITEM_WIDTH, y: position.y });

--- a/frontend/src/components/MapView/DateSelector/utils.ts
+++ b/frontend/src/components/MapView/DateSelector/utils.ts
@@ -151,5 +151,5 @@ export function findDateIndex(
 }
 
 export function formatDate(date: number): string {
-  return moment(date + USER_DATE_OFFSET).format(MONTH_FIRST_DATE_FORMAT);
+  return moment(date).format(MONTH_FIRST_DATE_FORMAT);
 }


### PR DESCRIPTION
This fixes issue #741 

How to test the feature:

- select a layer with dates
- change the timezone in chrome - https://www.browserstack.com/guide/change-time-zone-in-chrome-for-testing
- reload the page and check that the ticks appear properly

<img width="1330" alt="Screenshot 2023-03-18 at 7 07 09 PM" src="https://user-images.githubusercontent.com/16843267/226126040-e65dd05e-f25d-498c-b1d6-18d7db0cac87.png">

