### PR TITLE
Add national level charts; COUNTRY=cambodia

### DIFF
--- a/frontend/src/components/DataViewer/index.tsx
+++ b/frontend/src/components/DataViewer/index.tsx
@@ -27,6 +27,7 @@ import { dateRangeSelector } from '../../context/mapStateSlice/selectors';
 import Chart from '../DataDrawer/Chart';
 import { ChartConfig } from '../../config/types';
 import { useSafeTranslation } from '../../i18n';
+import { appConfig } from '../../config';
 
 const isAdminBoundary = (
   params: AdminBoundaryParams | EWSParams,
@@ -51,23 +52,28 @@ function DataViewer({ classes }: DatasetProps) {
       return;
     }
 
-    const requestParams: DatasetRequestParams = isAdminBoundary(params)
-      ? {
-          id: params.id,
-          boundaryProps: params.boundaryProps,
-          url: params.url,
-          serverLayerName: params.serverLayerName,
-          datasetFields: params.datasetFields,
-          selectedDate,
-        }
-      : {
-          date: selectedDate,
-          externalId: params.externalId,
-          triggerLevels: params.triggerLevels,
-          baseUrl: params.baseUrl,
-        };
-
-    dispatch(loadDataset(requestParams));
+    if (isAdminBoundary(params)) {
+      const { code: adminCode, level } = params.boundaryProps[params.id];
+      const requestParams: DatasetRequestParams = {
+        id: params.id,
+        level,
+        adminCode: adminCode || appConfig.countryAdmin0Id,
+        boundaryProps: params.boundaryProps,
+        url: params.url,
+        serverLayerName: params.serverLayerName,
+        datasetFields: params.datasetFields,
+        selectedDate,
+      };
+      dispatch(loadDataset(requestParams));
+    } else {
+      const requestParams: DatasetRequestParams = {
+        date: selectedDate,
+        externalId: params.externalId,
+        triggerLevels: params.triggerLevels,
+        baseUrl: params.baseUrl,
+      };
+      dispatch(loadDataset(requestParams));
+    }
   }, [params, dispatch, selectedDate]);
 
   if (!params) {

--- a/frontend/src/components/MapView/DateSelector/utils.ts
+++ b/frontend/src/components/MapView/DateSelector/utils.ts
@@ -7,21 +7,6 @@ export const TIMELINE_ITEM_WIDTH = 10;
 // displaying UTC dates.
 export const USER_DATE_OFFSET = new Date().getTimezoneOffset() * 60000;
 
-export const months = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sept',
-  'Oct',
-  'Nov',
-  'Dec',
-];
-
 /**
  * Return the closest date from a given list of available dates
  * @param date
@@ -57,21 +42,6 @@ export function findClosestDate(
 }
 
 /**
- * Return the start and end date of a month (utc format)
- * @param month
- * @param year
- * @return { startDate, endDate }
- */
-export function getMonthStartAndEnd(month: number, year: number) {
-  const monthDate = moment({ year, month });
-
-  const startDate = monthDate.startOf('month').valueOf();
-  const endDate = monthDate.endOf('month').valueOf();
-
-  return { startDate, endDate };
-}
-
-/**
  * Return the list of available dates the month
  * @param month
  * @param year
@@ -85,21 +55,6 @@ export function findAvailableDayInMonth(
 ) {
   const reference = new Date(year, month);
   return availableDates.filter(d => moment(d).isSame(reference, 'month'));
-}
-
-/**
- * Return true if there is an available date in the month
- * @param month
- * @param year
- * @param availableDates in millisecond format
- * @return
- */
-export function isAvailableMonth(
-  month: number,
-  year: number,
-  availableDates: ReturnType<Date['getTime']>[],
-) {
-  return findAvailableDayInMonth(month, year, availableDates).length > 0;
 }
 
 /**

--- a/frontend/src/components/MapView/DateSelector/utils.ts
+++ b/frontend/src/components/MapView/DateSelector/utils.ts
@@ -42,22 +42,6 @@ export function findClosestDate(
 }
 
 /**
- * Return the list of available dates the month
- * @param month
- * @param year
- * @param availableDates in millisecond format
- * @return a list of available dates the month
- */
-export function findAvailableDayInMonth(
-  month: number,
-  year: number,
-  availableDates: ReturnType<Date['getTime']>[],
-) {
-  const reference = new Date(year, month);
-  return availableDates.filter(d => moment(d).isSame(reference, 'month'));
-}
-
-/**
  * Binary search to return index of available dates that matched
  * @param availableDates in millisecond format, should be sorted
  * @param date in millisecond format

--- a/frontend/src/components/MapView/Layers/BoundaryDropdown.tsx
+++ b/frontend/src/components/MapView/Layers/BoundaryDropdown.tsx
@@ -360,19 +360,4 @@ function BoundaryDropdown({
   );
 }
 
-export const ButtonStyleBoundaryDropdown = withStyles(() => ({
-  root: {
-    '& label': {
-      textTransform: 'uppercase',
-      letterSpacing: '3px',
-      fontSize: '11px',
-      position: 'absolute',
-      top: '-13px',
-    },
-    '& svg': { color: 'white', fontSize: '1.25rem' },
-    '& .MuiInput-root': { margin: 0 },
-    '& .MuiInputLabel-shrink': { display: 'none' },
-  },
-}))(SimpleBoundaryDropdown);
-
 export default BoundaryDropdown;

--- a/frontend/src/components/MapView/Layers/BoundaryDropdown.tsx
+++ b/frontend/src/components/MapView/Layers/BoundaryDropdown.tsx
@@ -13,7 +13,6 @@ import {
   Theme,
   Typography,
   useMediaQuery,
-  withStyles,
 } from '@material-ui/core';
 import { last, sortBy } from 'lodash';
 import React, { forwardRef, ReactNode, useEffect, useState } from 'react';

--- a/frontend/src/components/MapView/Layers/raster-utils.ts
+++ b/frontend/src/components/MapView/Layers/raster-utils.ts
@@ -4,7 +4,7 @@ import { Feature, MultiPolygon, point } from '@turf/helpers';
 import { buffer } from 'd3-fetch';
 import * as GeoTIFF from 'geotiff';
 import { Map as MapBoxMap } from 'mapbox-gl';
-import { createGetCoverageUrl, createGetMapUrl } from 'prism-common';
+import { createGetMapUrl } from 'prism-common';
 import { Dispatch } from 'redux';
 import { addNotification } from '../../../context/notificationStateSlice';
 import { BACKEND_URL } from '../../../utils/constants';
@@ -62,16 +62,6 @@ export type GeoTiffImage = {
     fillValue?: number | number[];
   }) => Promise<Rasters>;
 };
-
-function numberOfTiles(
-  min: number,
-  max: number,
-  resolution: number,
-  pixelsPerTile: number,
-) {
-  const range = max - min;
-  return Math.ceil((range * resolution) / pixelsPerTile);
-}
 
 export function getWMSUrl(
   baseUrl: string,

--- a/frontend/src/components/MapView/Layers/raster-utils.ts
+++ b/frontend/src/components/MapView/Layers/raster-utils.ts
@@ -90,62 +90,6 @@ export function getWMSUrl(
   });
 }
 
-/**
- * Generates an array of WCS URLs to request GeoTiff tiles based on the given extent and pixel resolution.
- *
- * @param baseUrl Base resource URL
- * @param layerName ID of coverage/layer to get on the server
- * @param date
- * @param extent Full extent of the area to get coverage images for
- * @param resolution pixels per degree lat/long
- * @param pixelsPerTile
- */
-export function WCSTileUrls(
-  baseUrl: string,
-  layerName: string,
-  date: string,
-  extent: Extent,
-  resolution = 256,
-  pixelsPerTile = 512,
-): string[] {
-  // Set up tile grid in x/y.
-  const [minX, minY, maxX, maxY] = extent;
-  if (minX > maxX || minY > maxY) {
-    throw new Error(
-      `Could not generate tile grid for ${baseUrl}/${layerName}: the extent ${extent} seems malformed or else may contain "wrapping" which is not implemented in the function 'WCSTileUrls'`,
-    );
-  }
-
-  const degPerTile = pixelsPerTile / resolution;
-
-  const xTiles = numberOfTiles(minX, maxX, resolution, pixelsPerTile);
-  const yTiles = numberOfTiles(minY, maxY, resolution, pixelsPerTile);
-
-  return [...Array(xTiles)]
-    .map((_1, xIdx) => {
-      const x = [
-        xIdx * degPerTile + minX,
-        (xIdx + 1) * degPerTile + minX,
-      ] as const;
-      return [...Array(yTiles)].map((_2, yIdx) => {
-        const y = [
-          yIdx * degPerTile + minY,
-          (yIdx + 1) * degPerTile + minY,
-        ] as const;
-        return createGetCoverageUrl({
-          bbox: [x[0], y[0], x[1], y[1]],
-          date,
-          height: pixelsPerTile,
-          layerId: layerName,
-          width: pixelsPerTile,
-          url: baseUrl,
-          version: '1.0.0',
-        });
-      });
-    })
-    .flat();
-}
-
 export function getTransform(geoTiffImage: GeoTiffImage): TransformMatrix {
   const tiepoint = geoTiffImage.getTiePoints()[0];
   const pixelScale = geoTiffImage.getFileDirectory().ModelPixelScale;
@@ -213,22 +157,6 @@ export function featureIntersectsImage(
     (xWithinImage(featureExtent[0]) || xWithinImage(featureExtent[2])) &&
     (yWithinImage(featureExtent[1]) || yWithinImage(featureExtent[2]))
   );
-}
-
-export function filterPointsByFeature(
-  rasterPoints: { x: number; y: number; value: number }[],
-  feature: GeoJsonBoundary,
-) {
-  const [minX, minY, maxX, maxY] = bbox(feature);
-  return rasterPoints.filter(({ x, y }) => {
-    return (
-      x > minX &&
-      x < maxX &&
-      y > minY &&
-      y < maxY &&
-      booleanPointInPolygon(point([x, y]), feature)
-    );
-  });
 }
 
 export function pixelsInFeature(

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
@@ -7,7 +7,6 @@ import {
 import { GeoJsonProperties } from 'geojson';
 import { omit } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
-import { appConfig } from '../../../../../config';
 import { ChartConfig, WMSLayerProps } from '../../../../../config/types';
 import {
   CHART_DATA_PREFIXES,

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
@@ -7,6 +7,7 @@ import {
 import { GeoJsonProperties } from 'geojson';
 import { omit } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
+import { appConfig } from '../../../../../config';
 import { ChartConfig, WMSLayerProps } from '../../../../../config/types';
 import {
   CHART_DATA_PREFIXES,
@@ -30,6 +31,8 @@ function ChartSection({
   const [chartDataset, setChartDataset] = useState<undefined | TableData>();
   const { levels } = chartLayer.chartData!;
 
+  const levelsDict = Object.fromEntries(levels.map(x => [x.level, x.id]));
+
   const params = useMemo(
     () =>
       getChartAdminBoundaryParams(
@@ -39,9 +42,10 @@ function ChartSection({
     [chartLayer, adminProperties],
   );
 
+  const adminId = levelsDict[adminLevel.toString()];
   useEffect(() => {
     const requestParams: DatasetRequestParams = {
-      id: levels[adminLevel - 1].id,
+      id: adminId,
       boundaryProps: params.boundaryProps,
       url: params.url,
       serverLayerName: params.serverLayerName,
@@ -51,6 +55,9 @@ function ChartSection({
 
     const getData = async () => {
       const results = await loadAdminBoundaryDataset(requestParams);
+      if (!results) {
+        return;
+      }
       const keyMap = Object.fromEntries(
         Object.entries(results.rows[0]).map(([key, value]) => {
           const newKey = requestParams.datasetFields.find(
@@ -141,7 +148,7 @@ const styles = () =>
 export interface ChartSectionProps extends WithStyles<typeof styles> {
   chartLayer: WMSLayerProps;
   adminProperties: GeoJsonProperties;
-  adminLevel: 1 | 2;
+  adminLevel: 0 | 1 | 2;
   date: number;
   dataForCsv: React.MutableRefObject<any>;
 }

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
@@ -7,6 +7,7 @@ import {
 import { GeoJsonProperties } from 'geojson';
 import { omit } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
+import { appConfig } from '../../../../../config';
 import { ChartConfig, WMSLayerProps } from '../../../../../config/types';
 import {
   CHART_DATA_PREFIXES,
@@ -41,10 +42,13 @@ function ChartSection({
     [chartLayer, adminProperties],
   );
 
-  const adminId = levelsDict[adminLevel.toString()];
+  const adminKey = levelsDict[adminLevel.toString()];
+  const { code: adminCode, level } = params.boundaryProps[adminKey];
   useEffect(() => {
     const requestParams: DatasetRequestParams = {
-      id: adminId,
+      id: adminKey,
+      level,
+      adminCode: adminCode || appConfig.countryAdmin0Id,
       boundaryProps: params.boundaryProps,
       url: params.url,
       serverLayerName: params.serverLayerName,

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -261,6 +261,13 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
     [data, i18nLocale],
   );
 
+  const generateCSVFilename = () => {
+    return [appConfig.country, admin1Title, admin2Title, ...selectedLayerTitles]
+      .filter(x => !!x)
+      .map(snakeCase)
+      .join('_');
+  };
+
   const onChangeAdmin1 = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!event.target.value) {
       setAdmin1Title('');
@@ -507,10 +514,7 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
       </FormControl>
       <Button
         className={classes.downloadButton}
-        onClick={downloadCsv(
-          dataForCsv,
-          `${admin1Title}_${selectedLayerTitles.map(snakeCase).join('_')}`,
-        )}
+        onClick={downloadCsv(dataForCsv, generateCSVFilename())}
         disabled={
           !(
             adminProperties &&

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -52,6 +52,7 @@ function getProperties(
   layerData: LayerData<BoundaryLayerProps>['data'],
   id?: string,
 ) {
+  // Return any properties, used for national level data.
   if (id === undefined) {
     return layerData.features[0].properties;
   }

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -241,20 +241,15 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
   const classes = useStyles();
   const [admin1Title, setAdmin1Title] = useState('');
   const [admin2Title, setAdmin2Title] = useState('');
-
   const [adminLevel, setAdminLevel] = useState<0 | 1 | 2>(
     countryAdmin0Id ? 0 : 1,
   );
-  const adminPropertiesInitialization =
-    data && countryAdmin0Id ? getProperties(data) : undefined;
 
   const [selectedLayerTitles, setSelectedLayerTitles] = useState<string[]>([]);
   const [selectedDate, setSelectedDate] = useState<number | null>(
     new Date().getTime(),
   );
-  const [adminProperties, setAdminProperties] = useState<
-    GeoJsonProperties | undefined
-  >(adminPropertiesInitialization);
+  const [adminProperties, setAdminProperties] = useState<GeoJsonProperties>();
   const dataForCsv = useRef<{ [key: string]: any[] }>({});
 
   const { t, i18n: i18nLocale } = useSafeTranslation();
@@ -314,11 +309,13 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
   };
 
   useEffect(() => {
-    if (
-      (adminProperties || countryAdmin0Id) &&
-      selectedDate &&
-      selectedLayerTitles.length >= 1
-    ) {
+    if (!adminProperties && countryAdmin0Id && data) {
+      setAdminProperties(getProperties(data));
+    }
+  }, [adminProperties, countryAdmin0Id, data]);
+
+  useEffect(() => {
+    if (adminProperties && selectedDate && selectedLayerTitles.length >= 1) {
       setPanelSize(PanelSize.xlarge);
     } else {
       setPanelSize(PanelSize.medium);
@@ -333,7 +330,7 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
 
   useEffect(() => {
     if (
-      (adminProperties || countryAdmin0Id) &&
+      adminProperties &&
       selectedDate &&
       tabIndex === tabValue &&
       selectedLayerTitles.length >= 1
@@ -354,7 +351,7 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
                 >
                   <ChartSection
                     chartLayer={layer}
-                    adminProperties={adminProperties || {}}
+                    adminProperties={adminProperties}
                     adminLevel={adminLevel}
                     date={selectedDate}
                     dataForCsv={dataForCsv}
@@ -366,28 +363,26 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
             // chart size is not responsive once it is mounted
             // seems to be possible in the newer chart.js versions
             // here we mount a new component if one chart
-            (adminProperties || countryAdmin0Id) &&
-              selectedDate &&
-              selectedLayerTitles.length === 1 && (
-                <Box
-                  style={{
-                    minHeight: '50vh',
-                    width: '100%',
-                  }}
-                >
-                  <ChartSection
-                    chartLayer={
-                      chartLayers.filter(layer =>
-                        selectedLayerTitles.includes(layer.title),
-                      )[0]
-                    }
-                    adminProperties={adminProperties || {}}
-                    adminLevel={adminLevel}
-                    date={selectedDate}
-                    dataForCsv={dataForCsv}
-                  />
-                </Box>
-              )
+            adminProperties && selectedDate && selectedLayerTitles.length === 1 && (
+              <Box
+                style={{
+                  minHeight: '50vh',
+                  width: '100%',
+                }}
+              >
+                <ChartSection
+                  chartLayer={
+                    chartLayers.filter(layer =>
+                      selectedLayerTitles.includes(layer.title),
+                    )[0]
+                  }
+                  adminProperties={adminProperties || {}}
+                  adminLevel={adminLevel}
+                  date={selectedDate}
+                  dataForCsv={dataForCsv}
+                />
+              </Box>
+            )
           }
         </Box>,
       );

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -132,7 +132,7 @@ const useStyles = makeStyles(() =>
       marginTop: 0,
       marginBottom: 'auto',
     },
-    removeAdmin2: {
+    removeAdmin: {
       fontWeight: 'bold',
     },
     downloadButton: {
@@ -419,13 +419,18 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
         classes={{ root: classes.selectRoot }}
         id="outlined-admin-1"
         select
-        label={t('Select Admin 1')}
+        label={countryAdmin0Id ? t('National Level') : t('Select Admin 1')}
         value={admin1Title}
         onChange={onChangeAdmin1}
         variant="outlined"
       >
-        <MenuItem key="empty-1">
-          <Box className={classes.removeAdmin2}> {t('Remove Admin 1')}</Box>
+        <MenuItem key="national-1" divider>
+          <Box className={classes.removeAdmin}> {t('National Level')}</Box>
+        </MenuItem>
+        <MenuItem style={{ pointerEvents: 'none' }} key="national-1">
+          <Box style={{ fontStyle: 'italic', fontWeight: 'bold' }}>
+            {t('Admin 1')}
+          </Box>
         </MenuItem>
         {categories.map(option => (
           <MenuItem key={option.title} value={option.title}>
@@ -443,8 +448,8 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
           onChange={onChangeAdmin2}
           variant="outlined"
         >
-          <MenuItem key="empty-2">
-            <Box className={classes.removeAdmin2}> {t('Remove Admin 2')}</Box>
+          <MenuItem key="empty-2" divider>
+            <Box className={classes.removeAdmin}> {t('Remove Admin 2')}</Box>
           </MenuItem>
           {categories
             .filter(elem => elem.title === admin1Title)[0]

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -443,7 +443,7 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
           onChange={onChangeAdmin2}
           variant="outlined"
         >
-          <MenuItem key="empty=2">
+          <MenuItem key="empty-2">
             <Box className={classes.removeAdmin2}> {t('Remove Admin 2')}</Box>
           </MenuItem>
           {categories

--- a/frontend/src/components/NavBar/PrintImage/index.tsx
+++ b/frontend/src/components/NavBar/PrintImage/index.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   createStyles,
   Typography,
-  WithStyles,
   withStyles,
 } from '@material-ui/core';
 import { useSelector } from 'react-redux';

--- a/frontend/src/components/NavBar/PrintImage/index.tsx
+++ b/frontend/src/components/NavBar/PrintImage/index.tsx
@@ -59,6 +59,4 @@ function PrintImage() {
 
 const styles = () => createStyles({});
 
-export interface DownloadProps extends WithStyles<typeof styles> {}
-
 export default withStyles(styles)(PrintImage);

--- a/frontend/src/config/cambodia/layers.json
+++ b/frontend/src/config/cambodia/layers.json
@@ -234,6 +234,11 @@
       ],
       "levels": [
         {
+          "level": "0",
+          "id": "dataviz_adm0_id",
+          "name": "Adm0_Name"
+        },
+        {
           "level": "1",
           "id": "dataviz_adm1_id",
           "name": "Adm1_Name"
@@ -253,6 +258,11 @@
         { "key": "rfh_avg", "label": "Average", "color": "#bdf2e6" }
       ],
       "levels": [
+        {
+          "level": "0",
+          "id": "dataviz_adm0_id",
+          "name": "Adm0_Name"
+        },
         {
           "level": "1",
           "id": "dataviz_adm1_id",
@@ -309,6 +319,11 @@
       ],
       "levels": [
         {
+          "level": "0",
+          "id": "dataviz_adm0_id",
+          "name": "Adm0_Name"
+        },
+        {
           "level": "1",
           "id": "dataviz_adm1_id",
           "name": "Adm1_Name"
@@ -361,6 +376,11 @@
         }
       ],
       "levels": [
+        {
+          "level": "0",
+          "id": "dataviz_adm0_id",
+          "name": "Adm0_Name"
+        },
         {
           "level": "1",
           "id": "dataviz_adm1_id",
@@ -415,6 +435,11 @@
         }
       ],
       "levels": [
+        {
+          "level": "0",
+          "id": "dataviz_adm0_id",
+          "name": "Adm0_Name"
+        },
         {
           "level": "1",
           "id": "dataviz_adm1_id",
@@ -548,6 +573,11 @@
       ],
       "levels": [
         {
+          "level": "0",
+          "id": "dataviz_adm0_id",
+          "name": "Adm0_Name"
+        },
+        {
           "level": "1",
           "id": "dataviz_adm1_id",
           "name": "Adm1_Name"
@@ -596,6 +626,11 @@
         { "key": "r3h_avg", "label": "Average", "color": "#bdf2e6" }
       ],
       "levels": [
+        {
+          "level": "0",
+          "id": "dataviz_adm0_id",
+          "name": "Adm0_Name"
+        },
         {
           "level": "1",
           "id": "dataviz_adm1_id",
@@ -1248,6 +1283,11 @@
       ],
       "levels": [
         {
+          "level": "0",
+          "id": "dataviz_adm0_id",
+          "name": "Adm0_Name"
+        },
+        {
           "level": "1",
           "id": "dataviz_adm1_id",
           "name": "Adm1_Name"
@@ -1306,6 +1346,11 @@
         }
       ],
       "levels": [
+        {
+          "level": "0",
+          "id": "dataviz_adm0_id",
+          "name": "Adm0_Name"
+        },
         {
           "level": "1",
           "id": "dataviz_adm1_id",
@@ -1663,7 +1708,7 @@
       "datetime_field": "Date_report",
       "measure_field": "NumPeoAff",
       "kobo_url": "https://kobo.humanitarianresponse.info/api/v2/assets/",
-      "filters": {"status": "Approved"}
+      "filters": { "status": "Approved" }
     },
     "opacity": 0.9,
     "feature_info_props": {
@@ -1723,7 +1768,7 @@
       "datetime_field": "Date_Dis",
       "measure_field": "NumPeoAff",
       "kobo_url": "https://kobo.humanitarianresponse.info/api/v2/assets/",
-      "filters": {"status": "Approved"}
+      "filters": { "status": "Approved" }
     },
     "opacity": 0.9,
     "feature_info_props": {
@@ -1793,7 +1838,7 @@
       "datetime_field": "Date_Dis",
       "measure_field": "DisTyp",
       "kobo_url": "https://kobo.humanitarianresponse.info/api/v2/assets/",
-      "filters": {"status": "Approved"}
+      "filters": { "status": "Approved" }
     },
     "opacity": 0.9,
     "feature_info_props": {
@@ -1821,15 +1866,15 @@
         "type": "text",
         "dataTitle": "Number of people affected"
       },
-        "NumVillAff": {
-          "type": "text",
-          "dataTitle": "Number of villages affected"
-        },
-        "status": {
-          "type": "text",
-          "dataTitle": "Form status"
-        }
+      "NumVillAff": {
+        "type": "text",
+        "dataTitle": "Number of villages affected"
       },
+      "status": {
+        "type": "text",
+        "dataTitle": "Form status"
+      }
+    },
     "legend_text": "Type of disaster",
     "legend": [
       {

--- a/frontend/src/config/cambodia/layers.json
+++ b/frontend/src/config/cambodia/layers.json
@@ -234,11 +234,6 @@
       ],
       "levels": [
         {
-          "level": "0",
-          "id": "dataviz_adm0_id",
-          "name": "Adm0_Name"
-        },
-        {
           "level": "1",
           "id": "dataviz_adm1_id",
           "name": "Adm1_Name"
@@ -294,11 +289,6 @@
       ],
       "levels": [
         {
-          "level": "0",
-          "id": "dataviz_adm0_id",
-          "name": "Adm0_Name"
-        },
-        {
           "level": "1",
           "id": "dataviz_adm1_id",
           "name": "Adm1_Name"
@@ -351,11 +341,6 @@
         }
       ],
       "levels": [
-        {
-          "level": "0",
-          "id": "dataviz_adm0_id",
-          "name": "Adm0_Name"
-        },
         {
           "level": "1",
           "id": "dataviz_adm1_id",
@@ -410,11 +395,6 @@
         }
       ],
       "levels": [
-        {
-          "level": "0",
-          "id": "dataviz_adm0_id",
-          "name": "Adm0_Name"
-        },
         {
           "level": "1",
           "id": "dataviz_adm1_id",
@@ -548,11 +528,6 @@
       ],
       "levels": [
         {
-          "level": "0",
-          "id": "dataviz_adm0_id",
-          "name": "Adm0_Name"
-        },
-        {
           "level": "1",
           "id": "dataviz_adm1_id",
           "name": "Adm1_Name"
@@ -601,11 +576,6 @@
         { "key": "r3h_avg", "label": "Average", "color": "#bdf2e6" }
       ],
       "levels": [
-        {
-          "level": "0",
-          "id": "dataviz_adm0_id",
-          "name": "Adm0_Name"
-        },
         {
           "level": "1",
           "id": "dataviz_adm1_id",
@@ -1258,11 +1228,6 @@
       ],
       "levels": [
         {
-          "level": "0",
-          "id": "dataviz_adm0_id",
-          "name": "Adm0_Name"
-        },
-        {
           "level": "1",
           "id": "dataviz_adm1_id",
           "name": "Adm1_Name"
@@ -1321,11 +1286,6 @@
         }
       ],
       "levels": [
-        {
-          "level": "0",
-          "id": "dataviz_adm0_id",
-          "name": "Adm0_Name"
-        },
         {
           "level": "1",
           "id": "dataviz_adm1_id",

--- a/frontend/src/config/cambodia/prism.json
+++ b/frontend/src/config/cambodia/prism.json
@@ -1,5 +1,6 @@
 {
   "country": "Cambodia",
+  "countryAdmin0Id": 44,
   "alertFormActive": false,
   "aboutPath": "data/cambodia/about.md",
   "enableNavigationDropdown": true,

--- a/frontend/src/config/mozambique/prism.json
+++ b/frontend/src/config/mozambique/prism.json
@@ -1,5 +1,6 @@
 {
   "country": "Mozambique",
+  "countryAdmin0Id": 170,
   "alertFormActive": false,
   "hidePanel": false,
   "enableNavigationDropdown": true,

--- a/frontend/src/config/types.ts
+++ b/frontend/src/config/types.ts
@@ -200,15 +200,6 @@ export enum RasterType {
 
 export type HazardDataType = GeometryType | RasterType;
 
-// not including standard deviation and sum quite yet
-// because we won't be able to re-use the WMS legend
-export enum DisplayZonalStats {
-  Max = 'Max',
-  Mean = 'Mean',
-  Median = 'Median',
-  Min = 'Min',
-}
-
 export type ZonalConfig = {
   // we're keeping snakecase here because that is what zonal uses
   // eslint-disable-next-line camelcase

--- a/frontend/src/config/zimbabwe/prism.json
+++ b/frontend/src/config/zimbabwe/prism.json
@@ -1,11 +1,10 @@
 {
   "country": "Zimbabwe",
+  "countryAdmin0Id": 271,
   "alertFormActive": false,
   "enableNavigationDropdown": true,
   "serversUrls": {
-    "wms": [
-      "https://api.earthobservation.vam.wfp.org/ows/wms"
-    ]
+    "wms": ["https://api.earthobservation.vam.wfp.org/ows/wms"]
   },
   "icons": {
     "rainfall": "icon_rain.png",
@@ -20,10 +19,7 @@
     "longitude": 30.095,
     "zoom": 5.99
   },
-  "defaultDisplayBoundaries": [
-    "admin_boundaries",
-    "admin1_boundaries"
-  ],
+  "defaultDisplayBoundaries": ["admin_boundaries", "admin1_boundaries"],
   "categories": {
     "rainfall": {
       "ZMSD_rainfall_data": [
@@ -197,10 +193,7 @@
           ]
         }
       ],
-      "dry_periods": [
-        "days_dry",
-        "streak_dry_days"
-      ],
+      "dry_periods": ["days_dry", "streak_dry_days"],
       "extreme_rain_events": [
         {
           "group_title": "Rainfall categories:",
@@ -247,10 +240,7 @@
       ]
     },
     "vegetation": {
-      "vegetation_conditions": [
-        "ndvi_dekad",
-        "ndvi_dekad_anomaly"
-      ]
+      "vegetation_conditions": ["ndvi_dekad", "ndvi_dekad_anomaly"]
     },
     "temperature": {
       "land_surface_temperature": [
@@ -271,9 +261,7 @@
       ]
     },
     "exposure": {
-      "demographics": [
-        "pop_2020"
-      ]
+      "demographics": ["pop_2020"]
     }
   }
 }

--- a/frontend/src/context/datasetStateSlice.ts
+++ b/frontend/src/context/datasetStateSlice.ts
@@ -189,6 +189,7 @@ const fetchHDC = async (
   };
   try {
     const response = await fetch(`${url}?${requestParamsStr}`);
+    // eslint-disable-next-line fp/no-mutation
     responseJson = await response.json();
   } catch {
     console.warn('Impossible to get HDC data.');

--- a/frontend/src/context/datasetStateSlice.ts
+++ b/frontend/src/context/datasetStateSlice.ts
@@ -60,6 +60,8 @@ export type AdminBoundaryParams = {
 
 export type AdminBoundaryRequestParams = AdminBoundaryParams & {
   selectedDate: number;
+  level: string;
+  adminCode: number;
 };
 
 export type DatasetRequestParams =
@@ -224,13 +226,11 @@ export const loadAdminBoundaryDataset = async (
 
   const {
     url: hdcUrl,
-    id,
-    boundaryProps,
+    level,
+    adminCode,
     serverLayerName,
     datasetFields,
   } = params;
-
-  const { code: adminCode, level } = boundaryProps[id];
 
   const endDateStr = endDate.format(DEFAULT_DATE_FORMAT);
   const startDateStr = startDate.format(DEFAULT_DATE_FORMAT);

--- a/frontend/src/context/datasetStateSlice.ts
+++ b/frontend/src/context/datasetStateSlice.ts
@@ -179,8 +179,20 @@ const fetchHDC = async (
     .map(([key, value]) => `${key}=${value}`)
     .join('&');
 
-  const response = await fetch(`${url}?${requestParamsStr}`);
-  const responseJson: HDCResponse = await response.json();
+  // TODO - better error handling.
+  let responseJson: HDCResponse = {
+    data: {
+      rfh: [100],
+    },
+    valids: [6.0],
+    date: ['2022-03-21'],
+  };
+  try {
+    const response = await fetch(`${url}?${requestParamsStr}`);
+    responseJson = await response.json();
+  } catch {
+    console.warn('Impossible to get HDC data.');
+  }
 
   const dates: number[] = responseJson.date.map((date: string) =>
     moment(date).valueOf(),
@@ -216,6 +228,7 @@ export const loadAdminBoundaryDataset = async (
     serverLayerName,
     datasetFields,
   } = params;
+
   const { code: adminCode, level } = boundaryProps[id];
 
   const endDateStr = endDate.format(DEFAULT_DATE_FORMAT);
@@ -232,6 +245,8 @@ export const loadAdminBoundaryDataset = async (
     start: startDateStr,
     end: endDateStr,
   };
+
+  console.log({ hdcRequestParams });
 
   const results = await fetchHDC(hdcUrl, datasetFields, hdcRequestParams);
   const tableData = createTableData(results, TableDataFormat.DATE);

--- a/frontend/src/context/datasetStateSlice.ts
+++ b/frontend/src/context/datasetStateSlice.ts
@@ -246,8 +246,6 @@ export const loadAdminBoundaryDataset = async (
     end: endDateStr,
   };
 
-  console.log({ hdcRequestParams });
-
   const results = await fetchHDC(hdcUrl, datasetFields, hdcRequestParams);
   const tableData = createTableData(results, TableDataFormat.DATE);
 

--- a/frontend/src/context/tooltipStateSlice.ts
+++ b/frontend/src/context/tooltipStateSlice.ts
@@ -90,9 +90,6 @@ export const tooltipStateSlice = createSlice({
 // Getters
 export const tooltipSelector = (state: RootState): MapTooltipState =>
   state.tooltipState;
-export const tooltipShowingSelector = (
-  state: RootState,
-): MapTooltipState['showing'] => state.tooltipState.showing;
 
 // Setters
 export const {

--- a/frontend/src/utils/admin-utils.ts
+++ b/frontend/src/utils/admin-utils.ts
@@ -21,11 +21,6 @@ export function getAdminLevelLayer(
   );
 }
 
-export function getAdminLayerURL(adminLevel: AdminLevelType = 1): string {
-  const adminLayer = getAdminLevelLayer(adminLevel);
-  return adminLayer.path;
-}
-
 export function getAdminNameProperty(adminLevel: AdminLevelType = 1): string {
   const { adminLevelNames } = getBoundaryLayerSingleton();
   return adminLevelNames[adminLevel - 1];

--- a/frontend/src/utils/admin-utils.ts
+++ b/frontend/src/utils/admin-utils.ts
@@ -52,6 +52,7 @@ export const getChartAdminBoundaryParams = (
 
   const { levels, url, fields: datasetFields } = chartData!;
 
+  // TODO - why not reduce this by level directly?
   const boundaryProps = levels.reduce(
     (obj, item) => ({
       ...obj,

--- a/frontend/src/utils/url-utils.ts
+++ b/frontend/src/utils/url-utils.ts
@@ -135,21 +135,6 @@ export const useUrlHistory = () => {
   };
 };
 
-export function copyTextToClipboard(text: string): Promise<void> {
-  if (navigator?.clipboard) {
-    return navigator?.clipboard.writeText(text);
-  }
-  // If navigator.clipboard is not supported, fallback to execCommand
-  const tmpElement = document.createElement('input');
-  document.body.appendChild(tmpElement);
-  // eslint-disable-next-line fp/no-mutation
-  tmpElement.value = text;
-  tmpElement.select();
-  document.execCommand('copy');
-  document.body.removeChild(tmpElement);
-  return Promise.resolve();
-}
-
 export const queryParamsToString = (
   queryParams?: {
     [key: string]: string | { [key: string]: string };


### PR DESCRIPTION
This PR adds national level charts provided that `countryAdmin0Id` is set in prism.json. (Actual configuration could evolve if we have the admin0 code available by other means)

This PR also improves the csv name generation adding the country name and all admin levels selected. 