### PR TITLE
Re-add opacity slider to legends

### DIFF
--- a/frontend/src/components/MapView/Legends/LegendItem/index.tsx
+++ b/frontend/src/components/MapView/Legends/LegendItem/index.tsx
@@ -165,11 +165,11 @@ const LegendItem = memo(
 const styles = () =>
   createStyles({
     paper: {
-      padding: 6,
+      padding: 8,
       width: 180,
     },
     slider: {
-      padding: '0 0px',
+      padding: '0 0',
     },
   });
 

--- a/frontend/src/components/MapView/Legends/LegendItem/index.tsx
+++ b/frontend/src/components/MapView/Legends/LegendItem/index.tsx
@@ -152,10 +152,10 @@ const LegendItem = memo(
             <LayerContentPreview layerId={id} />
           </Grid>
           <Divider />
-          {renderedOpacitySlider}
           {renderedLegend}
           <LoadingBar layerId={id} />
           {renderedChildren}
+          {renderedOpacitySlider}
         </Paper>
       </ListItem>
     );
@@ -165,11 +165,11 @@ const LegendItem = memo(
 const styles = () =>
   createStyles({
     paper: {
-      padding: 8,
+      padding: 6,
       width: 180,
     },
     slider: {
-      padding: '0 5px',
+      padding: '0 0px',
     },
   });
 

--- a/frontend/src/components/MapView/Legends/index.tsx
+++ b/frontend/src/components/MapView/Legends/index.tsx
@@ -76,6 +76,7 @@ const Legends = memo(({ classes, layers }: LegendsProps) => {
           legendUrl={getLayerLegendUrl(layer)}
           type={layer.type}
           opacity={layer.opacity}
+          displayOpacitySlider
         >
           {t(layer.legendText)}
         </LegendItem>


### PR DESCRIPTION
This is an attempt to re-add the opacity slider to the bottom of the legends to make it more accessible.

TODO:
<img width="1038" alt="Screenshot 2023-06-22 at 6 54 43 PM" src="https://github.com/WFP-VAM/prism-app/assets/16843267/138e032e-dc33-4546-b317-c458da9af4c1">

