### PR TITLE
WIP - Investigating Kobo date issue

### DIFF
--- a/api/app/kobo.py
+++ b/api/app/kobo.py
@@ -119,6 +119,7 @@ def parse_form_response(
     datetime_value_string = get_first(
         [value for key, value in form_dict.items() if key.endswith(datetime_field)]
     )
+    # TODO - what happens if datetime_value_string is None?
     datetime_value = parse_form_field(datetime_value_string, labels.get(datetime_field))  # type: ignore
 
     geom_field = form_fields.get("geom_field") or "DoesNotExist"


### PR DESCRIPTION
I noticed this error in the API logs:

```
api        |   File "/usr/local/lib/python3.10/dist-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
api        |     return await future
api        |   File "/usr/local/lib/python3.10/dist-packages/anyio/_backends/_asyncio.py", line 867, in run
api        |     result = context.run(func, *args)
api        |   File "/app/main.py", line 187, in get_kobo_form_dates
api        |     return get_form_dates(koboUrl, formId, datetimeField, filters)
api        |   File "/app/kobo.py", line 215, in get_form_dates
api        |     forms = [parse_form_response(f, form_fields, form_labels) for f in form_responses]
api        |   File "/app/kobo.py", line 215, in <listcomp>
api        |     forms = [parse_form_response(f, form_fields, form_labels) for f in form_responses]
api        |   File "/app/kobo.py", line 122, in parse_form_response
api        |     datetime_value = parse_form_field(datetime_value_string, labels.get(datetime_field))  # type: ignore
api        |   File "/app/kobo.py", line 70, in parse_form_field
api        |     return dtparser(value).astimezone(timezone.utc)
api        |   File "/usr/local/lib/python3.10/dist-packages/dateutil/parser/_parser.py", line 1368, in parse
api        |     return DEFAULTPARSER.parse(timestr, **kwargs)
api        |   File "/usr/local/lib/python3.10/dist-packages/dateutil/parser/_parser.py", line 640, in parse
api        |     res, skipped_tokens = self._parse(timestr, **kwargs)
api        |   File "/usr/local/lib/python3.10/dist-packages/dateutil/parser/_parser.py", line 719, in _parse
api        |     l = _timelex.split(timestr)         # Splits the timestr into tokens
api        |   File "/usr/local/lib/python3.10/dist-packages/dateutil/parser/_parser.py", line 201, in split
api        |     return list(cls(s))
api        |   File "/usr/local/lib/python3.10/dist-packages/dateutil/parser/_parser.py", line 69, in __init__
api        |     raise TypeError('Parser must be a string or character stream, not '
api        | TypeError: Parser must be a string or character stream, not NoneType
```

And tracked it done to a missing datetime in the form. See TODO added in the PR. Not sure what we should set the date to if it's missing. @JorgeMartinezG @wadhwamatic any ideas?