### PR TITLE
Added indications of active layers in foldbutton and individual menu items

### DIFF
--- a/frontend/src/components/MapView/FoldButton/index.tsx
+++ b/frontend/src/components/MapView/FoldButton/index.tsx
@@ -1,4 +1,5 @@
 import {
+  Badge,
   Button,
   makeStyles,
   Theme,
@@ -6,8 +7,10 @@ import {
   Typography,
 } from '@material-ui/core';
 import DragIndicatorIcon from '@material-ui/icons/DragIndicator';
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { useSafeTranslation } from '../../../i18n';
+import { activeLayersSelector } from '../../../context/mapStateSlice/selectors';
 
 interface IProps {
   isPanelHidden: boolean;
@@ -37,13 +40,32 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-function FoldButton({ isPanelHidden, setIsPanelHidden }: IProps) {
+const FoldButton = ({ isPanelHidden, setIsPanelHidden }: IProps) => {
   const classes = useStyles();
   const { t } = useSafeTranslation();
+  const activeLayers = useSelector(activeLayersSelector);
 
-  const onClick = () => {
+  const onClick = useCallback(() => {
     setIsPanelHidden(value => !value);
-  };
+  }, [setIsPanelHidden]);
+
+  const renderedIcon = useMemo(() => {
+    if (isPanelHidden && activeLayers.length >= 1) {
+      return (
+        <Badge
+          anchorOrigin={{
+            horizontal: 'right',
+            vertical: 'top',
+          }}
+          badgeContent={activeLayers.length}
+          color="secondary"
+        >
+          <DragIndicatorIcon />
+        </Badge>
+      );
+    }
+    return <DragIndicatorIcon />;
+  }, [activeLayers.length, isPanelHidden]);
 
   return (
     <Tooltip title={<Typography>{t('Menu')}</Typography>} arrow>
@@ -56,10 +78,10 @@ function FoldButton({ isPanelHidden, setIsPanelHidden }: IProps) {
         size="medium"
         onClick={onClick}
       >
-        <DragIndicatorIcon />
+        {renderedIcon}
       </Button>
     </Tooltip>
   );
-}
+};
 
 export default FoldButton;

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`renders as expected 1`] = `
 <div>
   <div
     class="MuiPaper-root MuiAccordion-root makeStyles-root-1 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
-    style="display: none;"
   >
     <div
       aria-controls="title"
@@ -16,7 +15,7 @@ exports[`renders as expected 1`] = `
       tabindex="0"
     >
       <div
-        class="MuiAccordionSummary-content"
+        class="MuiAccordionSummary-content makeStyles-summaryContent-5"
       >
         <mock-typography
           classes="[object Object]"

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/__snapshots__/index.test.tsx.snap
@@ -11,18 +11,18 @@ exports[`renders as expected 1`] = `
       <mock-switch
         checked="false"
         classes="[object Object]"
-        classname="SwitchItem-switch-6"
+        classname="memo-switch-6"
         inputprops="[object Object]"
         size="small"
       />
       <mock-typography
-        classname="SwitchItem-titleUnchecked-2"
+        classname="memo-titleUnchecked-2"
       />
       <mock-tooltip
         title="Opacity"
       >
         <button
-          class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-9 Mui-disabled Mui-disabled"
+          class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-9 Mui-disabled Mui-disabled"
           disabled=""
           tabindex="-1"
           type="button"

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.tsx
@@ -12,13 +12,15 @@ import {
   withStyles,
 } from '@material-ui/core';
 import OpacityIcon from '@material-ui/icons/Opacity';
-import React, { useState } from 'react';
+import React, {
+  ChangeEvent,
+  memo,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  ExposedPopulationDefinition,
-  LayerKey,
-  LayerType,
-} from '../../../../../../config/types';
+import { LayerKey, LayerType } from '../../../../../../config/types';
 import {
   getDisplayBoundaryLayers,
   LayerDefinitions,
@@ -41,18 +43,7 @@ import { Extent } from '../../../../Layers/raster-utils';
 import LayerDownloadOptions from './LayerDownloadOptions';
 import ExposureAnalysisOption from './ExposureAnalysisOption';
 
-/**
- * Returns layer identifier used to perform exposure analysis.
- *
- * @return LayerKey or undefined if exposure not found or GeometryType is not Polygon.
- */
-function getExposureFromLayer(
-  layer: LayerType,
-): ExposedPopulationDefinition | undefined {
-  return (layer.type === 'wms' && layer.exposure) || undefined;
-}
-
-function SwitchItem({ classes, layer, extent }: SwitchItemProps) {
+const SwitchItem = memo(({ classes, layer, extent }: SwitchItemProps) => {
   const {
     id: layerId,
     title: layerTitle,
@@ -72,124 +63,262 @@ function SwitchItem({ classes, layer, extent }: SwitchItemProps) {
     removeLayerFromUrl,
   } = useUrlHistory();
 
-  const selected = selectedLayers.some(({ id: testId }) => {
-    return (
-      testId === layerId || (group && group.layers.some(l => l.id === testId))
-    );
-  });
+  const selected = useMemo(() => {
+    return selectedLayers.some(({ id: testId }) => {
+      return (
+        testId === layerId || (group && group.layers.some(l => l.id === testId))
+      );
+    });
+  }, [group, layerId, selectedLayers]);
 
-  const selectedActiveLayer = selected
-    ? selectedLayers.filter(sl => {
-        return (
-          (group?.activateAll &&
-            group?.layers.find(l => l.id === sl.id && l.main)) ||
-          (!group?.activateAll && group?.layers.map(l => l.id).includes(sl.id))
-        );
-      })
-    : [];
+  const selectedActiveLayer = useMemo(() => {
+    return selected
+      ? selectedLayers.filter(sl => {
+          return (
+            (group?.activateAll &&
+              group?.layers.find(l => l.id === sl.id && l.main)) ||
+            (!group?.activateAll &&
+              group?.layers.map(l => l.id).includes(sl.id))
+          );
+        })
+      : [];
+  }, [group, selected, selectedLayers]);
 
-  const initialActiveLayer =
-    selectedActiveLayer.length > 0 ? selectedActiveLayer[0].id : null;
+  const initialActiveLayer = useMemo(() => {
+    return selectedActiveLayer.length > 0 ? selectedActiveLayer[0].id : null;
+  }, [selectedActiveLayer]);
 
   const [activeLayer, setActiveLayer] = useState(
     initialActiveLayer || (group?.layers?.find(l => l.main)?.id as string),
   );
 
-  const exposure = getExposureFromLayer(layer);
+  const exposure = useMemo(() => {
+    return (layer.type === 'wms' && layer.exposure) || undefined;
+  }, [layer.exposure, layer.type]);
 
-  const validatedTitle = t(group?.groupTitle || layerTitle || '');
+  const validatedTitle = useMemo(() => {
+    return t(group?.groupTitle || layerTitle || '');
+  }, [group, layerTitle, t]);
 
-  const toggleLayerValue = (selectedLayerId: string, checked: boolean) => {
-    // clear previous table dataset loaded first
-    // to close the dataseries and thus close chart
-    dispatch(clearDataset());
+  const toggleLayerValue = useCallback(
+    (selectedLayerId: string, checked: boolean) => {
+      // clear previous table dataset loaded first
+      // to close the dataseries and thus close chart
+      dispatch(clearDataset());
 
-    const selectedLayer = group
-      ? LayerDefinitions[selectedLayerId as LayerKey]
-      : layer;
+      const selectedLayer = group
+        ? LayerDefinitions[selectedLayerId as LayerKey]
+        : layer;
 
-    const urlLayerKey = getUrlKey(selectedLayer);
+      const urlLayerKey = getUrlKey(selectedLayer);
 
-    if (checked) {
-      const updatedUrl = appendLayerToUrl(
-        urlLayerKey,
-        selectedLayers,
-        selectedLayer,
-      );
+      if (checked) {
+        const updatedUrl = appendLayerToUrl(
+          urlLayerKey,
+          selectedLayers,
+          selectedLayer,
+        );
 
-      updateHistory(urlLayerKey, updatedUrl);
+        updateHistory(urlLayerKey, updatedUrl);
 
-      if (
-        !('boundary' in selectedLayer) &&
-        selectedLayer.type === 'admin_level_data'
-      ) {
-        refreshBoundaries(map, dispatch);
-      }
-    } else {
-      removeLayerFromUrl(urlLayerKey, selectedLayer.id);
-      dispatch(removeLayer(selectedLayer));
+        if (
+          !('boundary' in selectedLayer) &&
+          selectedLayer.type === 'admin_level_data'
+        ) {
+          refreshBoundaries(map, dispatch);
+        }
+      } else {
+        removeLayerFromUrl(urlLayerKey, selectedLayer.id);
+        // reset opacity value
+        setOpacityValue(initialOpacity || 0);
+        // reset opacity selected
+        setIsOpacitySelected(false);
+        dispatch(removeLayer(selectedLayer));
 
-      // For admin boundary layers with boundary property
-      // we have to de-activate the unique boundary and re-activate
-      // default boundaries
-      if ('boundary' in selectedLayer) {
-        const boundaryId = selectedLayer.boundary || '';
+        // For admin boundary layers with boundary property
+        // we have to de-activate the unique boundary and re-activate
+        // default boundaries
+        if ('boundary' in selectedLayer) {
+          const boundaryId = selectedLayer.boundary || '';
 
-        if (Object.keys(LayerDefinitions).includes(boundaryId)) {
-          const displayBoundaryLayers = getDisplayBoundaryLayers();
-          const uniqueBoundaryLayer = LayerDefinitions[boundaryId as LayerKey];
+          if (Object.keys(LayerDefinitions).includes(boundaryId)) {
+            const displayBoundaryLayers = getDisplayBoundaryLayers();
+            const uniqueBoundaryLayer =
+              LayerDefinitions[boundaryId as LayerKey];
 
-          if (
-            !displayBoundaryLayers
-              .map(l => l.id)
-              .includes(uniqueBoundaryLayer.id)
-          ) {
-            safeDispatchRemoveLayer(map, uniqueBoundaryLayer, dispatch);
+            if (
+              !displayBoundaryLayers
+                .map(l => l.id)
+                .includes(uniqueBoundaryLayer.id)
+            ) {
+              safeDispatchRemoveLayer(map, uniqueBoundaryLayer, dispatch);
+            }
+
+            displayBoundaryLayers.forEach(l => {
+              safeDispatchAddLayer(map, l, dispatch);
+            });
           }
-
-          displayBoundaryLayers.forEach(l => {
-            safeDispatchAddLayer(map, l, dispatch);
-          });
         }
       }
+    },
+    [
+      appendLayerToUrl,
+      dispatch,
+      group,
+      initialOpacity,
+      layer,
+      map,
+      removeLayerFromUrl,
+      selectedLayers,
+      updateHistory,
+    ],
+  );
+
+  const handleSelect = useCallback(
+    (event: React.ChangeEvent<{ value: string | unknown }>) => {
+      const selectedId = event.target.value;
+      setActiveLayer(selectedId as string);
+      toggleLayerValue(selectedId as string, true);
+    },
+    [toggleLayerValue],
+  );
+
+  const renderedGroupLayersMenuItems = useMemo(() => {
+    return group?.layers.map(menu => {
+      return (
+        <MenuItem key={menu.id} value={menu.id}>
+          {t(menu.label)}
+        </MenuItem>
+      );
+    });
+  }, [group, t]);
+
+  const renderedSelectGroupActivateAll = useMemo(() => {
+    if (group?.activateAll) {
+      return null;
     }
-  };
+    return (
+      <Select
+        className={classes.select}
+        classes={{
+          root: selected ? classes.selectItem : classes.selectItemUnchecked,
+        }}
+        value={activeLayer}
+        onChange={e => handleSelect(e)}
+      >
+        {renderedGroupLayersMenuItems}
+      </Select>
+    );
+  }, [
+    activeLayer,
+    classes.select,
+    classes.selectItem,
+    classes.selectItemUnchecked,
+    group,
+    handleSelect,
+    renderedGroupLayersMenuItems,
+    selected,
+  ]);
 
-  const handleSelect = (
-    event: React.ChangeEvent<{ value: string | unknown }>,
-  ) => {
-    const selectedId = event.target.value;
-    setActiveLayer(selectedId as string);
-    toggleLayerValue(selectedId as string, true);
-  };
-
-  const menuTitle = group ? (
-    <>
+  const menuTitle = useMemo(() => {
+    if (group) {
+      return (
+        <>
+          <Typography
+            className={selected ? classes.title : classes.titleUnchecked}
+          >
+            {validatedTitle}
+          </Typography>
+          {renderedSelectGroupActivateAll}
+        </>
+      );
+    }
+    return (
       <Typography className={selected ? classes.title : classes.titleUnchecked}>
         {validatedTitle}
       </Typography>
-      {!group.activateAll && (
-        <Select
-          className={classes.select}
-          classes={{
-            root: selected ? classes.selectItem : classes.selectItemUnchecked,
-          }}
-          value={activeLayer}
-          onChange={e => handleSelect(e)}
-        >
-          {group.layers.map(menu => (
-            <MenuItem key={menu.id} value={menu.id}>
-              {t(menu.label)}
-            </MenuItem>
-          ))}
-        </Select>
-      )}
-    </>
-  ) : (
-    <Typography className={selected ? classes.title : classes.titleUnchecked}>
-      {validatedTitle}
-    </Typography>
+    );
+  }, [
+    classes.title,
+    classes.titleUnchecked,
+    group,
+    renderedSelectGroupActivateAll,
+    selected,
+    validatedTitle,
+  ]);
+
+  const renderedExposureAnalysisOption = useMemo(() => {
+    if (!exposure) {
+      return null;
+    }
+    return (
+      <ExposureAnalysisOption
+        layer={layer}
+        extent={extent}
+        selected={selected}
+        exposure={exposure}
+      />
+    );
+  }, [exposure, extent, layer, selected]);
+
+  const handleOnChangeSliderValue = useCallback(
+    (event: ChangeEvent<{}>, newValue: number | number[]) => {
+      handleChangeOpacity(
+        event,
+        newValue as number,
+        map,
+        layerId,
+        layerType,
+        val => setOpacityValue(val),
+      );
+    },
+    [layerId, layerType, map],
   );
+
+  const renderedOpacitySlider = useMemo(() => {
+    if (!selected || !isOpacitySelected) {
+      return null;
+    }
+    return (
+      <Box display="flex" justifyContent="right" alignItems="center">
+        <Box pr={3}>
+          <Typography
+            classes={{ root: classes.opacityText }}
+          >{`Opacity ${Math.round(opacity * 100)}%`}</Typography>
+        </Box>
+        <Box width="25%" pr={3}>
+          <Slider
+            value={opacity}
+            step={0.01}
+            min={0}
+            max={1}
+            aria-labelledby="left-opacity-slider"
+            classes={{
+              root: classes.opacitySliderRoot,
+              thumb: classes.opacitySliderThumb,
+            }}
+            onChange={handleOnChangeSliderValue}
+          />
+        </Box>
+      </Box>
+    );
+  }, [
+    classes.opacitySliderRoot,
+    classes.opacitySliderThumb,
+    classes.opacityText,
+    handleOnChangeSliderValue,
+    isOpacitySelected,
+    opacity,
+    selected,
+  ]);
+
+  const handleOnChangeSwitch = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      toggleLayerValue(activeLayer, event.target.checked);
+    },
+    [activeLayer, toggleLayerValue],
+  );
+
   return (
     <Box display="flex" flexDirection="column" maxWidth="100%">
       <Box key={layerId} display="flex" alignItems="center" m={2}>
@@ -201,7 +330,7 @@ function SwitchItem({ classes, layer, extent }: SwitchItemProps) {
             track: classes.switchTrack,
           }}
           checked={selected}
-          onChange={e => toggleLayerValue(activeLayer, e.target.checked)}
+          onChange={handleOnChangeSwitch}
           inputProps={{
             'aria-label': validatedTitle,
           }}
@@ -222,55 +351,17 @@ function SwitchItem({ classes, layer, extent }: SwitchItemProps) {
             <OpacityIcon />
           </IconButton>
         </Tooltip>
-        {exposure && (
-          <ExposureAnalysisOption
-            layer={layer}
-            extent={extent}
-            selected={selected}
-            exposure={exposure}
-          />
-        )}
+        {renderedExposureAnalysisOption}
         <LayerDownloadOptions
           layer={layer}
           extent={extent}
           selected={selected}
         />
       </Box>
-      {selected && isOpacitySelected && (
-        <Box display="flex" justifyContent="right" alignItems="center">
-          <Box pr={3}>
-            <Typography
-              classes={{ root: classes.opacityText }}
-            >{`Opacity ${Math.round(opacity * 100)}%`}</Typography>
-          </Box>
-          <Box width="25%" pr={3}>
-            <Slider
-              value={opacity}
-              step={0.01}
-              min={0}
-              max={1}
-              aria-labelledby="left-opacity-slider"
-              classes={{
-                root: classes.opacitySliderRoot,
-                thumb: classes.opacitySliderThumb,
-              }}
-              onChange={(e, newValue) =>
-                handleChangeOpacity(
-                  e,
-                  newValue as number,
-                  map,
-                  layerId,
-                  layerType,
-                  val => setOpacityValue(val),
-                )
-              }
-            />
-          </Box>
-        </Box>
-      )}
+      {renderedOpacitySlider}
     </Box>
   );
-}
+});
 
 const styles = () =>
   createStyles({

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/__snapshots__/index.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`renders as expected 1`] = `
       tabindex="0"
     >
       <div
-        class="MuiAccordionSummary-content"
+        class="MuiAccordionSummary-content makeStyles-summaryContent-5"
       >
         <mock-typography
           classes="[object Object]"

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/index.tsx
@@ -3,6 +3,7 @@ import {
   AccordionDetails,
   AccordionSummary,
   Button,
+  Chip,
   createStyles,
   Grid,
   makeStyles,
@@ -10,13 +11,21 @@ import {
 } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import RemoveIcon from '@material-ui/icons/Remove';
-import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
+import React, {
+  ChangeEvent,
+  memo,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { isEqual } from 'lodash';
 import { LayerType, TableType } from '../../../../../config/types';
 import { loadTable } from '../../../../../context/tableStateSlice';
 import { useSafeTranslation } from '../../../../../i18n';
 import { Extent } from '../../../Layers/raster-utils';
 import SwitchItem from './SwitchItem';
+import { layersSelector } from '../../../../../context/mapStateSlice/selectors';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -34,6 +43,12 @@ const useStyles = makeStyles(() =>
     expandIcon: {
       color: '#53888F',
     },
+    summaryContent: {
+      alignItems: 'center',
+    },
+    chipRoot: {
+      marginLeft: '3%',
+    },
     title: {
       color: '#53888F',
       fontWeight: 500,
@@ -41,66 +56,129 @@ const useStyles = makeStyles(() =>
   }),
 );
 
-function MenuSwitch({
-  title,
-  layers,
-  tables,
-  extent,
-}: {
+interface MenuSwitchProps {
   title: string;
   layers: LayerType[];
   tables: TableType[];
   extent?: Extent;
-}) {
-  const { t } = useSafeTranslation();
-  const classes = useStyles();
-  const dispatch = useDispatch();
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  const showTableClicked = (table: TableType) => {
-    dispatch(loadTable(table.id));
-  };
-
-  return (
-    <Accordion
-      key={title}
-      elevation={0}
-      classes={{ root: classes.root }}
-      onChange={(_, expand) => setIsExpanded(expand)}
-    >
-      <AccordionSummary
-        expandIcon={isExpanded ? <RemoveIcon /> : <AddIcon />}
-        classes={{ root: classes.rootSummary, expandIcon: classes.expandIcon }}
-        aria-controls={title}
-        id={title}
-      >
-        <Typography classes={{ root: classes.title }}>{t(title)}</Typography>
-      </AccordionSummary>
-      <AccordionDetails classes={{ root: classes.rootDetails }}>
-        <Grid container direction="column">
-          {layers.map(layer => {
-            if (
-              layer.group &&
-              layer.group.layers.find(l => l.id === layer.id && !l.main)
-            ) {
-              return null;
-            }
-            return <SwitchItem key={layer.id} layer={layer} extent={extent} />;
-          })}
-
-          {tables.map(table => (
-            <Button
-              id={table.title}
-              key={table.title}
-              onClick={() => showTableClicked(table)}
-            >
-              <Typography variant="body1">{table.title}</Typography>
-            </Button>
-          ))}
-        </Grid>
-      </AccordionDetails>
-    </Accordion>
-  );
 }
+
+const MenuSwitch = memo(
+  ({ title, layers, tables, extent }: MenuSwitchProps) => {
+    const { t } = useSafeTranslation();
+    const selectedLayers = useSelector(layersSelector);
+    const classes = useStyles();
+    const dispatch = useDispatch();
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const showTableClicked = useCallback(
+      (table: TableType) => {
+        dispatch(loadTable(table.id));
+      },
+      [dispatch],
+    );
+
+    const handleAccordionExpand = useCallback(
+      (event: ChangeEvent<{}>, expanded: boolean) => {
+        setIsExpanded(expanded);
+      },
+      [],
+    );
+
+    const renderedItems = useMemo(() => {
+      return layers.map((layer: LayerType) => {
+        const foundNotRenderedLayer = layer.group?.layers.find(layerItem => {
+          return layerItem.id === layer.id && !layerItem.main;
+        });
+        if (layer.group && foundNotRenderedLayer) {
+          return null;
+        }
+        return <SwitchItem key={layer.id} layer={layer} extent={extent} />;
+      });
+    }, [extent, layers]);
+
+    const handleTableClick = useCallback(
+      (table: TableType) => {
+        return () => {
+          showTableClicked(table);
+        };
+      },
+      [showTableClicked],
+    );
+
+    const selectedInternalLayers = useMemo(() => {
+      return selectedLayers.filter(layer => {
+        return layers.some(internalLayer => {
+          return isEqual(internalLayer, layer);
+        });
+      });
+    }, [layers, selectedLayers]);
+
+    const renderedSelectedInternalLayerLabel = useMemo(() => {
+      return selectedInternalLayers.length === 1
+        ? `${selectedInternalLayers.length} ${t('Active Layer')}`
+        : `${selectedInternalLayers.length} ${t('Active Layers')}`;
+    }, [selectedInternalLayers.length, t]);
+
+    const renderedSelectedLayerInformation = useMemo(() => {
+      if (!selectedInternalLayers.length) {
+        return null;
+      }
+      return (
+        <Chip
+          classes={{ root: classes.chipRoot }}
+          color="secondary"
+          label={renderedSelectedInternalLayerLabel}
+        />
+      );
+    }, [
+      classes.chipRoot,
+      renderedSelectedInternalLayerLabel,
+      selectedInternalLayers.length,
+    ]);
+
+    const renderedTables = useMemo(() => {
+      return tables.map((table: TableType) => {
+        return (
+          <Button
+            id={table.title}
+            key={table.title}
+            onClick={handleTableClick(table)}
+          >
+            <Typography variant="body1">{table.title}</Typography>
+          </Button>
+        );
+      });
+    }, [handleTableClick, tables]);
+
+    return (
+      <Accordion
+        elevation={0}
+        classes={{ root: classes.root }}
+        onChange={handleAccordionExpand}
+      >
+        <AccordionSummary
+          expandIcon={isExpanded ? <RemoveIcon /> : <AddIcon />}
+          classes={{
+            root: classes.rootSummary,
+            expandIcon: classes.expandIcon,
+            content: classes.summaryContent,
+          }}
+          aria-controls={title}
+          id={title}
+        >
+          <Typography classes={{ root: classes.title }}>{t(title)}</Typography>
+          {renderedSelectedLayerInformation}
+        </AccordionSummary>
+        <AccordionDetails classes={{ root: classes.rootDetails }}>
+          <Grid container direction="column">
+            {renderedItems}
+            {renderedTables}
+          </Grid>
+        </AccordionDetails>
+      </Accordion>
+    );
+  },
+);
 
 export default MenuSwitch;

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/index.tsx
@@ -1,30 +1,27 @@
 import { Box } from '@material-ui/core';
-import React from 'react';
-import { useSelector } from 'react-redux';
-import { leftPanelTabValueSelector } from '../../../../context/leftPanelStateSlice';
+import React, { memo, useMemo } from 'react';
 import { Extent } from '../../Layers/raster-utils';
 import MenuItem from './MenuItem';
 import { menuList } from './utils';
+import { MenuItemType } from '../../../../config/types';
 
-const tabIndex = 0;
-
-function LayersPanel({ extent }: LayersPanelProps) {
-  const tabValue = useSelector(leftPanelTabValueSelector);
-
-  return (
-    <Box>
-      {menuList.map(({ title, ...category }) => (
+const LayersPanel = memo(({ extent }: LayersPanelProps) => {
+  const renderedRootAccordionItems = useMemo(() => {
+    return menuList.map((menuItem: MenuItemType) => {
+      return (
         <MenuItem
-          key={title}
-          title={title}
-          {...category}
+          key={menuItem.title}
+          title={menuItem.title}
+          layersCategories={menuItem.layersCategories}
+          icon={menuItem.icon}
           extent={extent}
-          shouldRender={tabIndex === tabValue}
         />
-      ))}
-    </Box>
-  );
-}
+      );
+    });
+  }, [extent]);
+
+  return <Box>{renderedRootAccordionItems}</Box>;
+});
 
 interface LayersPanelProps {
   extent?: Extent;

--- a/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`renders as expected 1`] = `
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-22"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -127,19 +127,19 @@ exports[`renders as expected 1`] = `
                             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                           >
                             <div
-                              class="MuiPaper-root MuiAccordion-root makeStyles-root-23 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                              class="MuiPaper-root MuiAccordion-root makeStyles-root-25 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
                             >
                               <div
                                 aria-controls="INAM Rainfall Data"
                                 aria-disabled="false"
                                 aria-expanded="false"
-                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-24"
+                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-26"
                                 id="INAM Rainfall Data"
                                 role="button"
                                 tabindex="0"
                               >
                                 <div
-                                  class="MuiAccordionSummary-content"
+                                  class="MuiAccordionSummary-content makeStyles-summaryContent-29"
                                 >
                                   <mock-typography
                                     classes="[object Object]"
@@ -150,7 +150,7 @@ exports[`renders as expected 1`] = `
                                 <div
                                   aria-disabled="false"
                                   aria-hidden="true"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-26 MuiIconButton-edgeEnd"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-28 MuiIconButton-edgeEnd"
                                 >
                                   <span
                                     class="MuiIconButton-label"
@@ -187,35 +187,35 @@ exports[`renders as expected 1`] = `
                                       role="region"
                                     >
                                       <div
-                                        class="MuiAccordionDetails-root makeStyles-rootDetails-25"
+                                        class="MuiAccordionDetails-root makeStyles-rootDetails-27"
                                       >
                                         <div
                                           class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                                         >
                                           <div
-                                            class="MuiBox-root MuiBox-root-41"
+                                            class="MuiBox-root MuiBox-root-45"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-42"
+                                              class="MuiBox-root MuiBox-root-46"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 Rainfall aggregate
                                               </mock-typography>
                                               <div
-                                                class="MuiInputBase-root MuiInput-root MuiInput-underline SwitchItem-select-30"
+                                                class="MuiInputBase-root MuiInput-root MuiInput-underline memo-select-34"
                                               >
                                                 <div
                                                   aria-haspopup="listbox"
-                                                  class="MuiSelect-root SwitchItem-selectItemUnchecked-32 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                                  class="MuiSelect-root memo-selectItemUnchecked-36 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
                                                   role="button"
                                                   tabindex="0"
                                                 >
@@ -293,7 +293,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -351,29 +351,29 @@ exports[`renders as expected 1`] = `
                                             </div>
                                           </div>
                                           <div
-                                            class="MuiBox-root MuiBox-root-43"
+                                            class="MuiBox-root MuiBox-root-47"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-44"
+                                              class="MuiBox-root MuiBox-root-48"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 Rainfall anomaly
                                               </mock-typography>
                                               <div
-                                                class="MuiInputBase-root MuiInput-root MuiInput-underline SwitchItem-select-30"
+                                                class="MuiInputBase-root MuiInput-root MuiInput-underline memo-select-34"
                                               >
                                                 <div
                                                   aria-haspopup="listbox"
-                                                  class="MuiSelect-root SwitchItem-selectItemUnchecked-32 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                                  class="MuiSelect-root memo-selectItemUnchecked-36 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
                                                   role="button"
                                                   tabindex="0"
                                                 >
@@ -451,7 +451,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -516,19 +516,19 @@ exports[`renders as expected 1`] = `
                               </div>
                             </div>
                             <div
-                              class="MuiPaper-root MuiAccordion-root makeStyles-root-23 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                              class="MuiPaper-root MuiAccordion-root makeStyles-root-25 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
                             >
                               <div
                                 aria-controls="Global Rainfall Products"
                                 aria-disabled="false"
                                 aria-expanded="false"
-                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-24"
+                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-26"
                                 id="Global Rainfall Products"
                                 role="button"
                                 tabindex="0"
                               >
                                 <div
-                                  class="MuiAccordionSummary-content"
+                                  class="MuiAccordionSummary-content makeStyles-summaryContent-29"
                                 >
                                   <mock-typography
                                     classes="[object Object]"
@@ -539,7 +539,7 @@ exports[`renders as expected 1`] = `
                                 <div
                                   aria-disabled="false"
                                   aria-hidden="true"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-26 MuiIconButton-edgeEnd"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-28 MuiIconButton-edgeEnd"
                                 >
                                   <span
                                     class="MuiIconButton-label"
@@ -576,35 +576,35 @@ exports[`renders as expected 1`] = `
                                       role="region"
                                     >
                                       <div
-                                        class="MuiAccordionDetails-root makeStyles-rootDetails-25"
+                                        class="MuiAccordionDetails-root makeStyles-rootDetails-27"
                                       >
                                         <div
                                           class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                                         >
                                           <div
-                                            class="MuiBox-root MuiBox-root-45"
+                                            class="MuiBox-root MuiBox-root-49"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-46"
+                                              class="MuiBox-root MuiBox-root-50"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 Rainfall aggregate
                                               </mock-typography>
                                               <div
-                                                class="MuiInputBase-root MuiInput-root MuiInput-underline SwitchItem-select-30"
+                                                class="MuiInputBase-root MuiInput-root MuiInput-underline memo-select-34"
                                               >
                                                 <div
                                                   aria-haspopup="listbox"
-                                                  class="MuiSelect-root SwitchItem-selectItemUnchecked-32 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                                  class="MuiSelect-root memo-selectItemUnchecked-36 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
                                                   role="button"
                                                   tabindex="0"
                                                 >
@@ -682,7 +682,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -740,29 +740,29 @@ exports[`renders as expected 1`] = `
                                             </div>
                                           </div>
                                           <div
-                                            class="MuiBox-root MuiBox-root-47"
+                                            class="MuiBox-root MuiBox-root-51"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-48"
+                                              class="MuiBox-root MuiBox-root-52"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 Rainfall anomaly
                                               </mock-typography>
                                               <div
-                                                class="MuiInputBase-root MuiInput-root MuiInput-underline SwitchItem-select-30"
+                                                class="MuiInputBase-root MuiInput-root MuiInput-underline memo-select-34"
                                               >
                                                 <div
                                                   aria-haspopup="listbox"
-                                                  class="MuiSelect-root SwitchItem-selectItemUnchecked-32 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                                  class="MuiSelect-root memo-selectItemUnchecked-36 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
                                                   role="button"
                                                   tabindex="0"
                                                 >
@@ -840,7 +840,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -898,29 +898,29 @@ exports[`renders as expected 1`] = `
                                             </div>
                                           </div>
                                           <div
-                                            class="MuiBox-root MuiBox-root-49"
+                                            class="MuiBox-root MuiBox-root-53"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-50"
+                                              class="MuiBox-root MuiBox-root-54"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 SPI
                                               </mock-typography>
                                               <div
-                                                class="MuiInputBase-root MuiInput-root MuiInput-underline SwitchItem-select-30"
+                                                class="MuiInputBase-root MuiInput-root MuiInput-underline memo-select-34"
                                               >
                                                 <div
                                                   aria-haspopup="listbox"
-                                                  class="MuiSelect-root SwitchItem-selectItemUnchecked-32 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                                  class="MuiSelect-root memo-selectItemUnchecked-36 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
                                                   role="button"
                                                   tabindex="0"
                                                 >
@@ -991,7 +991,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -1056,19 +1056,19 @@ exports[`renders as expected 1`] = `
                               </div>
                             </div>
                             <div
-                              class="MuiPaper-root MuiAccordion-root makeStyles-root-23 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                              class="MuiPaper-root MuiAccordion-root makeStyles-root-25 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
                             >
                               <div
                                 aria-controls="Dry Periods"
                                 aria-disabled="false"
                                 aria-expanded="false"
-                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-24"
+                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-26"
                                 id="Dry Periods"
                                 role="button"
                                 tabindex="0"
                               >
                                 <div
-                                  class="MuiAccordionSummary-content"
+                                  class="MuiAccordionSummary-content makeStyles-summaryContent-29"
                                 >
                                   <mock-typography
                                     classes="[object Object]"
@@ -1079,7 +1079,7 @@ exports[`renders as expected 1`] = `
                                 <div
                                   aria-disabled="false"
                                   aria-hidden="true"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-26 MuiIconButton-edgeEnd"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-28 MuiIconButton-edgeEnd"
                                 >
                                   <span
                                     class="MuiIconButton-label"
@@ -1116,238 +1116,7 @@ exports[`renders as expected 1`] = `
                                       role="region"
                                     >
                                       <div
-                                        class="MuiAccordionDetails-root makeStyles-rootDetails-25"
-                                      >
-                                        <div
-                                          class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
-                                        >
-                                          <div
-                                            class="MuiBox-root MuiBox-root-51"
-                                          >
-                                            <div
-                                              class="MuiBox-root MuiBox-root-52"
-                                            >
-                                              <mock-switch
-                                                checked="false"
-                                                classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
-                                                inputprops="[object Object]"
-                                                size="small"
-                                              />
-                                              <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
-                                              >
-                                                Days since last rain
-                                              </mock-typography>
-                                              <mock-tooltip
-                                                title="Opacity"
-                                              >
-                                                <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
-                                                  disabled=""
-                                                  tabindex="-1"
-                                                  type="button"
-                                                >
-                                                  <span
-                                                    class="MuiIconButton-label"
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      class="MuiSvgIcon-root"
-                                                      focusable="false"
-                                                      viewBox="0 0 24 24"
-                                                    >
-                                                      <path
-                                                        d="M17.66 8L12 2.35 6.34 8C4.78 9.56 4 11.64 4 13.64s.78 4.11 2.34 5.67 3.61 2.35 5.66 2.35 4.1-.79 5.66-2.35S20 15.64 20 13.64 19.22 9.56 17.66 8zM6 14c.01-2 .62-3.27 1.76-4.4L12 5.27l4.24 4.38C17.38 10.77 17.99 12 18 14H6z"
-                                                      />
-                                                    </svg>
-                                                  </span>
-                                                </button>
-                                              </mock-tooltip>
-                                              <mock-tooltip
-                                                title="Download"
-                                              >
-                                                <button
-                                                  class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
-                                                  disabled=""
-                                                  tabindex="-1"
-                                                  type="button"
-                                                >
-                                                  <span
-                                                    class="MuiIconButton-label"
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      class="MuiSvgIcon-root"
-                                                      focusable="false"
-                                                      viewBox="0 0 24 24"
-                                                    >
-                                                      <path
-                                                        d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                                                      />
-                                                    </svg>
-                                                  </span>
-                                                </button>
-                                              </mock-tooltip>
-                                              <mock-menu
-                                                id="download-menu"
-                                                keepmounted="true"
-                                                open="false"
-                                              >
-                                                <mock-menuitem>
-                                                  Download as GeoTIFF
-                                                </mock-menuitem>
-                                              </mock-menu>
-                                            </div>
-                                          </div>
-                                          <div
-                                            class="MuiBox-root MuiBox-root-53"
-                                          >
-                                            <div
-                                              class="MuiBox-root MuiBox-root-54"
-                                            >
-                                              <mock-switch
-                                                checked="false"
-                                                classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
-                                                inputprops="[object Object]"
-                                                size="small"
-                                              />
-                                              <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
-                                              >
-                                                Longest dry spell
-                                              </mock-typography>
-                                              <mock-tooltip
-                                                title="Opacity"
-                                              >
-                                                <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
-                                                  disabled=""
-                                                  tabindex="-1"
-                                                  type="button"
-                                                >
-                                                  <span
-                                                    class="MuiIconButton-label"
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      class="MuiSvgIcon-root"
-                                                      focusable="false"
-                                                      viewBox="0 0 24 24"
-                                                    >
-                                                      <path
-                                                        d="M17.66 8L12 2.35 6.34 8C4.78 9.56 4 11.64 4 13.64s.78 4.11 2.34 5.67 3.61 2.35 5.66 2.35 4.1-.79 5.66-2.35S20 15.64 20 13.64 19.22 9.56 17.66 8zM6 14c.01-2 .62-3.27 1.76-4.4L12 5.27l4.24 4.38C17.38 10.77 17.99 12 18 14H6z"
-                                                      />
-                                                    </svg>
-                                                  </span>
-                                                </button>
-                                              </mock-tooltip>
-                                              <mock-tooltip
-                                                title="Download"
-                                              >
-                                                <button
-                                                  class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
-                                                  disabled=""
-                                                  tabindex="-1"
-                                                  type="button"
-                                                >
-                                                  <span
-                                                    class="MuiIconButton-label"
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      class="MuiSvgIcon-root"
-                                                      focusable="false"
-                                                      viewBox="0 0 24 24"
-                                                    >
-                                                      <path
-                                                        d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                                                      />
-                                                    </svg>
-                                                  </span>
-                                                </button>
-                                              </mock-tooltip>
-                                              <mock-menu
-                                                id="download-menu"
-                                                keepmounted="true"
-                                                open="false"
-                                              >
-                                                <mock-menuitem>
-                                                  Download as GeoTIFF
-                                                </mock-menuitem>
-                                              </mock-menu>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="MuiPaper-root MuiAccordion-root makeStyles-root-23 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
-                            >
-                              <div
-                                aria-controls="Extreme Rain Events"
-                                aria-disabled="false"
-                                aria-expanded="false"
-                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-24"
-                                id="Extreme Rain Events"
-                                role="button"
-                                tabindex="0"
-                              >
-                                <div
-                                  class="MuiAccordionSummary-content"
-                                >
-                                  <mock-typography
-                                    classes="[object Object]"
-                                  >
-                                    Extreme Rain Events
-                                  </mock-typography>
-                                </div>
-                                <div
-                                  aria-disabled="false"
-                                  aria-hidden="true"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-26 MuiIconButton-edgeEnd"
-                                >
-                                  <span
-                                    class="MuiIconButton-label"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MuiSvgIcon-root"
-                                      focusable="false"
-                                      viewBox="0 0 24 24"
-                                    >
-                                      <path
-                                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                                      />
-                                    </svg>
-                                  </span>
-                                  <span
-                                    class="MuiTouchRipple-root"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                class="MuiCollapse-container MuiCollapse-hidden"
-                                style="min-height: 0px;"
-                              >
-                                <div
-                                  class="MuiCollapse-wrapper"
-                                >
-                                  <div
-                                    class="MuiCollapse-wrapperInner"
-                                  >
-                                    <div
-                                      aria-labelledby="Extreme Rain Events"
-                                      id="Extreme Rain Events"
-                                      role="region"
-                                    >
-                                      <div
-                                        class="MuiAccordionDetails-root makeStyles-rootDetails-25"
+                                        class="MuiAccordionDetails-root makeStyles-rootDetails-27"
                                       >
                                         <div
                                           class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
@@ -1361,78 +1130,20 @@ exports[`renders as expected 1`] = `
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
-                                                Rainfall categories:
+                                                Days since last rain
                                               </mock-typography>
-                                              <div
-                                                class="MuiInputBase-root MuiInput-root MuiInput-underline SwitchItem-select-30"
-                                              >
-                                                <div
-                                                  aria-haspopup="listbox"
-                                                  class="MuiSelect-root SwitchItem-selectItemUnchecked-32 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-                                                  role="button"
-                                                  tabindex="0"
-                                                >
-                                                  Heavy (&gt;75th percentile)
-                                                </div>
-                                                <input
-                                                  aria-hidden="true"
-                                                  class="MuiSelect-nativeInput"
-                                                  tabindex="-1"
-                                                  value="days_heavy_rain"
-                                                />
-                                                <svg
-                                                  aria-hidden="true"
-                                                  class="MuiSvgIcon-root MuiSelect-icon"
-                                                  focusable="false"
-                                                  viewBox="0 0 24 24"
-                                                >
-                                                  <path
-                                                    d="M7 10l5 5 5-5z"
-                                                  />
-                                                </svg>
-                                                <mock-menu
-                                                  anchorel="[object HTMLDivElement]"
-                                                  id="menu-"
-                                                  menulistprops="[object Object]"
-                                                  open="false"
-                                                  paperprops="[object Object]"
-                                                >
-                                                  <mock-menuitem
-                                                    aria-selected="true"
-                                                    data-value="days_heavy_rain"
-                                                    role="option"
-                                                    selected="true"
-                                                  >
-                                                    Heavy (&gt;75th percentile)
-                                                  </mock-menuitem>
-                                                  <mock-menuitem
-                                                    data-value="days_intense_rain"
-                                                    role="option"
-                                                    selected="false"
-                                                  >
-                                                    Intense (&gt;90th percentile)
-                                                  </mock-menuitem>
-                                                  <mock-menuitem
-                                                    data-value="days_extreme_rain"
-                                                    role="option"
-                                                    selected="false"
-                                                  >
-                                                    Extreme (&gt;95th percentile)
-                                                  </mock-menuitem>
-                                                </mock-menu>
-                                              </div>
                                               <mock-tooltip
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -1498,21 +1209,310 @@ exports[`renders as expected 1`] = `
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
+                                              >
+                                                Longest dry spell
+                                              </mock-typography>
+                                              <mock-tooltip
+                                                title="Opacity"
+                                              >
+                                                <button
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
+                                                  disabled=""
+                                                  tabindex="-1"
+                                                  type="button"
+                                                >
+                                                  <span
+                                                    class="MuiIconButton-label"
+                                                  >
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      class="MuiSvgIcon-root"
+                                                      focusable="false"
+                                                      viewBox="0 0 24 24"
+                                                    >
+                                                      <path
+                                                        d="M17.66 8L12 2.35 6.34 8C4.78 9.56 4 11.64 4 13.64s.78 4.11 2.34 5.67 3.61 2.35 5.66 2.35 4.1-.79 5.66-2.35S20 15.64 20 13.64 19.22 9.56 17.66 8zM6 14c.01-2 .62-3.27 1.76-4.4L12 5.27l4.24 4.38C17.38 10.77 17.99 12 18 14H6z"
+                                                      />
+                                                    </svg>
+                                                  </span>
+                                                </button>
+                                              </mock-tooltip>
+                                              <mock-tooltip
+                                                title="Download"
+                                              >
+                                                <button
+                                                  class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
+                                                  disabled=""
+                                                  tabindex="-1"
+                                                  type="button"
+                                                >
+                                                  <span
+                                                    class="MuiIconButton-label"
+                                                  >
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      class="MuiSvgIcon-root"
+                                                      focusable="false"
+                                                      viewBox="0 0 24 24"
+                                                    >
+                                                      <path
+                                                        d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                                                      />
+                                                    </svg>
+                                                  </span>
+                                                </button>
+                                              </mock-tooltip>
+                                              <mock-menu
+                                                id="download-menu"
+                                                keepmounted="true"
+                                                open="false"
+                                              >
+                                                <mock-menuitem>
+                                                  Download as GeoTIFF
+                                                </mock-menuitem>
+                                              </mock-menu>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="MuiPaper-root MuiAccordion-root makeStyles-root-25 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                            >
+                              <div
+                                aria-controls="Extreme Rain Events"
+                                aria-disabled="false"
+                                aria-expanded="false"
+                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-26"
+                                id="Extreme Rain Events"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="MuiAccordionSummary-content makeStyles-summaryContent-29"
+                                >
+                                  <mock-typography
+                                    classes="[object Object]"
+                                  >
+                                    Extreme Rain Events
+                                  </mock-typography>
+                                </div>
+                                <div
+                                  aria-disabled="false"
+                                  aria-hidden="true"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-28 MuiIconButton-edgeEnd"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                class="MuiCollapse-container MuiCollapse-hidden"
+                                style="min-height: 0px;"
+                              >
+                                <div
+                                  class="MuiCollapse-wrapper"
+                                >
+                                  <div
+                                    class="MuiCollapse-wrapperInner"
+                                  >
+                                    <div
+                                      aria-labelledby="Extreme Rain Events"
+                                      id="Extreme Rain Events"
+                                      role="region"
+                                    >
+                                      <div
+                                        class="MuiAccordionDetails-root makeStyles-rootDetails-27"
+                                      >
+                                        <div
+                                          class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
+                                        >
+                                          <div
+                                            class="MuiBox-root MuiBox-root-59"
+                                          >
+                                            <div
+                                              class="MuiBox-root MuiBox-root-60"
+                                            >
+                                              <mock-switch
+                                                checked="false"
+                                                classes="[object Object]"
+                                                classname="memo-switch-37"
+                                                inputprops="[object Object]"
+                                                size="small"
+                                              />
+                                              <mock-typography
+                                                classname="memo-titleUnchecked-33"
+                                              >
+                                                Rainfall categories:
+                                              </mock-typography>
+                                              <div
+                                                class="MuiInputBase-root MuiInput-root MuiInput-underline memo-select-34"
+                                              >
+                                                <div
+                                                  aria-haspopup="listbox"
+                                                  class="MuiSelect-root memo-selectItemUnchecked-36 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                                  role="button"
+                                                  tabindex="0"
+                                                >
+                                                  Heavy (&gt;75th percentile)
+                                                </div>
+                                                <input
+                                                  aria-hidden="true"
+                                                  class="MuiSelect-nativeInput"
+                                                  tabindex="-1"
+                                                  value="days_heavy_rain"
+                                                />
+                                                <svg
+                                                  aria-hidden="true"
+                                                  class="MuiSvgIcon-root MuiSelect-icon"
+                                                  focusable="false"
+                                                  viewBox="0 0 24 24"
+                                                >
+                                                  <path
+                                                    d="M7 10l5 5 5-5z"
+                                                  />
+                                                </svg>
+                                                <mock-menu
+                                                  anchorel="[object HTMLDivElement]"
+                                                  id="menu-"
+                                                  menulistprops="[object Object]"
+                                                  open="false"
+                                                  paperprops="[object Object]"
+                                                >
+                                                  <mock-menuitem
+                                                    aria-selected="true"
+                                                    data-value="days_heavy_rain"
+                                                    role="option"
+                                                    selected="true"
+                                                  >
+                                                    Heavy (&gt;75th percentile)
+                                                  </mock-menuitem>
+                                                  <mock-menuitem
+                                                    data-value="days_intense_rain"
+                                                    role="option"
+                                                    selected="false"
+                                                  >
+                                                    Intense (&gt;90th percentile)
+                                                  </mock-menuitem>
+                                                  <mock-menuitem
+                                                    data-value="days_extreme_rain"
+                                                    role="option"
+                                                    selected="false"
+                                                  >
+                                                    Extreme (&gt;95th percentile)
+                                                  </mock-menuitem>
+                                                </mock-menu>
+                                              </div>
+                                              <mock-tooltip
+                                                title="Opacity"
+                                              >
+                                                <button
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
+                                                  disabled=""
+                                                  tabindex="-1"
+                                                  type="button"
+                                                >
+                                                  <span
+                                                    class="MuiIconButton-label"
+                                                  >
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      class="MuiSvgIcon-root"
+                                                      focusable="false"
+                                                      viewBox="0 0 24 24"
+                                                    >
+                                                      <path
+                                                        d="M17.66 8L12 2.35 6.34 8C4.78 9.56 4 11.64 4 13.64s.78 4.11 2.34 5.67 3.61 2.35 5.66 2.35 4.1-.79 5.66-2.35S20 15.64 20 13.64 19.22 9.56 17.66 8zM6 14c.01-2 .62-3.27 1.76-4.4L12 5.27l4.24 4.38C17.38 10.77 17.99 12 18 14H6z"
+                                                      />
+                                                    </svg>
+                                                  </span>
+                                                </button>
+                                              </mock-tooltip>
+                                              <mock-tooltip
+                                                title="Download"
+                                              >
+                                                <button
+                                                  class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
+                                                  disabled=""
+                                                  tabindex="-1"
+                                                  type="button"
+                                                >
+                                                  <span
+                                                    class="MuiIconButton-label"
+                                                  >
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      class="MuiSvgIcon-root"
+                                                      focusable="false"
+                                                      viewBox="0 0 24 24"
+                                                    >
+                                                      <path
+                                                        d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                                                      />
+                                                    </svg>
+                                                  </span>
+                                                </button>
+                                              </mock-tooltip>
+                                              <mock-menu
+                                                id="download-menu"
+                                                keepmounted="true"
+                                                open="false"
+                                              >
+                                                <mock-menuitem>
+                                                  Download as GeoTIFF
+                                                </mock-menuitem>
+                                              </mock-menu>
+                                            </div>
+                                          </div>
+                                          <div
+                                            class="MuiBox-root MuiBox-root-61"
+                                          >
+                                            <div
+                                              class="MuiBox-root MuiBox-root-62"
+                                            >
+                                              <mock-switch
+                                                checked="false"
+                                                classes="[object Object]"
+                                                classname="memo-switch-37"
+                                                inputprops="[object Object]"
+                                                size="small"
+                                              />
+                                              <mock-typography
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 Consecutive days of rainfall:
                                               </mock-typography>
                                               <div
-                                                class="MuiInputBase-root MuiInput-root MuiInput-underline SwitchItem-select-30"
+                                                class="MuiInputBase-root MuiInput-root MuiInput-underline memo-select-34"
                                               >
                                                 <div
                                                   aria-haspopup="listbox"
-                                                  class="MuiSelect-root SwitchItem-selectItemUnchecked-32 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                                  class="MuiSelect-root memo-selectItemUnchecked-36 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
                                                   role="button"
                                                   tabindex="0"
                                                 >
@@ -1569,7 +1569,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -1653,7 +1653,7 @@ exports[`renders as expected 1`] = `
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-22"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -1707,19 +1707,19 @@ exports[`renders as expected 1`] = `
                             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                           >
                             <div
-                              class="MuiPaper-root MuiAccordion-root makeStyles-root-23 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                              class="MuiPaper-root MuiAccordion-root makeStyles-root-25 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
                             >
                               <div
                                 aria-controls="Vegetation Conditions"
                                 aria-disabled="false"
                                 aria-expanded="false"
-                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-24"
+                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-26"
                                 id="Vegetation Conditions"
                                 role="button"
                                 tabindex="0"
                               >
                                 <div
-                                  class="MuiAccordionSummary-content"
+                                  class="MuiAccordionSummary-content makeStyles-summaryContent-29"
                                 >
                                   <mock-typography
                                     classes="[object Object]"
@@ -1730,7 +1730,7 @@ exports[`renders as expected 1`] = `
                                 <div
                                   aria-disabled="false"
                                   aria-hidden="true"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-26 MuiIconButton-edgeEnd"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-28 MuiIconButton-edgeEnd"
                                 >
                                   <span
                                     class="MuiIconButton-label"
@@ -1767,26 +1767,26 @@ exports[`renders as expected 1`] = `
                                       role="region"
                                     >
                                       <div
-                                        class="MuiAccordionDetails-root makeStyles-rootDetails-25"
+                                        class="MuiAccordionDetails-root makeStyles-rootDetails-27"
                                       >
                                         <div
                                           class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                                         >
                                           <div
-                                            class="MuiBox-root MuiBox-root-59"
+                                            class="MuiBox-root MuiBox-root-63"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-60"
+                                              class="MuiBox-root MuiBox-root-64"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 10-day NDVI (MODIS)
                                               </mock-typography>
@@ -1794,7 +1794,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -1852,20 +1852,20 @@ exports[`renders as expected 1`] = `
                                             </div>
                                           </div>
                                           <div
-                                            class="MuiBox-root MuiBox-root-61"
+                                            class="MuiBox-root MuiBox-root-65"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-62"
+                                              class="MuiBox-root MuiBox-root-66"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 10-day NDVI anomaly (MODIS)
                                               </mock-typography>
@@ -1873,7 +1873,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -1957,7 +1957,7 @@ exports[`renders as expected 1`] = `
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-22"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -2011,19 +2011,19 @@ exports[`renders as expected 1`] = `
                             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                           >
                             <div
-                              class="MuiPaper-root MuiAccordion-root makeStyles-root-23 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                              class="MuiPaper-root MuiAccordion-root makeStyles-root-25 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
                             >
                               <div
                                 aria-controls="INAM Air Temperature"
                                 aria-disabled="false"
                                 aria-expanded="false"
-                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-24"
+                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-26"
                                 id="INAM Air Temperature"
                                 role="button"
                                 tabindex="0"
                               >
                                 <div
-                                  class="MuiAccordionSummary-content"
+                                  class="MuiAccordionSummary-content makeStyles-summaryContent-29"
                                 >
                                   <mock-typography
                                     classes="[object Object]"
@@ -2034,7 +2034,7 @@ exports[`renders as expected 1`] = `
                                 <div
                                   aria-disabled="false"
                                   aria-hidden="true"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-26 MuiIconButton-edgeEnd"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-28 MuiIconButton-edgeEnd"
                                 >
                                   <span
                                     class="MuiIconButton-label"
@@ -2071,238 +2071,7 @@ exports[`renders as expected 1`] = `
                                       role="region"
                                     >
                                       <div
-                                        class="MuiAccordionDetails-root makeStyles-rootDetails-25"
-                                      >
-                                        <div
-                                          class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
-                                        >
-                                          <div
-                                            class="MuiBox-root MuiBox-root-63"
-                                          >
-                                            <div
-                                              class="MuiBox-root MuiBox-root-64"
-                                            >
-                                              <mock-switch
-                                                checked="false"
-                                                classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
-                                                inputprops="[object Object]"
-                                                size="small"
-                                              />
-                                              <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
-                                              >
-                                                INAM mean maximum air temperature (10-day)
-                                              </mock-typography>
-                                              <mock-tooltip
-                                                title="Opacity"
-                                              >
-                                                <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
-                                                  disabled=""
-                                                  tabindex="-1"
-                                                  type="button"
-                                                >
-                                                  <span
-                                                    class="MuiIconButton-label"
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      class="MuiSvgIcon-root"
-                                                      focusable="false"
-                                                      viewBox="0 0 24 24"
-                                                    >
-                                                      <path
-                                                        d="M17.66 8L12 2.35 6.34 8C4.78 9.56 4 11.64 4 13.64s.78 4.11 2.34 5.67 3.61 2.35 5.66 2.35 4.1-.79 5.66-2.35S20 15.64 20 13.64 19.22 9.56 17.66 8zM6 14c.01-2 .62-3.27 1.76-4.4L12 5.27l4.24 4.38C17.38 10.77 17.99 12 18 14H6z"
-                                                      />
-                                                    </svg>
-                                                  </span>
-                                                </button>
-                                              </mock-tooltip>
-                                              <mock-tooltip
-                                                title="Download"
-                                              >
-                                                <button
-                                                  class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
-                                                  disabled=""
-                                                  tabindex="-1"
-                                                  type="button"
-                                                >
-                                                  <span
-                                                    class="MuiIconButton-label"
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      class="MuiSvgIcon-root"
-                                                      focusable="false"
-                                                      viewBox="0 0 24 24"
-                                                    >
-                                                      <path
-                                                        d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                                                      />
-                                                    </svg>
-                                                  </span>
-                                                </button>
-                                              </mock-tooltip>
-                                              <mock-menu
-                                                id="download-menu"
-                                                keepmounted="true"
-                                                open="false"
-                                              >
-                                                <mock-menuitem>
-                                                  Download as GeoTIFF
-                                                </mock-menuitem>
-                                              </mock-menu>
-                                            </div>
-                                          </div>
-                                          <div
-                                            class="MuiBox-root MuiBox-root-65"
-                                          >
-                                            <div
-                                              class="MuiBox-root MuiBox-root-66"
-                                            >
-                                              <mock-switch
-                                                checked="false"
-                                                classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
-                                                inputprops="[object Object]"
-                                                size="small"
-                                              />
-                                              <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
-                                              >
-                                                INAM mean maximum air temperature anomaly (10-day)
-                                              </mock-typography>
-                                              <mock-tooltip
-                                                title="Opacity"
-                                              >
-                                                <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
-                                                  disabled=""
-                                                  tabindex="-1"
-                                                  type="button"
-                                                >
-                                                  <span
-                                                    class="MuiIconButton-label"
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      class="MuiSvgIcon-root"
-                                                      focusable="false"
-                                                      viewBox="0 0 24 24"
-                                                    >
-                                                      <path
-                                                        d="M17.66 8L12 2.35 6.34 8C4.78 9.56 4 11.64 4 13.64s.78 4.11 2.34 5.67 3.61 2.35 5.66 2.35 4.1-.79 5.66-2.35S20 15.64 20 13.64 19.22 9.56 17.66 8zM6 14c.01-2 .62-3.27 1.76-4.4L12 5.27l4.24 4.38C17.38 10.77 17.99 12 18 14H6z"
-                                                      />
-                                                    </svg>
-                                                  </span>
-                                                </button>
-                                              </mock-tooltip>
-                                              <mock-tooltip
-                                                title="Download"
-                                              >
-                                                <button
-                                                  class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
-                                                  disabled=""
-                                                  tabindex="-1"
-                                                  type="button"
-                                                >
-                                                  <span
-                                                    class="MuiIconButton-label"
-                                                  >
-                                                    <svg
-                                                      aria-hidden="true"
-                                                      class="MuiSvgIcon-root"
-                                                      focusable="false"
-                                                      viewBox="0 0 24 24"
-                                                    >
-                                                      <path
-                                                        d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                                                      />
-                                                    </svg>
-                                                  </span>
-                                                </button>
-                                              </mock-tooltip>
-                                              <mock-menu
-                                                id="download-menu"
-                                                keepmounted="true"
-                                                open="false"
-                                              >
-                                                <mock-menuitem>
-                                                  Download as GeoTIFF
-                                                </mock-menuitem>
-                                              </mock-menu>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="MuiPaper-root MuiAccordion-root makeStyles-root-23 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
-                            >
-                              <div
-                                aria-controls="Land Surface Temperature"
-                                aria-disabled="false"
-                                aria-expanded="false"
-                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-24"
-                                id="Land Surface Temperature"
-                                role="button"
-                                tabindex="0"
-                              >
-                                <div
-                                  class="MuiAccordionSummary-content"
-                                >
-                                  <mock-typography
-                                    classes="[object Object]"
-                                  >
-                                    Land Surface Temperature
-                                  </mock-typography>
-                                </div>
-                                <div
-                                  aria-disabled="false"
-                                  aria-hidden="true"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-26 MuiIconButton-edgeEnd"
-                                >
-                                  <span
-                                    class="MuiIconButton-label"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      class="MuiSvgIcon-root"
-                                      focusable="false"
-                                      viewBox="0 0 24 24"
-                                    >
-                                      <path
-                                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                                      />
-                                    </svg>
-                                  </span>
-                                  <span
-                                    class="MuiTouchRipple-root"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                class="MuiCollapse-container MuiCollapse-hidden"
-                                style="min-height: 0px;"
-                              >
-                                <div
-                                  class="MuiCollapse-wrapper"
-                                >
-                                  <div
-                                    class="MuiCollapse-wrapperInner"
-                                  >
-                                    <div
-                                      aria-labelledby="Land Surface Temperature"
-                                      id="Land Surface Temperature"
-                                      role="region"
-                                    >
-                                      <div
-                                        class="MuiAccordionDetails-root makeStyles-rootDetails-25"
+                                        class="MuiAccordionDetails-root makeStyles-rootDetails-27"
                                       >
                                         <div
                                           class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
@@ -2316,20 +2085,20 @@ exports[`renders as expected 1`] = `
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
-                                                Daytime Land Surface Temperature - 10-day (MODIS)
+                                                INAM mean maximum air temperature (10-day)
                                               </mock-typography>
                                               <mock-tooltip
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -2395,20 +2164,172 @@ exports[`renders as expected 1`] = `
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
-                                                Daytime Land Surface Temperature - 10-day Anomaly (MODIS)
+                                                INAM mean maximum air temperature anomaly (10-day)
                                               </mock-typography>
                                               <mock-tooltip
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
+                                                  disabled=""
+                                                  tabindex="-1"
+                                                  type="button"
+                                                >
+                                                  <span
+                                                    class="MuiIconButton-label"
+                                                  >
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      class="MuiSvgIcon-root"
+                                                      focusable="false"
+                                                      viewBox="0 0 24 24"
+                                                    >
+                                                      <path
+                                                        d="M17.66 8L12 2.35 6.34 8C4.78 9.56 4 11.64 4 13.64s.78 4.11 2.34 5.67 3.61 2.35 5.66 2.35 4.1-.79 5.66-2.35S20 15.64 20 13.64 19.22 9.56 17.66 8zM6 14c.01-2 .62-3.27 1.76-4.4L12 5.27l4.24 4.38C17.38 10.77 17.99 12 18 14H6z"
+                                                      />
+                                                    </svg>
+                                                  </span>
+                                                </button>
+                                              </mock-tooltip>
+                                              <mock-tooltip
+                                                title="Download"
+                                              >
+                                                <button
+                                                  class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
+                                                  disabled=""
+                                                  tabindex="-1"
+                                                  type="button"
+                                                >
+                                                  <span
+                                                    class="MuiIconButton-label"
+                                                  >
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      class="MuiSvgIcon-root"
+                                                      focusable="false"
+                                                      viewBox="0 0 24 24"
+                                                    >
+                                                      <path
+                                                        d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                                                      />
+                                                    </svg>
+                                                  </span>
+                                                </button>
+                                              </mock-tooltip>
+                                              <mock-menu
+                                                id="download-menu"
+                                                keepmounted="true"
+                                                open="false"
+                                              >
+                                                <mock-menuitem>
+                                                  Download as GeoTIFF
+                                                </mock-menuitem>
+                                              </mock-menu>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="MuiPaper-root MuiAccordion-root makeStyles-root-25 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                            >
+                              <div
+                                aria-controls="Land Surface Temperature"
+                                aria-disabled="false"
+                                aria-expanded="false"
+                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-26"
+                                id="Land Surface Temperature"
+                                role="button"
+                                tabindex="0"
+                              >
+                                <div
+                                  class="MuiAccordionSummary-content makeStyles-summaryContent-29"
+                                >
+                                  <mock-typography
+                                    classes="[object Object]"
+                                  >
+                                    Land Surface Temperature
+                                  </mock-typography>
+                                </div>
+                                <div
+                                  aria-disabled="false"
+                                  aria-hidden="true"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-28 MuiIconButton-edgeEnd"
+                                >
+                                  <span
+                                    class="MuiIconButton-label"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                class="MuiCollapse-container MuiCollapse-hidden"
+                                style="min-height: 0px;"
+                              >
+                                <div
+                                  class="MuiCollapse-wrapper"
+                                >
+                                  <div
+                                    class="MuiCollapse-wrapperInner"
+                                  >
+                                    <div
+                                      aria-labelledby="Land Surface Temperature"
+                                      id="Land Surface Temperature"
+                                      role="region"
+                                    >
+                                      <div
+                                        class="MuiAccordionDetails-root makeStyles-rootDetails-27"
+                                      >
+                                        <div
+                                          class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
+                                        >
+                                          <div
+                                            class="MuiBox-root MuiBox-root-71"
+                                          >
+                                            <div
+                                              class="MuiBox-root MuiBox-root-72"
+                                            >
+                                              <mock-switch
+                                                checked="false"
+                                                classes="[object Object]"
+                                                classname="memo-switch-37"
+                                                inputprops="[object Object]"
+                                                size="small"
+                                              />
+                                              <mock-typography
+                                                classname="memo-titleUnchecked-33"
+                                              >
+                                                Daytime Land Surface Temperature - 10-day (MODIS)
+                                              </mock-typography>
+                                              <mock-tooltip
+                                                title="Opacity"
+                                              >
+                                                <button
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -2466,20 +2387,99 @@ exports[`renders as expected 1`] = `
                                             </div>
                                           </div>
                                           <div
-                                            class="MuiBox-root MuiBox-root-71"
+                                            class="MuiBox-root MuiBox-root-73"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-72"
+                                              class="MuiBox-root MuiBox-root-74"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
+                                              >
+                                                Daytime Land Surface Temperature - 10-day Anomaly (MODIS)
+                                              </mock-typography>
+                                              <mock-tooltip
+                                                title="Opacity"
+                                              >
+                                                <button
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
+                                                  disabled=""
+                                                  tabindex="-1"
+                                                  type="button"
+                                                >
+                                                  <span
+                                                    class="MuiIconButton-label"
+                                                  >
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      class="MuiSvgIcon-root"
+                                                      focusable="false"
+                                                      viewBox="0 0 24 24"
+                                                    >
+                                                      <path
+                                                        d="M17.66 8L12 2.35 6.34 8C4.78 9.56 4 11.64 4 13.64s.78 4.11 2.34 5.67 3.61 2.35 5.66 2.35 4.1-.79 5.66-2.35S20 15.64 20 13.64 19.22 9.56 17.66 8zM6 14c.01-2 .62-3.27 1.76-4.4L12 5.27l4.24 4.38C17.38 10.77 17.99 12 18 14H6z"
+                                                      />
+                                                    </svg>
+                                                  </span>
+                                                </button>
+                                              </mock-tooltip>
+                                              <mock-tooltip
+                                                title="Download"
+                                              >
+                                                <button
+                                                  class="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
+                                                  disabled=""
+                                                  tabindex="-1"
+                                                  type="button"
+                                                >
+                                                  <span
+                                                    class="MuiIconButton-label"
+                                                  >
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      class="MuiSvgIcon-root"
+                                                      focusable="false"
+                                                      viewBox="0 0 24 24"
+                                                    >
+                                                      <path
+                                                        d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                                                      />
+                                                    </svg>
+                                                  </span>
+                                                </button>
+                                              </mock-tooltip>
+                                              <mock-menu
+                                                id="download-menu"
+                                                keepmounted="true"
+                                                open="false"
+                                              >
+                                                <mock-menuitem>
+                                                  Download as GeoTIFF
+                                                </mock-menuitem>
+                                              </mock-menu>
+                                            </div>
+                                          </div>
+                                          <div
+                                            class="MuiBox-root MuiBox-root-75"
+                                          >
+                                            <div
+                                              class="MuiBox-root MuiBox-root-76"
+                                            >
+                                              <mock-switch
+                                                checked="false"
+                                                classes="[object Object]"
+                                                classname="memo-switch-37"
+                                                inputprops="[object Object]"
+                                                size="small"
+                                              />
+                                              <mock-typography
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 Land Surface Temperature - 10-day Amplitude (MODIS)
                                               </mock-typography>
@@ -2487,7 +2487,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -2571,7 +2571,7 @@ exports[`renders as expected 1`] = `
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-22"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -2625,19 +2625,19 @@ exports[`renders as expected 1`] = `
                             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                           >
                             <div
-                              class="MuiPaper-root MuiAccordion-root makeStyles-root-23 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                              class="MuiPaper-root MuiAccordion-root makeStyles-root-25 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
                             >
                               <div
                                 aria-controls="Tropical Storms"
                                 aria-disabled="false"
                                 aria-expanded="false"
-                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-24"
+                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-26"
                                 id="Tropical Storms"
                                 role="button"
                                 tabindex="0"
                               >
                                 <div
-                                  class="MuiAccordionSummary-content"
+                                  class="MuiAccordionSummary-content makeStyles-summaryContent-29"
                                 >
                                   <mock-typography
                                     classes="[object Object]"
@@ -2648,7 +2648,7 @@ exports[`renders as expected 1`] = `
                                 <div
                                   aria-disabled="false"
                                   aria-hidden="true"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-26 MuiIconButton-edgeEnd"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-28 MuiIconButton-edgeEnd"
                                 >
                                   <span
                                     class="MuiIconButton-label"
@@ -2685,26 +2685,26 @@ exports[`renders as expected 1`] = `
                                       role="region"
                                     >
                                       <div
-                                        class="MuiAccordionDetails-root makeStyles-rootDetails-25"
+                                        class="MuiAccordionDetails-root makeStyles-rootDetails-27"
                                       >
                                         <div
                                           class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                                         >
                                           <div
-                                            class="MuiBox-root MuiBox-root-73"
+                                            class="MuiBox-root MuiBox-root-77"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-74"
+                                              class="MuiBox-root MuiBox-root-78"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 Tropical Storms
                                               </mock-typography>
@@ -2712,7 +2712,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -2792,7 +2792,7 @@ exports[`renders as expected 1`] = `
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-22"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -2846,19 +2846,19 @@ exports[`renders as expected 1`] = `
                             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                           >
                             <div
-                              class="MuiPaper-root MuiAccordion-root makeStyles-root-23 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                              class="MuiPaper-root MuiAccordion-root makeStyles-root-25 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
                             >
                               <div
                                 aria-controls="Poverty"
                                 aria-disabled="false"
                                 aria-expanded="false"
-                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-24"
+                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-26"
                                 id="Poverty"
                                 role="button"
                                 tabindex="0"
                               >
                                 <div
-                                  class="MuiAccordionSummary-content"
+                                  class="MuiAccordionSummary-content makeStyles-summaryContent-29"
                                 >
                                   <mock-typography
                                     classes="[object Object]"
@@ -2869,7 +2869,7 @@ exports[`renders as expected 1`] = `
                                 <div
                                   aria-disabled="false"
                                   aria-hidden="true"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-26 MuiIconButton-edgeEnd"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-28 MuiIconButton-edgeEnd"
                                 >
                                   <span
                                     class="MuiIconButton-label"
@@ -2906,26 +2906,26 @@ exports[`renders as expected 1`] = `
                                       role="region"
                                     >
                                       <div
-                                        class="MuiAccordionDetails-root makeStyles-rootDetails-25"
+                                        class="MuiAccordionDetails-root makeStyles-rootDetails-27"
                                       >
                                         <div
                                           class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                                         >
                                           <div
-                                            class="MuiBox-root MuiBox-root-75"
+                                            class="MuiBox-root MuiBox-root-79"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-76"
+                                              class="MuiBox-root MuiBox-root-80"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 Multidimensional Poverty Index
                                               </mock-typography>
@@ -2933,7 +2933,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -3001,19 +3001,19 @@ exports[`renders as expected 1`] = `
                               </div>
                             </div>
                             <div
-                              class="MuiPaper-root MuiAccordion-root makeStyles-root-23 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                              class="MuiPaper-root MuiAccordion-root makeStyles-root-25 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
                             >
                               <div
                                 aria-controls="Food Insecurity"
                                 aria-disabled="false"
                                 aria-expanded="false"
-                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-24"
+                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-26"
                                 id="Food Insecurity"
                                 role="button"
                                 tabindex="0"
                               >
                                 <div
-                                  class="MuiAccordionSummary-content"
+                                  class="MuiAccordionSummary-content makeStyles-summaryContent-29"
                                 >
                                   <mock-typography
                                     classes="[object Object]"
@@ -3024,7 +3024,7 @@ exports[`renders as expected 1`] = `
                                 <div
                                   aria-disabled="false"
                                   aria-hidden="true"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-26 MuiIconButton-edgeEnd"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-28 MuiIconButton-edgeEnd"
                                 >
                                   <span
                                     class="MuiIconButton-label"
@@ -3061,35 +3061,35 @@ exports[`renders as expected 1`] = `
                                       role="region"
                                     >
                                       <div
-                                        class="MuiAccordionDetails-root makeStyles-rootDetails-25"
+                                        class="MuiAccordionDetails-root makeStyles-rootDetails-27"
                                       >
                                         <div
                                           class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                                         >
                                           <div
-                                            class="MuiBox-root MuiBox-root-77"
+                                            class="MuiBox-root MuiBox-root-81"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-78"
+                                              class="MuiBox-root MuiBox-root-82"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 IPC
                                               </mock-typography>
                                               <div
-                                                class="MuiInputBase-root MuiInput-root MuiInput-underline SwitchItem-select-30"
+                                                class="MuiInputBase-root MuiInput-root MuiInput-underline memo-select-34"
                                               >
                                                 <div
                                                   aria-haspopup="listbox"
-                                                  class="MuiSelect-root SwitchItem-selectItemUnchecked-32 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+                                                  class="MuiSelect-root memo-selectItemUnchecked-36 MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
                                                   role="button"
                                                   tabindex="0"
                                                 >
@@ -3174,7 +3174,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -3261,7 +3261,7 @@ exports[`renders as expected 1`] = `
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-22"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -3315,19 +3315,19 @@ exports[`renders as expected 1`] = `
                             class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                           >
                             <div
-                              class="MuiPaper-root MuiAccordion-root makeStyles-root-23 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                              class="MuiPaper-root MuiAccordion-root makeStyles-root-25 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
                             >
                               <div
                                 aria-controls="Population"
                                 aria-disabled="false"
                                 aria-expanded="false"
-                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-24"
+                                class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-26"
                                 id="Population"
                                 role="button"
                                 tabindex="0"
                               >
                                 <div
-                                  class="MuiAccordionSummary-content"
+                                  class="MuiAccordionSummary-content makeStyles-summaryContent-29"
                                 >
                                   <mock-typography
                                     classes="[object Object]"
@@ -3338,7 +3338,7 @@ exports[`renders as expected 1`] = `
                                 <div
                                   aria-disabled="false"
                                   aria-hidden="true"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-26 MuiIconButton-edgeEnd"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-28 MuiIconButton-edgeEnd"
                                 >
                                   <span
                                     class="MuiIconButton-label"
@@ -3375,26 +3375,26 @@ exports[`renders as expected 1`] = `
                                       role="region"
                                     >
                                       <div
-                                        class="MuiAccordionDetails-root makeStyles-rootDetails-25"
+                                        class="MuiAccordionDetails-root makeStyles-rootDetails-27"
                                       >
                                         <div
                                           class="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-column"
                                         >
                                           <div
-                                            class="MuiBox-root MuiBox-root-79"
+                                            class="MuiBox-root MuiBox-root-83"
                                           >
                                             <div
-                                              class="MuiBox-root MuiBox-root-80"
+                                              class="MuiBox-root MuiBox-root-84"
                                             >
                                               <mock-switch
                                                 checked="false"
                                                 classes="[object Object]"
-                                                classname="SwitchItem-switch-33"
+                                                classname="memo-switch-37"
                                                 inputprops="[object Object]"
                                                 size="small"
                                               />
                                               <mock-typography
-                                                classname="SwitchItem-titleUnchecked-29"
+                                                classname="memo-titleUnchecked-33"
                                               >
                                                 Total population
                                               </mock-typography>
@@ -3402,7 +3402,7 @@ exports[`renders as expected 1`] = `
                                                 title="Opacity"
                                               >
                                                 <button
-                                                  class="MuiButtonBase-root MuiIconButton-root SwitchItem-opacityRoot-36 Mui-disabled Mui-disabled"
+                                                  class="MuiButtonBase-root MuiIconButton-root memo-opacityRoot-40 Mui-disabled Mui-disabled"
                                                   disabled=""
                                                   tabindex="-1"
                                                   type="button"
@@ -3494,10 +3494,10 @@ exports[`renders as expected 1`] = `
       </div>
     </mock-drawer>
     <div
-      class="MuiBox-root MuiBox-root-115 MapView-container-2"
+      class="MuiBox-root MuiBox-root-119 MapView-container-2"
     >
       <div
-        class="MuiBox-root MuiBox-root-116 MapView-optionContainer-3"
+        class="MuiBox-root MuiBox-root-120 MapView-optionContainer-3"
         style="margin-left: 30vw;"
       >
         <mock-tooltip
@@ -3535,7 +3535,7 @@ exports[`renders as expected 1`] = `
                 class="MuiGrid-root MuiGrid-item"
               >
                 <div
-                  class="makeStyles-button-119"
+                  class="makeStyles-button-123"
                 >
                   <svg
                     aria-hidden="true"
@@ -3548,7 +3548,7 @@ exports[`renders as expected 1`] = `
                     />
                   </svg>
                   <div
-                    class="makeStyles-selectContainer-120"
+                    class="makeStyles-selectContainer-124"
                   />
                 </div>
               </div>

--- a/frontend/src/components/MapView/index.tsx
+++ b/frontend/src/components/MapView/index.tsx
@@ -30,8 +30,8 @@ import {
   BoundaryLayer,
   ImpactLayer,
   PointDataLayer,
-  WMSLayer,
   StaticRasterLayer,
+  WMSLayer,
 } from './Layers';
 
 import {
@@ -44,12 +44,12 @@ import {
 } from '../../config/types';
 
 import { Extent } from './Layers/raster-utils';
-import { useUrlHistory, UrlLayerKey, getUrlKey } from '../../utils/url-utils';
+import { getUrlKey, UrlLayerKey, useUrlHistory } from '../../utils/url-utils';
 
 import {
-  LayerDefinitions,
-  getDisplayBoundaryLayers,
   getBoundaryLayerSingleton,
+  getDisplayBoundaryLayers,
+  LayerDefinitions,
 } from '../../config/utils';
 
 import DateSelector from './DateSelector';
@@ -62,10 +62,10 @@ import {
 } from '../../context/mapStateSlice/selectors';
 import {
   addLayer,
+  layerOrdering,
+  removeLayer,
   setMap,
   updateDateRange,
-  removeLayer,
-  layerOrdering,
 } from '../../context/mapStateSlice';
 import * as boundaryInfoStateSlice from '../../context/mapBoundaryInfoStateSlice';
 import { setLoadingLayerIds } from '../../context/mapTileLoadingStateSlice';

--- a/frontend/src/context/mapStateSlice/selectors.ts
+++ b/frontend/src/context/mapStateSlice/selectors.ts
@@ -5,11 +5,15 @@ import { Map as MapBoxMap } from 'mapbox-gl';
 import type { RootState } from '../store';
 import type { LayerDataTypes } from '../layers/layer-data';
 import type { MapState } from '.';
-import type { LayerKey } from '../../config/types';
+import type { LayerKey, LayerType } from '../../config/types';
 import { BoundaryRelationsDict } from '../../components/Common/BoundaryDropdown/utils';
 
 export const layersSelector = (state: RootState): MapState['layers'] =>
   state.mapState.layers;
+export const activeLayersSelector = (state: RootState): MapState['layers'] =>
+  state.mapState.layers.filter((layer: LayerType) => {
+    return !layer.id.includes('boundaries');
+  });
 export const dateRangeSelector = (state: RootState): MapState['dateRange'] =>
   state.mapState.dateRange;
 export const mapSelector = (state: RootState): MapBoxMap | undefined =>


### PR DESCRIPTION
This branch adds indications in the left panel of active layers enabled to individual accordion dropdown items, to layers tab and to the fold button when the sidebar is closed. Also with the refactoring of some of the `SwitchItem` code I managed to fix the transparency slider bug when you toggle a layer reduce transparency and enable it again the transparency didn't change. Please let me know if this is what we wanted as an expected behavior. Cc @wadhwamatic @ericboucher . Below I attach some screenshots of the indications. The UX is the following: When a user is on the layers tab the specific information of the active layer is displayed on the specific item that is enabled. When a user switches the tab and goes for example to the charts panel or the analysis panel, a badge with the number of the active layers are displayed on the header tab of the layers. When the sidebar is folded and some of the layers are active a badge is displayed above the icon of the FoldButton indicating how many active layers are enabled.

Screenshot/video of feature:
![Screenshot from 2023-04-20 13-20-46](https://user-images.githubusercontent.com/62129256/233338642-d8bae0c5-9d48-421c-b3d7-168909ee6cad.png)
![Screenshot from 2023-04-20 13-20-53](https://user-images.githubusercontent.com/62129256/233338685-94fafac9-e9d4-4d7d-a1d2-b5d5dd870a33.png)
![Screenshot from 2023-04-20 13-21-03](https://user-images.githubusercontent.com/62129256/233338730-8a8afbd9-eeb7-417a-a648-d1a39c676790.png)

