### PR TITLE
Added maxValue and minValue in charts configuration

### DIFF
--- a/frontend/src/components/DataDrawer/Chart/index.tsx
+++ b/frontend/src/components/DataDrawer/Chart/index.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import colormap from 'colormap';
 import { ChartOptions } from 'chart.js';
 import { Bar, Line } from 'react-chartjs-2';
-import { TFunction, TFunctionKeys } from 'i18next';
+import { TFunctionKeys } from 'i18next';
 import moment, { LocaleSpecifier } from 'moment';
-import { ChartConfig, DatasetField, ChartConfig } from '../../../config/types';
-
+import { ChartConfig, DatasetField } from '../../../config/types';
 import { TableData } from '../../../context/tableStateSlice';
 import { useSafeTranslation } from '../../../i18n';
 
@@ -19,137 +18,77 @@ type ChartProps = {
   legendAtBottom?: boolean;
 };
 
-function colorShuffle(colors: string[]) {
-  return colors.map((_, i) =>
-    i % 2 ? colors[i] : colors[colors.length - i - 1],
-  );
-}
+const Chart = memo(
+  ({
+    title,
+    data,
+    config,
+    xAxisLabel,
+    datasetFields,
+    notMaintainAspectRatio,
+    legendAtBottom,
+  }: ChartProps) => {
+    const { t } = useSafeTranslation();
 
-function getChartConfig(
-  stacked: boolean,
-  title: string,
-  displayLegend: boolean,
-  xAxisLabel?: string,
-  notMaintainAspectRatio?: boolean,
-  legendAtBottom?: boolean,
-  minValue?: number,
-  maxValue?: number,
-) {
-  return {
-    maintainAspectRatio: !(notMaintainAspectRatio ?? false),
-    title: {
-      fontColor: '#CCC',
-      display: true,
-      text: title,
-      fontSize: 14,
-    },
-    scales: {
-      xAxes: [
-        {
-          stacked,
-          gridLines: {
-            display: false,
-          },
-          ticks: {
-            fontColor: '#CCC',
-          },
-          ...(xAxisLabel
-            ? {
-                scaleLabel: {
-                  labelString: xAxisLabel,
-                  display: true,
-                },
-              }
-            : {}),
-        },
-      ],
-      yAxes: [
-        {
-          ticks: {
-            fontColor: '#CCC',
-            ...(minValue && { suggestedMin: minValue }),
-            ...(maxValue && { suggestedMax: maxValue }),
-          },
-          stacked,
-          gridLines: {
-            display: false,
-          },
-        },
-      ],
-    },
-    legend: {
-      display: displayLegend,
-      position: legendAtBottom ? 'bottom' : 'right',
-    },
-  } as ChartOptions;
-}
+    const transpose = useMemo(() => {
+      return config.transpose || false;
+    }, [config.transpose]);
 
-function formatChartData(
-  data: TableData,
-  config: ChartConfig,
-  datasetFields: DatasetField[] | undefined,
-  t: TFunction,
-) {
-  /**
-   * This function assumes that the data is fomratted as follows:
-   * First Row -> "keys"
-   * Second Row -> "column names / headers"
-   *
-   * Example:
-   *  Month,data1,data2,data3
-   *  Month,Average,High,Low
-   *  Dec-18,6750,12000,3200
-   *  Jan-19,6955,10600,3600
-   *  Feb-19,6881,10300,3600
-   *  Mar-19,6505,10000,2700
-   *  Apr-19,6319,10200,3000
-   *
-   * The function uses the config fields:
-   *  - data: the identifier fot keys. Eg. config.data = data for the above dataset
-   *          will select columns data1, data2, data3
-   *
-   * - category: the key to use to identify categories. Eg. "Month" in the example above.
-   *
-   * - transpose: specify if rows or columns should be used to form datasets.
-   *               By default, the function uses each row as a dataset.
-   *               In the example above, we will need to transpose the data
-   *               using config.transpose = true.
-   *  - fill
-   */
+    const header = useMemo(() => {
+      return data.rows[0];
+    }, [data.rows]);
 
-  const transpose = config.transpose || false;
-  const header = data.rows[0];
-  const tableRows = data.rows.slice(1, data.rows.length);
+    const tableRows = useMemo(() => {
+      return data.rows.slice(1, data.rows.length);
+    }, [data.rows]);
 
-  // Get the keys for the data of interest
-  const indices = Object.keys(header).filter(key =>
-    key.includes(config.data || ''),
-  );
+    // Get the keys for the data of interest
+    const indices = useMemo(() => {
+      return Object.keys(header).filter(key => key.includes(config.data || ''));
+    }, [config.data, header]);
 
-  // rainbow-soft map requires nshades to be at least size 11
-  const nshades = Math.max(11, !transpose ? tableRows.length : indices.length);
+    // rainbow-soft map requires nshades to be at least size 11
+    const nshades = useMemo(() => {
+      if (!transpose) {
+        return Math.max(11, tableRows.length);
+      }
+      return Math.max(11, indices.length);
+    }, [indices.length, tableRows.length, transpose]);
 
-  const colors =
-    config.colors ||
-    colorShuffle(
-      colormap({
-        colormap: 'rainbow-soft',
-        nshades,
-        format: 'hex',
-        alpha: 0.5,
-      }),
-    );
+    const colorShuffle = useCallback((colors: string[]) => {
+      return colors.map((_, i) =>
+        i % 2 ? colors[i] : colors[colors.length - i - 1],
+      );
+    }, []);
 
-  const labels = !transpose
-    ? indices.map(index => header[index])
-    : tableRows.map(row => {
+    const colors = useMemo(() => {
+      return (
+        config.colors ||
+        colorShuffle(
+          colormap({
+            colormap: 'rainbow-soft',
+            nshades,
+            format: 'hex',
+            alpha: 0.5,
+          }),
+        )
+      );
+    }, [colorShuffle, config.colors, nshades]);
+
+    const labels = useMemo(() => {
+      if (!transpose) {
+        return indices.map(index => header[index]);
+      }
+      return tableRows.map(row => {
         return moment(row[config.category])
           .locale(t('date_locale') as LocaleSpecifier)
           .format('YYYY-MM-DD');
       });
+    }, [config.category, header, indices, t, tableRows, transpose]);
 
-  const datasets = !transpose
-    ? tableRows.map((row, i) => {
+    // The table rows data sets
+    const tableRowsDataSet = useMemo(() => {
+      return tableRows.map((row, i) => {
         return {
           label: t(row[config.category] as TFunctionKeys) || '',
           fill: config.fill || false,
@@ -159,24 +98,36 @@ function formatChartData(
           pointRadius: data.EWSConfig ? 0 : 1, // Disable point rendering for EWS only.
           data: indices.map(index => (row[index] as number) || null),
         };
-      })
-    : indices.map((indiceKey, i) => {
+      });
+    }, [
+      colors,
+      config.category,
+      config.fill,
+      data.EWSConfig,
+      indices,
+      t,
+      tableRows,
+    ]);
+
+    const configureIndicePointRadius = useCallback(
+      (indiceKey: string) => {
         const foundDataSetFieldPointRadius = datasetFields?.find(
           datasetField => {
             return header[indiceKey] === datasetField.label;
           },
         )?.pointRadius;
 
-        let pointRadius;
-
         if (foundDataSetFieldPointRadius !== undefined) {
-          // eslint-disable-next-line fp/no-mutation
-          pointRadius = foundDataSetFieldPointRadius;
-        } else {
-          // eslint-disable-next-line fp/no-mutation
-          pointRadius = data.EWSConfig ? 0 : 1; // Disable point rendering for EWS only.
+          return foundDataSetFieldPointRadius;
         }
+        return data.EWSConfig ? 0 : 1; // Disable point rendering for EWS only.
+      },
+      [data.EWSConfig, datasetFields, header],
+    );
 
+    // The indicesDataSet
+    const indicesDataSet = useMemo(() => {
+      return indices.map((indiceKey, i) => {
         return {
           label: t(header[indiceKey] as TFunctionKeys),
           fill: config.fill || false,
@@ -184,90 +135,135 @@ function formatChartData(
           borderColor: colors[i],
           borderWidth: 2,
           data: tableRows.map(row => (row[indiceKey] as number) || null),
-          pointRadius,
+          pointRadius: configureIndicePointRadius(indiceKey),
         };
       });
+    }, [
+      colors,
+      config.fill,
+      configureIndicePointRadius,
+      header,
+      indices,
+      t,
+      tableRows,
+    ]);
 
-  const EWSthresholds = data.EWSConfig
-    ? Object.values(data.EWSConfig).map(obj => ({
-        label: t(obj.label as TFunctionKeys),
-        backgroundColor: obj.color,
-        borderColor: obj.color,
-        borderWidth: 2,
-        pointRadius: 0,
-        // Deep copy is needed: https://github.com/reactchartjs/react-chartjs-2/issues/524#issuecomment-722814079
-        data: [...obj.values],
-        fill: false,
-      }))
-    : [];
+    const EWSthresholds = useMemo(() => {
+      if (data.EWSConfig) {
+        return Object.values(data.EWSConfig).map(obj => ({
+          label: obj.label,
+          backgroundColor: obj.color,
+          borderColor: obj.color,
+          borderWidth: 2,
+          pointRadius: 0,
+          // Deep copy is needed: https://github.com/reactchartjs/react-chartjs-2/issues/524#issuecomment-722814079
+          data: [...obj.values],
+          fill: false,
+        }));
+      }
+      return [];
+    }, [data.EWSConfig]);
 
-  const datasetsWithThresholds = [...datasets, ...EWSthresholds];
+    /**
+     * The following memo value Assumes that the data is formatted as follows:
+     * First Row -> "keys"
+     * Second Row -> "column names / headers"
+     *
+     * Example:
+     *  Month,data1,data2,data3
+     *  Month,Average,High,Low
+     *  Dec-18,6750,12000,3200
+     *  Jan-19,6955,10600,3600
+     *  Feb-19,6881,10300,3600
+     *  Mar-19,6505,10000,2700
+     *  Apr-19,6319,10200,3000
+     *
+     * The function uses the config fields:
+     *  - data: the identifier fot keys. Eg. config.data = data for the above dataset
+     *          will select columns data1, data2, data3
+     *
+     * - category: the key to use to identify categories. Eg. "Month" in the example above.
+     *
+     * - transpose: specify if rows or columns should be used to form datasets.
+     *               By default, the function uses each row as a dataset.
+     *               In the example above, we will need to transpose the data
+     *               using config.transpose = true.
+     *  - fill
+     */
+    const chartData = useMemo(() => {
+      const datasets = !transpose ? tableRowsDataSet : indicesDataSet;
+      const datasetsWithThresholds = [...datasets, ...EWSthresholds];
 
-  return {
-    labels,
-    datasets: datasetsWithThresholds,
-  };
-}
+      return {
+        labels,
+        datasets: datasetsWithThresholds,
+      };
+    }, [EWSthresholds, indicesDataSet, labels, tableRowsDataSet, transpose]);
 
-function Chart({
-  title,
-  data,
-  config,
-  xAxisLabel,
-  datasetFields,
-  notMaintainAspectRatio,
-  legendAtBottom,
-}: ChartProps) {
-  const { t } = useSafeTranslation();
+    const chartConfig = useMemo(() => {
+      return {
+        maintainAspectRatio: !(notMaintainAspectRatio ?? false),
+        title: {
+          fontColor: '#CCC',
+          display: true,
+          text: title,
+          fontSize: 14,
+        },
+        scales: {
+          xAxes: [
+            {
+              stacked: config?.stacked ?? false,
+              gridLines: {
+                display: false,
+              },
+              ticks: {
+                fontColor: '#CCC',
+              },
+              ...(xAxisLabel
+                ? {
+                    scaleLabel: {
+                      labelString: xAxisLabel,
+                      display: true,
+                    },
+                  }
+                : {}),
+            },
+          ],
+          yAxes: [
+            {
+              ticks: {
+                fontColor: '#CCC',
+                ...(config?.minValue && { suggestedMin: config?.minValue }),
+                ...(config?.maxValue && { suggestedMax: config?.maxValue }),
+              },
+              stacked: config?.stacked ?? false,
+              gridLines: {
+                display: false,
+              },
+            },
+          ],
+        },
+        legend: {
+          display: config.displayLegend,
+          position: legendAtBottom ? 'bottom' : 'right',
+        },
+      } as ChartOptions;
+    }, [config, legendAtBottom, notMaintainAspectRatio, title, xAxisLabel]);
 
-  try {
-    const chartData = formatChartData(data, config, datasetFields, t);
-
-    switch (config.type) {
-      case 'bar':
-        return (
-          <Bar
-            data={chartData}
-            options={getChartConfig(
-              config.stacked || false,
-              title,
-              config.displayLegend || false,
-              xAxisLabel,
-              notMaintainAspectRatio,
-              legendAtBottom,
-              config?.minValue,
-              config?.maxValue,
-            )}
-          />
-        );
-      case 'line':
-        return (
-          <Line
-            data={chartData}
-            options={getChartConfig(
-              config.stacked || false,
-              title,
-              config.displayLegend || false,
-              xAxisLabel,
-              notMaintainAspectRatio,
-              legendAtBottom,
-              config?.minValue,
-              config?.maxValue,
-            )}
-          />
-        );
-      default:
-        throw new Error(
-          `Charts of type ${config.type} have not been implemented yet.`,
-        );
-    }
-  } catch (err) {
-    console.error(
-      err,
-      'An error occured. This chart structure may not be supported yet.',
-    );
-  }
-  return null;
-}
+    return useMemo(() => {
+      switch (config.type) {
+        case 'bar':
+          return <Bar data={chartData} options={chartConfig} />;
+        case 'line':
+          return <Line data={chartData} options={chartConfig} />;
+        default:
+          console.error(
+            `Charts of type ${config.type} have not been implemented yet.`,
+          );
+          return null;
+      }
+    }, [chartConfig, chartData, config.type]);
+  },
+);
 
 export default Chart;

--- a/frontend/src/components/DataDrawer/Chart/index.tsx
+++ b/frontend/src/components/DataDrawer/Chart/index.tsx
@@ -30,6 +30,8 @@ function getChartConfig(
   xAxisLabel?: string,
   notMaintainAspectRatio?: boolean,
   legendAtBottom?: boolean,
+  minValue?: number,
+  maxValue?: number,
 ) {
   return {
     maintainAspectRatio: !(notMaintainAspectRatio ?? false),
@@ -63,6 +65,8 @@ function getChartConfig(
         {
           ticks: {
             fontColor: '#CCC',
+            ...(minValue && { suggestedMin: minValue }),
+            ...(maxValue && { suggestedMax: maxValue }),
           },
           stacked,
           gridLines: {
@@ -170,11 +174,11 @@ function formatChartData(data: TableData, config: ChartConfig, t: TFunction) {
       }))
     : [];
 
-  const datasetsWithTresholds = [...datasets, ...EWSthresholds];
+  const datasetsWithThresholds = [...datasets, ...EWSthresholds];
 
   return {
     labels,
-    datasets: datasetsWithTresholds,
+    datasets: datasetsWithThresholds,
   };
 }
 
@@ -203,6 +207,8 @@ function Chart({
               xAxisLabel,
               notMaintainAspectRatio,
               legendAtBottom,
+              config?.minValue,
+              config?.maxValue,
             )}
           />
         );
@@ -217,6 +223,8 @@ function Chart({
               xAxisLabel,
               notMaintainAspectRatio,
               legendAtBottom,
+              config?.minValue,
+              config?.maxValue,
             )}
           />
         );

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
@@ -206,11 +206,12 @@ function ChartSection({
         title={t(title)}
         config={config}
         data={chartDataset}
+        datasetFields={params.datasetFields}
         notMaintainAspectRatio
         legendAtBottom
       />
     );
-  }, [chartDataset, classes.loading, config, t, title]);
+  }, [chartDataset, classes.loading, config, params.datasetFields, t, title]);
 }
 
 const styles = () =>

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
@@ -8,7 +8,11 @@ import { GeoJsonProperties } from 'geojson';
 import { omit } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { appConfig } from '../../../../../config';
-import { ChartConfig, WMSLayerProps } from '../../../../../config/types';
+import {
+  ChartConfig,
+  DatasetField,
+  WMSLayerProps,
+} from '../../../../../config/types';
 import {
   CHART_DATA_PREFIXES,
   DatasetRequestParams,
@@ -147,6 +151,30 @@ function ChartSection({
     return params.datasetFields?.map(row => row.color);
   }, [params.datasetFields]);
 
+  const minValue = useMemo(() => {
+    return Math.min(
+      ...(params.datasetFields
+        ?.filter((row: DatasetField) => {
+          return row?.minValue !== undefined;
+        })
+        .map((row: DatasetField) => {
+          return row.minValue;
+        }) as number[]),
+    );
+  }, [params.datasetFields]);
+
+  const maxValue = useMemo(() => {
+    return Math.max(
+      ...(params.datasetFields
+        ?.filter((row: DatasetField) => {
+          return row?.maxValue !== undefined;
+        })
+        .map((row: DatasetField) => {
+          return row.maxValue;
+        }) as number[]),
+    );
+  }, [params.datasetFields]);
+
   const config: ChartConfig = useMemo(() => {
     return {
       type: chartType,
@@ -155,9 +183,11 @@ function ChartSection({
       data: CHART_DATA_PREFIXES.col,
       transpose: true,
       displayLegend: true,
+      minValue,
+      maxValue,
       colors,
     };
-  }, [chartType, colors]);
+  }, [chartType, colors, maxValue, minValue]);
 
   const title = useMemo(() => {
     return chartLayer.title;

--- a/frontend/src/config/cambodia/layers.json
+++ b/frontend/src/config/cambodia/layers.json
@@ -279,11 +279,15 @@
     "chart_data": {
       "url": "https://api.earthobservation.vam.wfp.org/stats/admin/fetch",
       "fields": [
-        { "key": "rfq", "label": "Rainfall anomaly", "color": "#375692" },
+        { "key": "rfq", "label": "Rainfall anomaly", "color": "#375692",
+          "minValue": 0,
+          "maxValue": 300
+        },
         {
           "key": "rfq_avg",
           "label": "Normal",
           "fallback": 100,
+          "pointRadius": 0,
           "color": "#eb3223"
         }
       ],

--- a/frontend/src/config/types.ts
+++ b/frontend/src/config/types.ts
@@ -331,6 +331,9 @@ export type DatasetField = {
   label: string;
   fallback?: number; // If key does not exist in json response use fallback (rainfall anomaly).
   color: string;
+  maxValue?: number;
+  minValue?: number;
+  pointRadius?: number;
 };
 
 type DatasetProps = {
@@ -610,6 +613,8 @@ export interface WfsRequestParams {
 export interface ChartConfig {
   type: string;
   category: string;
+  minValue?: number;
+  maxValue?: number;
   stacked?: boolean;
   exclude?: string[];
   data?: string;

--- a/frontend/src/context/datasetStateSlice.ts
+++ b/frontend/src/context/datasetStateSlice.ts
@@ -245,7 +245,6 @@ export const loadAdminBoundaryDataset = async (
 
   const results = await fetchHDC(hdcUrl, datasetFields, hdcRequestParams);
   const tableData = createTableData(results, TableDataFormat.DATE);
-
   return new Promise<TableData>(resolve => resolve(tableData));
 };
 


### PR DESCRIPTION
This branch takes into account the following assumptions:
 - The `maxValue` `minValue` are added in the fields section of `layers.json` of `chart_data` collection.
 - The codebase calculates the `max` and `min` values of multiple `maxValue` and `minValue` fields, if by mistake for example we configure `maxValue` of 200 in one field and `maxValue` of 300 in another field he codebase will keep the 300, the vise versa applies also in the min values.
 - The `maxValues` and `minValues` are applied in the y-axis ticks as `suggestedMin` `suggestedMax`, this practically means that if a value is over the configured `maxValue`, or less than the configured `minValue` the ticks will be adjusted to facilitate those values.
 
 @wadhwamatic I have added some `minValue` and `maxValue` and `pointRadius` in 10 day rainfall anomaly of the `layers.json` for testing purposes, feel free to adjust and replace them with the acceptable values (or remove them, if we don't need them for the specific `chart_data`).  Following with a commit that accomplishes the `pointRadius` configuration. This was a little bit more tricky, because while `minValues` and `maxValues` are configured in the y-axis, `pointRadius` applies to each data specifically as config. 
 
 Cc @ericboucher 