### PR TITLE
Added "Clear All" Button for clearing charts selections

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -20,6 +20,7 @@ import { GeoJsonProperties } from 'geojson';
 import { groupBy, mapKeys, snakeCase } from 'lodash';
 import React, {
   MutableRefObject,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -145,6 +146,18 @@ const useStyles = makeStyles(() =>
         backgroundColor: '#62B2BD',
       },
       marginTop: '2em',
+      marginLeft: '25%',
+      marginRight: '25%',
+      width: '50%',
+      '&.Mui-disabled': { opacity: 0.5 },
+    },
+    clearAllSelectionsButton: {
+      backgroundColor: '#788489',
+      '&:hover': {
+        backgroundColor: '#788489',
+      },
+      marginTop: 10,
+      marginBottom: 10,
       marginLeft: '25%',
       marginRight: '25%',
       width: '50%',
@@ -413,6 +426,18 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
     tabValue,
   ]);
 
+  const handleClearAllSelectedCharts = useCallback(() => {
+    setSelectedLayerTitles([]);
+    // Clear the date
+    setSelectedDate(new Date().getTime());
+    // reset the admin level
+    setAdminLevel(countryAdmin0Id ? 0 : 1);
+    // reset admin 1 title
+    setAdmin1Title('');
+    // reset the admin 2 title
+    setAdmin2Title('');
+  }, [countryAdmin0Id]);
+
   if (tabIndex !== tabValue) {
     return null;
   }
@@ -428,10 +453,10 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
         onChange={onChangeAdmin1}
         variant="outlined"
       >
-        <MenuItem key="national-1" divider>
+        <MenuItem divider>
           <Box className={classes.removeAdmin}> {t('National Level')}</Box>
         </MenuItem>
-        <MenuItem style={{ pointerEvents: 'none' }} key="national-1">
+        <MenuItem style={{ pointerEvents: 'none' }}>
           <Box style={{ fontStyle: 'italic', fontWeight: 'bold' }}>
             {t('Admin 1')}
           </Box>
@@ -452,7 +477,7 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
           onChange={onChangeAdmin2}
           variant="outlined"
         >
-          <MenuItem key="empty-2" divider>
+          <MenuItem divider>
             <Box className={classes.removeAdmin}> {t('Remove Admin 2')}</Box>
           </MenuItem>
           {categories
@@ -534,6 +559,20 @@ function ChartsPanel({ setPanelSize, setResultsPage }: ChartsPanelProps) {
         }
       >
         <Typography variant="body2">{t('Download CSV')}</Typography>
+      </Button>
+      <Button
+        className={classes.clearAllSelectionsButton}
+        onClick={handleClearAllSelectedCharts}
+        disabled={
+          !(
+            adminProperties &&
+            selectedDate &&
+            tabIndex === tabValue &&
+            selectedLayerTitles.length >= 1
+          )
+        }
+      >
+        <Typography variant="body2">{t('Clear All')}</Typography>
       </Button>
     </Box>
   );

--- a/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
@@ -3494,10 +3494,10 @@ exports[`renders as expected 1`] = `
       </div>
     </mock-drawer>
     <div
-      class="MuiBox-root MuiBox-root-110 MapView-container-2"
+      class="MuiBox-root MuiBox-root-111 MapView-container-2"
     >
       <div
-        class="MuiBox-root MuiBox-root-111 MapView-optionContainer-3"
+        class="MuiBox-root MuiBox-root-112 MapView-optionContainer-3"
         style="margin-left: 30vw;"
       >
         <mock-tooltip
@@ -3532,11 +3532,11 @@ exports[`renders as expected 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
             >
               <div
-                class="makeStyles-button-114"
+                class="makeStyles-button-115"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-icon-115 MuiSvgIcon-fontSizeSmall"
+                  class="MuiSvgIcon-root makeStyles-icon-116 MuiSvgIcon-fontSizeSmall"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -3545,7 +3545,7 @@ exports[`renders as expected 1`] = `
                   />
                 </svg>
                 <div
-                  class="makeStyles-selectContainer-116"
+                  class="makeStyles-selectContainer-117"
                 />
               </div>
             </div>


### PR DESCRIPTION
Created "Clear All" button for clearing the selection UX flow in Charts Panel.

@ericboucher Please let me know if we need to remove also the `adminProperties` state variable when we clear the selection flow. As I tested the functionality seems to be working ok, without removing it from the state.

<img width="1723" alt="Screenshot 2023-03-24 at 6 58 36 PM" src="https://user-images.githubusercontent.com/16843267/227604086-ef8804b9-9b7c-4620-ab68-35366e9d265c.png">
