### PR TITLE
Fixed time info in EWS-1294 charts; COUNTRY=cambodia

### DIFF
--- a/frontend/src/components/Common/Chart/index.tsx
+++ b/frontend/src/components/Common/Chart/index.tsx
@@ -80,11 +80,24 @@ const Chart = memo(
         return indices.map(index => header[index]);
       }
       return tableRows.map(row => {
+        if (data.EWSConfig) {
+          return moment(row[config.category], 'HH:mm')
+            .locale(t('date_locale') as LocaleSpecifier)
+            .format('HH:mm');
+        }
         return moment(row[config.category])
           .locale(t('date_locale') as LocaleSpecifier)
           .format('YYYY-MM-DD');
       });
-    }, [config.category, header, indices, t, tableRows, transpose]);
+    }, [
+      config.category,
+      data.EWSConfig,
+      header,
+      indices,
+      t,
+      tableRows,
+      transpose,
+    ]);
 
     // The table rows data sets
     const tableRowsDataSet = useMemo(() => {


### PR DESCRIPTION
This fixes the problem with the time info in EWS-1294 charts. The problem was that the dates are actually in format `HH:mm`, and the moment could not parse it unless we had to explicitly define it. At some point this was working correctly with the exact same code I tried to revert to the previous code that was working and the problem seems to exist to the old code also. My guess is that at some point maybe an update to the package happened that does not allow us to parse hours without setting the format first. However this is a common pattern to parse the correct format based on this [stackoverflow](https://stackoverflow.com/questions/74189283/how-to-add-minutes-and-hours-to-a-string-in-momentjs), anyway this now fixes the problem and sets the correct parsing when we have `EWSconfig` or not.
