### PR TITLE
Add report doc loader

### DIFF
--- a/frontend/src/components/Common/LoadingBlinkingDots/index.tsx
+++ b/frontend/src/components/Common/LoadingBlinkingDots/index.tsx
@@ -1,0 +1,35 @@
+import React, { memo } from 'react';
+import { createStyles, withStyles, WithStyles } from '@material-ui/core';
+
+const LoadingBlinkingDots = memo(({ classes }: LoadingBlinkingDotsProps) => {
+  return (
+    <>
+      <span className={classes.dot}>.</span>
+      <span className={classes.dot}>.</span>
+      <span className={classes.dot}>.</span>
+    </>
+  );
+});
+
+const styles = () =>
+  createStyles({
+    '@keyframes blink': {
+      '50%': {
+        color: 'transparent',
+      },
+    },
+    dot: {
+      color: 'black',
+      animation: '1s $blink infinite',
+      '&:nth-child(2)': {
+        animationDelay: '250ms',
+      },
+      '&:nth-child(3)': {
+        animationDelay: '500ms',
+      },
+    },
+  });
+
+export interface LoadingBlinkingDotsProps extends WithStyles<typeof styles> {}
+
+export default withStyles(styles)(LoadingBlinkingDots);

--- a/frontend/src/components/Common/ReportDialog/index.tsx
+++ b/frontend/src/components/Common/ReportDialog/index.tsx
@@ -2,7 +2,6 @@ import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
-  CircularProgress,
   createStyles,
   Dialog,
   DialogActions,
@@ -125,19 +124,22 @@ const ReportDialog = memo(
       }
       return (
         <Box className={classes.documentLoadingContainer}>
-          <CircularProgress size={100} />
           <Typography
-            className={classes.documentLoadingText}
+            className={classes.documentLoaderText}
             variant="body1"
             component="span"
           >
-            {t('Loading document...')}
+            {t('Loading document')}
           </Typography>
+          <span className={classes.documentLoaderDot}>.</span>
+          <span className={classes.documentLoaderDot}>.</span>
+          <span className={classes.documentLoaderDot}>.</span>
         </Box>
       );
     }, [
+      classes.documentLoaderDot,
+      classes.documentLoaderText,
       classes.documentLoadingContainer,
-      classes.documentLoadingText,
       documentIsLoading,
       t,
     ]);
@@ -194,8 +196,8 @@ const ReportDialog = memo(
             <PDFDownloadLink document={reportDoc} fileName={getPDFName}>
               {({ loading }) =>
                 loading || documentIsLoading
-                  ? 'Loading document...'
-                  : 'Download'
+                  ? `${t('Loading document')}...`
+                  : t('Download')
               }
             </PDFDownloadLink>
           </Button>
@@ -207,22 +209,35 @@ const ReportDialog = memo(
 
 const styles = (theme: Theme) =>
   createStyles({
+    '@keyframes blink': {
+      '50%': {
+        color: 'transparent',
+      },
+    },
     documentLoadingContainer: {
       backgroundColor: 'white',
       display: 'flex',
       justifyContent: 'center',
-      flexDirection: 'column',
       alignItems: 'center',
       height: '100%',
       position: 'absolute',
-      gap: '2.5rem',
       top: '50%',
       left: '50%',
       transform: 'translate(-50%, -50%)',
       width: '100%',
     },
-    documentLoadingText: {
+    documentLoaderText: {
       color: 'black',
+    },
+    documentLoaderDot: {
+      color: 'black',
+      animation: '1s $blink infinite',
+      '&:nth-child(2)': {
+        animationDelay: '250ms',
+      },
+      '&:nth-child(3)': {
+        animationDelay: '500ms',
+      },
     },
     titleRoot: {
       background: theme.dialog?.border,

--- a/frontend/src/components/Common/ReportDialog/reportDoc.tsx
+++ b/frontend/src/components/Common/ReportDialog/reportDoc.tsx
@@ -89,7 +89,7 @@ const ReportDoc = memo(
     columns,
   }: ReportDocProps) => {
     if (mapImage === null) {
-      return <></>;
+      return <Document />;
     }
 
     const styles = makeStyles(theme);

--- a/frontend/src/components/Common/ReportDialog/reportDoc.tsx
+++ b/frontend/src/components/Common/ReportDialog/reportDoc.tsx
@@ -88,10 +88,6 @@ const ReportDoc = memo(
     tableData,
     columns,
   }: ReportDocProps) => {
-    if (mapImage === null) {
-      return <Document />;
-    }
-
     const styles = makeStyles(theme);
 
     const date = useMemo(() => {
@@ -271,7 +267,7 @@ const ReportDoc = memo(
 interface ReportDocProps {
   theme: Theme;
   reportType: ReportType;
-  mapImage: string | null;
+  mapImage: string;
   tableName: string;
   tableRowsNum?: number;
   tableShowTotal: boolean;

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
@@ -675,7 +675,7 @@ function AnalysisPanel({
           variant="body1"
           component="span"
         >
-          {t('Loading Exposure Analysis Data...')}
+          {t('Loading Exposure Analysis Data')}...
         </Typography>
       </Box>
     );

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
@@ -105,6 +105,7 @@ import {
   leftPanelTabValueSelector,
   setTabValue,
 } from '../../../../context/leftPanelStateSlice';
+import LoadingBlinkingDots from '../../../Common/LoadingBlinkingDots';
 
 const tabIndex = 2;
 
@@ -670,13 +671,16 @@ function AnalysisPanel({
     return (
       <Box className={classes.exposureAnalysisLoadingContainer}>
         <CircularProgress size={100} />
-        <Typography
-          className={classes.exposureAnalysisLoadingText}
-          variant="body1"
-          component="span"
-        >
-          {t('Loading Exposure Analysis Data')}...
-        </Typography>
+        <Box className={classes.exposureAnalysisLoadingTextContainer}>
+          <Typography
+              className={classes.exposureAnalysisLoadingText}
+              variant="body1"
+              component="span"
+          >
+            {t('Loading Exposure Analysis Data')}
+          </Typography>
+          <LoadingBlinkingDots />
+        </Box>
       </Box>
     );
   }, [
@@ -1123,6 +1127,11 @@ const styles = (theme: Theme) =>
       gap: '2.5rem',
       height: '100%',
       width: '100%',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    exposureAnalysisLoadingTextContainer: {
+      display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
@@ -673,9 +673,9 @@ function AnalysisPanel({
         <CircularProgress size={100} />
         <Box className={classes.exposureAnalysisLoadingTextContainer}>
           <Typography
-              className={classes.exposureAnalysisLoadingText}
-              variant="body1"
-              component="span"
+            className={classes.exposureAnalysisLoadingText}
+            variant="body1"
+            component="span"
           >
             {t('Loading Exposure Analysis Data')}
           </Typography>
@@ -686,6 +686,7 @@ function AnalysisPanel({
   }, [
     classes.exposureAnalysisLoadingContainer,
     classes.exposureAnalysisLoadingText,
+    classes.exposureAnalysisLoadingTextContainer,
     isExposureAnalysisLoading,
     t,
   ]);

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
@@ -670,9 +670,21 @@ function AnalysisPanel({
     return (
       <Box className={classes.exposureAnalysisLoadingContainer}>
         <CircularProgress size={100} />
+        <Typography
+          className={classes.exposureAnalysisLoadingText}
+          variant="body1"
+          component="span"
+        >
+          {t('Loading Exposure Analysis Data...')}
+        </Typography>
       </Box>
     );
-  }, [classes.exposureAnalysisLoadingContainer, isExposureAnalysisLoading]);
+  }, [
+    classes.exposureAnalysisLoadingContainer,
+    classes.exposureAnalysisLoadingText,
+    isExposureAnalysisLoading,
+    t,
+  ]);
 
   const renderedExposureAnalysisTable = useMemo(() => {
     if (!(analysisResult instanceof ExposedPopulationResult)) {
@@ -1107,10 +1119,15 @@ const styles = (theme: Theme) =>
     },
     exposureAnalysisLoadingContainer: {
       display: 'flex',
+      flexDirection: 'column',
+      gap: '2.5rem',
       height: '100%',
       width: '100%',
       justifyContent: 'center',
       alignItems: 'center',
+    },
+    exposureAnalysisLoadingText: {
+      color: 'black',
     },
     analysisPanelParams: {
       padding: 10,

--- a/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
@@ -3494,10 +3494,10 @@ exports[`renders as expected 1`] = `
       </div>
     </mock-drawer>
     <div
-      class="MuiBox-root MuiBox-root-112 MapView-container-2"
+      class="MuiBox-root MuiBox-root-113 MapView-container-2"
     >
       <div
-        class="MuiBox-root MuiBox-root-113 MapView-optionContainer-3"
+        class="MuiBox-root MuiBox-root-114 MapView-optionContainer-3"
         style="margin-left: 30vw;"
       >
         <mock-tooltip
@@ -3532,11 +3532,11 @@ exports[`renders as expected 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
             >
               <div
-                class="makeStyles-button-116"
+                class="makeStyles-button-117"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-icon-117 MuiSvgIcon-fontSizeSmall"
+                  class="MuiSvgIcon-root makeStyles-icon-118 MuiSvgIcon-fontSizeSmall"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -3545,7 +3545,7 @@ exports[`renders as expected 1`] = `
                   />
                 </svg>
                 <div
-                  class="makeStyles-selectContainer-118"
+                  class="makeStyles-selectContainer-119"
                 />
               </div>
             </div>

--- a/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
@@ -3494,10 +3494,10 @@ exports[`renders as expected 1`] = `
       </div>
     </mock-drawer>
     <div
-      class="MuiBox-root MuiBox-root-113 MapView-container-2"
+      class="MuiBox-root MuiBox-root-114 MapView-container-2"
     >
       <div
-        class="MuiBox-root MuiBox-root-114 MapView-optionContainer-3"
+        class="MuiBox-root MuiBox-root-115 MapView-optionContainer-3"
         style="margin-left: 30vw;"
       >
         <mock-tooltip
@@ -3532,11 +3532,11 @@ exports[`renders as expected 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
             >
               <div
-                class="makeStyles-button-117"
+                class="makeStyles-button-118"
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root makeStyles-icon-118 MuiSvgIcon-fontSizeSmall"
+                  class="MuiSvgIcon-root makeStyles-icon-119 MuiSvgIcon-fontSizeSmall"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -3545,7 +3545,7 @@ exports[`renders as expected 1`] = `
                   />
                 </svg>
                 <div
-                  class="makeStyles-selectContainer-119"
+                  class="makeStyles-selectContainer-120"
                 />
               </div>
             </div>


### PR DESCRIPTION
Added custom workaround to show loader in creating pdf reports of exposure analysis (currently waiting about 20 seconds for the report to be generated)

How to test the feature:
Select exposure analysis and click the create report button on the exposure analysis actions below in the sidebar.