### PR TITLE
Fix date warnings appear twice

### DIFF
--- a/frontend/src/context/notificationStateSlice.ts
+++ b/frontend/src/context/notificationStateSlice.ts
@@ -17,7 +17,7 @@ type NotificationConstructor = {
 export class Notification {
   readonly message: string;
   readonly type: Color;
-  readonly key: string; // each notification needs a unique ID. Date.now() seems to do the job
+  readonly key: string; // each notification needs a unique ID. We generate a hash from the notification message
 
   constructor({ message, type }: NotificationConstructor) {
     this.type = type;

--- a/frontend/src/context/notificationStateSlice.ts
+++ b/frontend/src/context/notificationStateSlice.ts
@@ -6,6 +6,7 @@ import {
 } from '@reduxjs/toolkit';
 import { Color } from '@material-ui/lab';
 import type { AppDispatch, RootState } from './store';
+import { stringHash } from '../utils/string-utils';
 
 // to test notification reaction to various error codes, http://httpstat.us/404 can be used where 404 is the status to test.
 type NotificationConstructor = {
@@ -16,11 +17,12 @@ type NotificationConstructor = {
 export class Notification {
   readonly message: string;
   readonly type: Color;
-  readonly key: number = Date.now(); // each notification needs a unique ID. Date.now() seems to do the job
+  readonly key: string; // each notification needs a unique ID. Date.now() seems to do the job
 
   constructor({ message, type }: NotificationConstructor) {
     this.type = type;
     this.message = message;
+    this.key = stringHash(message);
   }
 }
 
@@ -37,12 +39,19 @@ export const notificationStateSlice = createSlice({
   initialState,
   reducers: {
     addNotification: (
-      { notifications, ...rest },
+      state,
       { payload }: PayloadAction<NotificationConstructor>,
-    ) => ({
-      ...rest,
-      notifications: notifications.concat(new Notification(payload)),
-    }),
+    ) => {
+      const { notifications, ...rest } = state;
+      const notification = new Notification(payload);
+      if (notifications.find(n => n.key === notification.key)) {
+        return state;
+      }
+      return {
+        ...rest,
+        notifications: notifications.concat(notification),
+      };
+    },
     removeNotification: (
       { notifications, ...rest },
       { payload }: PayloadAction<Notification['key']>,

--- a/frontend/src/context/notificationStateSlice.ts
+++ b/frontend/src/context/notificationStateSlice.ts
@@ -44,9 +44,16 @@ export const notificationStateSlice = createSlice({
     ) => {
       const { notifications, ...rest } = state;
       const notification = new Notification(payload);
+
+      /**
+       * If there is a notification with the same key (hash), it means that there
+       * is an existing notification with the same message. In this case
+       * we do not update the state and return the existing.
+       */
       if (notifications.find(n => n.key === notification.key)) {
         return state;
       }
+
       return {
         ...rest,
         notifications: notifications.concat(notification),

--- a/frontend/src/utils/string-utils.ts
+++ b/frontend/src/utils/string-utils.ts
@@ -1,0 +1,18 @@
+/* eslint-disable no-bitwise, fp/no-mutation */
+
+// https://stackoverflow.com/a/7616484
+export const stringHash = (s: string): string => {
+  let hash = 0;
+
+  if (typeof s !== 'string' || s.length === 0) {
+    return hash.toString();
+  }
+
+  for (let i = 0; i < s.length; i += 1) {
+    const chr = s.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0; // Convert to 32bit integer - bitwise or and assign the result to "hash"
+  }
+
+  return hash.toString();
+};


### PR DESCRIPTION
With this fix, we basically block the display of duplicate notifications by using a hash which is generated by the notification message.

This fixes issue [#814].

How to test the feature:

1. Select Cambodia
2. Enable layer X
3. Select a date that is out of range for a layer Y
4. Enable layer Y along with X
5. Expect to see a single notification saying there is no data for that date

Screenshot/video of feature:

https://github.com/WFP-VAM/prism-app/assets/24255041/a9a924c0-1bd0-47d7-831a-4c94f25af8c9

