### PR TITLE
Generating configurations for reports creation; COUNTRY=cambodia

### DIFF
--- a/frontend/src/components/Common/ReportDialog/ReportDocLegend.tsx
+++ b/frontend/src/components/Common/ReportDialog/ReportDocLegend.tsx
@@ -49,7 +49,7 @@ const ReportDocLegend = memo(({ theme, title, definition }: LegendProps) => {
   const renderedDefinitions = useMemo(() => {
     return definition.map(item => {
       return (
-        <View key={item.value} style={styles.legendContent}>
+        <View key={item.value as string} style={styles.legendContent}>
           <View style={item.style} />
           <Text style={[styles.legendText]}>{item.value}</Text>
         </View>

--- a/frontend/src/components/Common/ReportDialog/index.tsx
+++ b/frontend/src/components/Common/ReportDialog/index.tsx
@@ -27,8 +27,8 @@ import {
 } from '../../../context/analysisResultStateSlice';
 import { Column, ExposedPopulationResult } from '../../../utils/analysis-utils';
 import ReportDoc from './reportDoc';
-import { ReportType } from './types';
 import LoadingBlinkingDots from '../LoadingBlinkingDots';
+import { ReportType } from '../../../config/types';
 
 type Format = 'png' | 'jpeg';
 
@@ -36,7 +36,7 @@ const ReportDialog = memo(
   ({
     classes,
     open,
-    reportType,
+    reportConfig,
     handleClose,
     tableData,
     columns,
@@ -50,7 +50,7 @@ const ReportDialog = memo(
       analysisResultSelector,
     ) as ExposedPopulationResult;
 
-    const eventDate = useMemo(() => {
+    const reportDate = useMemo(() => {
       return analysisResult?.date
         ? moment(new Date(analysisResult?.date)).format('YYYY-MM-DD')
         : '';
@@ -106,14 +106,9 @@ const ReportDialog = memo(
               t={t}
               exposureLegendDefinition={analysisResult?.legend ?? []}
               theme={theme}
-              reportType={reportType}
-              tableName="Population Exposure"
               tableShowTotal
-              eventName={
-                reportType === ReportType.Storm
-                  ? `Storm Report (${eventDate})`
-                  : `Flood Report (${eventDate})`
-              }
+              reportTitle={`${t(reportConfig.titleValue)} ${reportDate}`}
+              reportConfig={reportConfig}
               mapImage={mapImage}
               tableData={tableData}
               columns={columns}
@@ -124,9 +119,9 @@ const ReportDialog = memo(
     }, [
       analysisResult,
       columns,
-      eventDate,
       mapImage,
-      reportType,
+      reportConfig,
+      reportDate,
       t,
       tableData,
       theme,
@@ -177,14 +172,9 @@ const ReportDialog = memo(
                 t={t}
                 exposureLegendDefinition={analysisResult?.legend ?? []}
                 theme={theme}
-                reportType={reportType}
-                tableName="Population Exposure"
+                reportTitle={`${t(reportConfig.titleValue)} ${reportDate}`}
+                reportConfig={reportConfig}
                 tableShowTotal
-                eventName={
-                  reportType === ReportType.Storm
-                    ? `Storm Report (${eventDate})`
-                    : `Flood Report (${eventDate})`
-                }
                 mapImage={mapImage}
                 tableData={tableData}
                 columns={columns}
@@ -200,22 +190,21 @@ const ReportDialog = memo(
       analysisResult,
       classes.actionButton,
       columns,
-      eventDate,
       getPDFName,
       mapImage,
       renderedLoadingButtonText,
-      reportType,
+      reportConfig,
+      reportDate,
       t,
       tableData,
       theme,
     ]);
 
-    // The report type text
-    const reportTypeText = useMemo(() => {
-      return reportType === ReportType.Storm
-        ? 'Storm impact Report'
-        : 'Flood Report';
-    }, [reportType]);
+    const renderedSignatureText = useMemo(() => {
+      return reportConfig?.signatureText
+        ? t(reportConfig.signatureText)
+        : t('PRISM automated report');
+    }, [reportConfig, t]);
 
     return (
       <Dialog
@@ -234,7 +223,9 @@ const ReportDialog = memo(
             >
               <ArrowBack />
             </IconButton>
-            <span className={classes.titleText}>{t(reportTypeText)}</span>
+            <span className={classes.titleText}>
+              {t(reportConfig.titleValue)}
+            </span>
           </div>
         </DialogTitle>
         <DialogContent
@@ -248,9 +239,7 @@ const ReportDialog = memo(
           {renderedPdfViewer}
         </DialogContent>
         <DialogActions className={classes.actions}>
-          <span className={classes.signature}>
-            {t('P R I S M automated report')}
-          </span>
+          <span className={classes.signature}>{renderedSignatureText}</span>
           {renderedDownloadPdfButton}
         </DialogActions>
       </Dialog>
@@ -312,7 +301,7 @@ const styles = (theme: Theme) =>
 
 export interface ReportProps extends WithStyles<typeof styles> {
   open: boolean;
-  reportType: ReportType;
+  reportConfig: ReportType;
   handleClose: () => void;
   tableData: AnalysisTableRow[];
   columns: Column[];

--- a/frontend/src/components/Common/ReportDialog/reportDoc.tsx
+++ b/frontend/src/components/Common/ReportDialog/reportDoc.tsx
@@ -1,18 +1,22 @@
 import React, { memo, useMemo } from 'react';
 import {
-  Page,
   Document,
-  StyleSheet,
-  View,
-  Text,
   Image,
+  Page,
+  StyleSheet,
+  Text,
+  View,
 } from '@react-pdf/renderer';
 import { Theme } from '@material-ui/core';
 import { TableRow as AnalysisTableRow } from '../../../context/analysisResultStateSlice';
 import { getLegendItemLabel } from '../../MapView/utils';
-import { LegendDefinition } from '../../../config/types';
+import {
+  LegendDefinition,
+  ReportType,
+  ReportTypeEnum,
+} from '../../../config/types';
 import { TFunction } from '../../../utils/data-utils';
-import { PDFLegendDefinition, ReportType } from './types';
+import { PDFLegendDefinition } from './types';
 import ReportDocLegend from './ReportDocLegend';
 import ReportDocTable from './ReportDocTable';
 import { Column } from '../../../utils/analysis-utils';
@@ -77,12 +81,11 @@ const makeStyles = (theme: Theme) =>
 const ReportDoc = memo(
   ({
     theme,
-    reportType,
     mapImage,
-    tableName,
     tableRowsNum,
     tableShowTotal,
-    eventName,
+    reportTitle,
+    reportConfig,
     exposureLegendDefinition,
     t,
     tableData,
@@ -93,6 +96,12 @@ const ReportDoc = memo(
     const date = useMemo(() => {
       return new Date().toUTCString();
     }, []);
+
+    const tableName = useMemo(() => {
+      return reportConfig?.tableName
+        ? reportConfig?.tableName
+        : 'Population Exposure';
+    }, [reportConfig]);
 
     const showRowTotal = useMemo(() => {
       return columns.length > 2;
@@ -109,63 +118,40 @@ const ReportDoc = memo(
     }, [tableData, tableRowsNum, tableShowTotal]);
 
     const areasLegendDefinition: PDFLegendDefinition[] = useMemo(() => {
-      return [
-        {
-          value: 'Province',
-          style: [styles.dash, { backgroundColor: '#000000' }],
-        },
-        {
-          value: 'District',
-          style: [styles.dash, { backgroundColor: '#999797' }],
-        },
-        {
-          value: 'Township',
-          style: [styles.dash, { backgroundColor: '#D8D6D6' }],
-        },
-      ];
-    }, [styles.dash]);
+      return reportConfig.areasLegendDefinition.items.map(areaDefinition => {
+        return {
+          value: t(areaDefinition.title),
+          style: [styles.dash, { backgroundColor: areaDefinition.color }],
+        };
+      });
+    }, [reportConfig.areasLegendDefinition.items, styles.dash, t]);
 
-    const stormWindBuffersLegendDefinition: PDFLegendDefinition[] = useMemo(() => {
-      return [
-        {
-          value: 'Uncertainty Cones',
-          style: [
-            styles.borderedBox,
-            { backgroundColor: '#ffffff', borderColor: '#b8b1b1' },
-          ],
+    const typeLegendDefinition: PDFLegendDefinition[] = useMemo(() => {
+      return reportConfig.typeLegendDefinition.items.map(
+        typeLegendDefinitionItem => {
+          return {
+            value: t(typeLegendDefinitionItem.title),
+            style: [
+              reportConfig.type === ReportTypeEnum.TROPICAL_STORMS
+                ? styles.borderedBox
+                : styles.box,
+              {
+                backgroundColor: typeLegendDefinitionItem.color,
+                ...(typeLegendDefinitionItem?.border && {
+                  borderColor: typeLegendDefinitionItem.border,
+                }),
+              },
+            ],
+          };
         },
-        {
-          value: 'Wind Buffer 60 km/h',
-          style: [
-            styles.borderedBox,
-            { backgroundColor: '#fffcf1', borderColor: '#f7e705' },
-          ],
-        },
-        {
-          value: 'Wind Buffer 90 km/h',
-          style: [
-            styles.borderedBox,
-            { backgroundColor: '#ffeed8', borderColor: '#f99408' },
-          ],
-        },
-        {
-          value: 'Wind Buffer 120 km/h',
-          style: [
-            styles.borderedBox,
-            { backgroundColor: '#fcd4ce', borderColor: '#f90c08' },
-          ],
-        },
-      ];
-    }, [styles.borderedBox]);
-
-    const floodsLegendDefinition: PDFLegendDefinition[] = useMemo(() => {
-      return [
-        {
-          value: 'flooded',
-          style: [styles.box, { backgroundColor: '#a50f15' }],
-        },
-      ];
-    }, [styles.box]);
+      );
+    }, [
+      reportConfig.type,
+      reportConfig.typeLegendDefinition.items,
+      styles.borderedBox,
+      styles.box,
+      t,
+    ]);
 
     const populationExposureLegendDefinition: PDFLegendDefinition[] = useMemo(() => {
       return exposureLegendDefinition.map(item => ({
@@ -174,41 +160,77 @@ const ReportDoc = memo(
       }));
     }, [exposureLegendDefinition, styles.box, t]);
 
-    // The rendered report doc legend
-    const renderedReportDocLegend = useMemo(() => {
-      if (reportType === ReportType.Storm) {
-        return (
-          <ReportDocLegend
-            title="Tropical Storms - Wind buffers"
-            definition={stormWindBuffersLegendDefinition}
-            theme={theme}
-          />
-        );
+    const renderedSourcesPrimaryText = useMemo(() => {
+      if (!reportConfig?.sourcesPrimaryText) {
+        return null;
       }
       return (
-        <ReportDocLegend
-          title="Potential Flooding"
-          definition={floodsLegendDefinition}
-          theme={theme}
-        />
+        <Text style={{ fontSize: theme.pdf?.fontSizes.small }}>
+          {reportConfig.sourcesPrimaryText}
+        </Text>
+      );
+    }, [reportConfig, theme.pdf]);
+
+    const renderedSourcesSecondaryText = useMemo(() => {
+      if (!reportConfig?.sourcesSecondaryText) {
+        return null;
+      }
+      return (
+        <Text
+          style={{
+            fontSize: theme.pdf?.fontSizes.extraSmall,
+            color: theme.pdf?.secondaryTextColor,
+          }}
+        >
+          {reportConfig.sourcesSecondaryText}
+        </Text>
+      );
+    }, [reportConfig, theme.pdf]);
+
+    const renderedSourcesView = useMemo(() => {
+      if (
+        !reportConfig?.sourcesPrimaryText &&
+        !reportConfig?.sourcesSecondaryText
+      ) {
+        return null;
+      }
+      return (
+        <View style={styles.section}>
+          {renderedSourcesPrimaryText}
+          {renderedSourcesSecondaryText}
+        </View>
       );
     }, [
-      floodsLegendDefinition,
-      reportType,
-      stormWindBuffersLegendDefinition,
-      theme,
+      renderedSourcesPrimaryText,
+      renderedSourcesSecondaryText,
+      reportConfig,
+      styles.section,
     ]);
+
+    const renderedSubText = useMemo(() => {
+      if (!reportConfig?.subText) {
+        return null;
+      }
+      return <Text style={styles.subText}>{t(reportConfig.subText)}</Text>;
+    }, [reportConfig, styles.subText, t]);
+
+    const renderedSignatureText = useMemo(() => {
+      return reportConfig?.signatureText
+        ? t(reportConfig.signatureText)
+        : t('PRISM automated report');
+    }, [reportConfig, t]);
 
     return (
       <Document>
         <Page size="A4" style={styles.page}>
           <View style={[styles.section]}>
-            <Text style={styles.title}>Event name: {eventName}</Text>
-            <Text style={styles.title}>Publication date: {date}</Text>
-            <Text style={styles.subText}>
-              This is an automated report.
-              <Text> Information should be treated as preliminary</Text>
+            <Text style={styles.title}>
+              {t(reportConfig.titleKey)}: {reportTitle}
             </Text>
+            <Text style={styles.title}>
+              {t(reportConfig.subTitleKey)}: {date}
+            </Text>
+            {renderedSubText}
           </View>
           <View style={styles.section}>
             <Image src={mapImage} style={styles.mapImage} />
@@ -216,33 +238,21 @@ const ReportDoc = memo(
           <View style={[styles.legendsContainer, styles.section]}>
             <ReportDocLegend
               theme={theme}
-              title="Areas"
+              title={t(reportConfig.areasLegendDefinition.title)}
               definition={areasLegendDefinition}
             />
-            {renderedReportDocLegend}
+            <ReportDocLegend
+              title={t(reportConfig.typeLegendDefinition.title)}
+              definition={typeLegendDefinition}
+              theme={theme}
+            />
             <ReportDocLegend
               title="Population Exposure"
               definition={populationExposureLegendDefinition}
               theme={theme}
             />
           </View>
-          <View style={styles.section}>
-            <Text style={{ fontSize: theme.pdf?.fontSizes.small }}>
-              Sources WFP, UNGIWG, OCHA, GAUL, USGS, NASA, UCSB
-            </Text>
-            <Text
-              style={{
-                fontSize: theme.pdf?.fontSizes.extraSmall,
-                color: theme.pdf?.secondaryTextColor,
-              }}
-            >
-              The designations employed and the presentation of material in the
-              map(s) do not imply the expression of any opinion on the part of
-              WFP concerning the legal or constitutional status of any country,
-              territory, city or sea, or concerning the delimitation of its
-              frontiers or boundaries.
-            </Text>
-          </View>
+          {renderedSourcesView}
           <View style={[styles.section]}>
             <ReportDocTable
               theme={theme}
@@ -256,7 +266,7 @@ const ReportDoc = memo(
             />
           </View>
           <Text fixed style={styles.footer}>
-            P R I S M automated report
+            {renderedSignatureText}
           </Text>
         </Page>
       </Document>
@@ -266,12 +276,11 @@ const ReportDoc = memo(
 
 interface ReportDocProps {
   theme: Theme;
-  reportType: ReportType;
   mapImage: string;
-  tableName: string;
   tableRowsNum?: number;
+  reportTitle: string;
+  reportConfig: ReportType;
   tableShowTotal: boolean;
-  eventName: string;
   exposureLegendDefinition: LegendDefinition;
   t: TFunction;
   tableData: AnalysisTableRow[];

--- a/frontend/src/components/Common/ReportDialog/types.ts
+++ b/frontend/src/components/Common/ReportDialog/types.ts
@@ -1,12 +1,8 @@
 import { Style } from '@react-pdf/types';
-
-export enum ReportType {
-  Storm,
-  Flood,
-}
+import { TFunctionResult } from 'i18next';
 
 export interface PDFLegendDefinition {
-  value: string | number;
+  value: string | number | TFunctionResult;
   style: Style | Style[];
 }
 

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/ExposureAnalysisActions/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/ExposureAnalysisActions/index.tsx
@@ -12,17 +12,17 @@ import { useSelector } from 'react-redux';
 import { downloadToFile } from '../../../utils';
 import { useSafeTranslation } from '../../../../../i18n';
 import {
+  exposureLayerIdSelector,
   getCurrentDefinition,
   TableRow,
   TableRow as AnalysisTableRow,
 } from '../../../../../context/analysisResultStateSlice';
-import { layersSelector } from '../../../../../context/mapStateSlice/selectors';
-import { ReportType } from '../../../../Common/ReportDialog/types';
 import ReportDialog from '../../../../Common/ReportDialog';
 import {
   Column,
   quoteAndEscapeCell,
 } from '../../../../../utils/analysis-utils';
+import { ReportsDefinitions } from '../../../../../config/utils';
 
 function ExposureAnalysisActions({
   analysisButton,
@@ -34,13 +34,9 @@ function ExposureAnalysisActions({
   // only display local names if local language is selected, otherwise display english name
   const { t } = useSafeTranslation();
   const analysisDefinition = useSelector(getCurrentDefinition);
-  const selectedLayers = useSelector(layersSelector);
+  const exposureLayerId = useSelector(exposureLayerIdSelector);
 
   const [openReport, setOpenReport] = useState(false);
-
-  const isShowingStormData = useMemo(() => {
-    return selectedLayers.some(({ id }) => id === 'adamts_buffers');
-  }, [selectedLayers]);
 
   const getCellValue = useCallback((value: string | number, column: Column) => {
     if (column.format && typeof value === 'number') {
@@ -60,6 +56,19 @@ function ExposureAnalysisActions({
       {},
     );
   }, [columns]);
+
+  const reportConfig = useMemo(() => {
+    // We use find here because exposure reports and layers have 1 - 1 sync.
+    // TODO Future enhancement if exposure reports are more than one for specific layer
+    const foundReportKeyBasedOnLayerId = Object.keys(ReportsDefinitions).find(
+      reportDefinitionKey => {
+        return (
+          ReportsDefinitions[reportDefinitionKey].layerId === exposureLayerId
+        );
+      },
+    );
+    return ReportsDefinitions[foundReportKeyBasedOnLayerId as string];
+  }, [exposureLayerId]);
 
   const tableDataRowsToRenderCsv = useMemo(() => {
     return tableData.map((tableRowData: TableRow) => {
@@ -101,6 +110,12 @@ function ExposureAnalysisActions({
     [analysisCsvData, analysisDefinition],
   );
 
+  const handleToggleReport = useCallback((toggle: boolean) => {
+    return () => {
+      setOpenReport(toggle);
+    };
+  }, []);
+
   return (
     <>
       <Button className={analysisButton} onClick={clearAnalysis}>
@@ -111,13 +126,13 @@ function ExposureAnalysisActions({
           <Typography variant="body2">{t('Download as CSV')}</Typography>
         </Button>
       )}
-      <Button className={bottomButton} onClick={() => setOpenReport(true)}>
+      <Button className={bottomButton} onClick={handleToggleReport(true)}>
         <Typography variant="body2">{t('Create Report')}</Typography>
       </Button>
       <ReportDialog
         open={openReport}
-        handleClose={() => setOpenReport(false)}
-        reportType={isShowingStormData ? ReportType.Storm : ReportType.Flood}
+        handleClose={handleToggleReport(false)}
+        reportConfig={reportConfig}
         tableData={tableData}
         columns={columns}
       />

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/ExposureAnalysisOption.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/ExposureAnalysisOption.tsx
@@ -15,6 +15,7 @@ import {
   ExposedPopulationDispatchParams,
   requestAndStoreExposedPopulation,
   setCurrentDataDefinition,
+  setExposureLayerId,
 } from '../../../../../../context/analysisResultStateSlice';
 import { setTabValue } from '../../../../../../context/leftPanelStateSlice';
 import { dateRangeSelector } from '../../../../../../context/mapStateSlice/selectors';
@@ -58,6 +59,9 @@ function ExposureAnalysisOption({
       extent,
       ...hazardLayer,
     };
+
+    // Set the exposure layer id in redux so that we can have access to the reports configurations through the layer id
+    dispatch(setExposureLayerId(layer.id));
 
     dispatch(requestAndStoreExposedPopulation(params));
     dispatch(

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.tsx
@@ -25,6 +25,7 @@ import { LayerKey, LayerType } from '../../../../../../config/types';
 import {
   getDisplayBoundaryLayers,
   LayerDefinitions,
+  ReportsDefinitions,
 } from '../../../../../../config/utils';
 import { clearDataset } from '../../../../../../context/datasetStateSlice';
 import { removeLayer } from '../../../../../../context/mapStateSlice';
@@ -260,7 +261,13 @@ const SwitchItem = memo(({ classes, layer, extent }: SwitchItemProps) => {
   ]);
 
   const renderedExposureAnalysisOption = useMemo(() => {
-    if (!exposure) {
+    // find if there are reports with the specific layer id in the reports.json
+    const foundReports = Object.keys(ReportsDefinitions).filter(
+      reportDefinitionKey => {
+        return ReportsDefinitions[reportDefinitionKey].layerId === layer.id;
+      },
+    );
+    if (!exposure || !foundReports.length) {
       return null;
     }
     return (

--- a/frontend/src/components/MapView/index.tsx
+++ b/frontend/src/components/MapView/index.tsx
@@ -29,6 +29,7 @@ import {
   getBoundaryLayerSingleton,
   getDisplayBoundaryLayers,
   LayerDefinitions,
+  ReportsDefinitions,
 } from '../../config/utils';
 
 import DateSelector from './DateSelector';
@@ -582,6 +583,8 @@ const MapView = memo(({ classes }: MapViewProps) => {
       </div>
     );
   }, [classes.loading, datesLoading]);
+
+  console.log(ReportsDefinitions);
 
   return (
     <Box className={classes.root}>

--- a/frontend/src/config/afghanistan/index.ts
+++ b/frontend/src/config/afghanistan/index.ts
@@ -3,11 +3,13 @@ import rawLayers from './layers.json';
 
 const rawTables = {};
 const translation = {};
+const rawReports = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'geoBoundaries-AFG-ADM1-extended.json',
 };

--- a/frontend/src/config/cambodia/index.ts
+++ b/frontend/src/config/cambodia/index.ts
@@ -1,5 +1,6 @@
 import appConfig from './prism.json';
 import rawLayers from './layers.json';
+import rawReports from './reports.json';
 import cambodiaTranslation from './translation.json';
 
 const rawTables = {};
@@ -9,6 +10,7 @@ export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'khm_bnd_admin3_gov_ed2022.json',
 };

--- a/frontend/src/config/cambodia/reports.json
+++ b/frontend/src/config/cambodia/reports.json
@@ -1,0 +1,40 @@
+{
+  "flood_extent_report": {
+    "layer_id": "flood_extent",
+    "type": "floods",
+    "title_key": "Event name",
+    "title_value": "Flood Report",
+    "sub_title_key": "Publication Date",
+    "sub_text": "This is an automated report. Information should be treated as preliminary",
+    "areas_legend_definition": {
+      "title": "Areas",
+      "items": [
+        {
+          "title": "Province",
+          "color": "#000000"
+        },
+        {
+          "title": "District",
+          "color": "#999797"
+        },
+        {
+          "title": "Township",
+          "color": "#D8D6D6"
+        }
+      ]
+    },
+    "type_legend_definition": {
+      "title": "Potential Flooding",
+      "items": [
+        {
+          "title": "Flooded",
+          "color": "#a50f15"
+        }
+      ]
+    },
+    "sources_primary_text": "Sources WFP, UNGIWG, OCHA, GAUL, USGS, NASA, UCSB",
+    "sources_secondary_text": "The designations employed and the presentation of material in the map(s) do not imply the expression of any opinion on the part of WFP concerning the legal or constitutional status of any country, territory, city or sea, or concerning the delimitation of its frontiers or boundaries.",
+    "table_name": "Population Exposure",
+    "signature_text": "PRISM automated report"
+  }
+}

--- a/frontend/src/config/cameroon/index.ts
+++ b/frontend/src/config/cameroon/index.ts
@@ -3,12 +3,14 @@ import rawLayers from './layers.json';
 import frTranslation from './translation.json';
 
 const rawTables = {};
+const rawReports = {};
 const translation = { fr: frTranslation };
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'cmr_admbnda_adm2_wfp_ocha.json',
 };

--- a/frontend/src/config/colombia/index.ts
+++ b/frontend/src/config/colombia/index.ts
@@ -2,12 +2,14 @@ import appConfig from './prism.json';
 import rawLayers from './layers.json';
 
 const rawTables = {};
+const rawReports = {};
 const translation = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'col_municipios.json',
 };

--- a/frontend/src/config/cuba/index.ts
+++ b/frontend/src/config/cuba/index.ts
@@ -3,11 +3,13 @@ import rawLayers from './layers.json';
 import cubaTranslation from './translation.json';
 
 const rawTables = {};
+const rawReports = {};
 const translation = { es: cubaTranslation };
 
 export default {
   appConfig,
   rawLayers,
+  rawReports,
   rawTables,
   translation,
   defaultBoundariesFile: 'cub_admbnda_adm2_2019.json',

--- a/frontend/src/config/ecuador/index.ts
+++ b/frontend/src/config/ecuador/index.ts
@@ -3,12 +3,14 @@ import rawLayers from './layers.json';
 import ecuadorTranslation from './translation.json';
 
 const rawTables = {};
+const rawReports = {};
 const translation = { es: ecuadorTranslation };
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'ecu_admbnda_adm2.json',
 };

--- a/frontend/src/config/global/index.ts
+++ b/frontend/src/config/global/index.ts
@@ -2,12 +2,14 @@ import appConfig from './prism.json';
 import rawLayers from './layers.json';
 
 const rawTables = {};
+const rawReports = {};
 const translation = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'adm0_simplified.json',
 };

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -11,6 +11,7 @@ import {
   indonesiaConfig,
   indonesiaRawLayers,
   indonesiaRawTables,
+  indonesiaRawReports,
 } from './indonesia';
 import jordan from './jordan';
 import kyrgyzstan from './kyrgyzstan';
@@ -43,6 +44,7 @@ const configMap = {
     appConfig: indonesiaConfig,
     rawLayers: indonesiaRawLayers,
     rawTables: indonesiaRawTables,
+    rawReports: indonesiaRawReports,
     defaultBoundariesFile: 'idn_admin_boundaries.json',
   },
   jordan,
@@ -83,11 +85,13 @@ const {
   defaultBoundariesFile,
   rawLayers,
   rawTables,
+  rawReports,
 }: {
   appConfig: Record<string, any>;
   defaultBoundariesFile: string;
   rawLayers: Record<string, any>;
   rawTables: Record<string, any>;
+  rawReports: Record<string, any>;
 } = configMap[safeCountry];
 
 const translation = get(configMap[safeCountry], 'translation', {});
@@ -124,6 +128,7 @@ export {
   defaultBoundariesPath,
   rawLayers,
   rawTables,
+  rawReports,
   msalInstance,
   msalRequest,
   enableNavigationDropdown,

--- a/frontend/src/config/indonesia/index.ts
+++ b/frontend/src/config/indonesia/index.ts
@@ -2,4 +2,11 @@ import indonesiaConfig from './prism.json';
 import indonesiaRawLayers from './layers.json';
 import indonesiaRawTables from './tables.json';
 
-export { indonesiaConfig, indonesiaRawLayers, indonesiaRawTables };
+const indonesiaRawReports = {};
+
+export {
+  indonesiaConfig,
+  indonesiaRawLayers,
+  indonesiaRawTables,
+  indonesiaRawReports,
+};

--- a/frontend/src/config/jordan/index.ts
+++ b/frontend/src/config/jordan/index.ts
@@ -3,12 +3,14 @@ import rawLayers from './layers.json';
 import jordanTranslation from './translation.json';
 
 const rawTables = {};
+const rawReports = {};
 const translation = { عربى: jordanTranslation };
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'jor_admbnda_adm2_jdos.json',
 };

--- a/frontend/src/config/kyrgyzstan/index.ts
+++ b/frontend/src/config/kyrgyzstan/index.ts
@@ -2,12 +2,14 @@ import appConfig from './prism.json';
 import rawLayers from './layers.json';
 
 const rawTables = {};
+const rawReports = {};
 const translation = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'District_KRYG.json',
 };

--- a/frontend/src/config/mongolia/index.ts
+++ b/frontend/src/config/mongolia/index.ts
@@ -3,12 +3,14 @@ import rawLayers from './layers.json';
 import rawTables from './tables.json';
 import mongoliaTranslation from './translation.json';
 
+const rawReports = {};
 const translation = { mn: mongoliaTranslation };
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'admin_boundaries.json',
 };

--- a/frontend/src/config/mozambique/index.ts
+++ b/frontend/src/config/mozambique/index.ts
@@ -1,14 +1,16 @@
 import appConfig from './prism.json';
 import rawLayers from './layers.json';
+import rawTables from './tables.json';
+import rawReports from './reports.json';
 import mozambiqueTranslation from './translation.json';
 
-const rawTables = {};
 const translation = { pt: mozambiqueTranslation };
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'moz_bnd_adm2_WFP.json',
 };

--- a/frontend/src/config/mozambique/reports.json
+++ b/frontend/src/config/mozambique/reports.json
@@ -1,0 +1,56 @@
+{
+  "adamts_buffers_report": {
+    "layer_id": "adamts_buffers",
+    "type": "tropical storms",
+    "title_key": "Event name",
+    "title_value": "Storm Report",
+    "sub_title_key": "Publication Date",
+    "sub_text": "This is an automated report. Information should be treated as preliminary",
+    "areas_legend_definition": {
+      "title": "Areas",
+      "items": [
+        {
+          "title": "Province",
+          "color": "#000000"
+        },
+        {
+          "title": "District",
+          "color": "#999797"
+        },
+        {
+          "title": "Township",
+          "color": "#D8D6D6"
+        }
+      ]
+    },
+    "type_legend_definition": {
+      "title": "Tropical Storms - Wind buffers",
+      "items": [
+        {
+          "title": "Uncertainty Cones",
+          "color": "#ffffff",
+          "border": "#b8b1b1"
+        },
+        {
+          "title": "Wind Buffer 60 km/h",
+          "color": "#fffcf1",
+          "border": "#f7e705"
+        },
+        {
+          "title": "Wind Buffer 90 km/h",
+          "color": "#ffeed8",
+          "border": "#f99408"
+        },
+        {
+          "title": "Wind Buffer 120 km/h",
+          "color": "#fcd4ce",
+          "border": "#f90c08"
+        }
+      ]
+    },
+    "sources_primary_text": "Sources WFP, UNGIWG, OCHA, GAUL, USGS, NASA, UCSB",
+    "sources_secondary_text": "The designations employed and the presentation of material in the map(s) do not imply the expression of any opinion on the part of WFP concerning the legal or constitutional status of any country, territory, city or sea, or concerning the delimitation of its frontiers or boundaries.",
+    "table_name": "Population Exposure",
+    "signature_text": "PRISM automated report"
+  }
+}

--- a/frontend/src/config/myanmar/index.ts
+++ b/frontend/src/config/myanmar/index.ts
@@ -1,5 +1,6 @@
 import appConfig from './prism.json';
 import rawLayers from './layers.json';
+import rawReports from './reports.json';
 // import myanmarTranslation from './translation.json';
 
 const rawTables = {};
@@ -9,6 +10,7 @@ export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'mmr_polbnda_adm3_250k_mimu.json',
 };

--- a/frontend/src/config/myanmar/reports.json
+++ b/frontend/src/config/myanmar/reports.json
@@ -1,0 +1,94 @@
+{
+  "flood_extent_report": {
+    "layer_id": "flood_extent",
+    "type": "floods",
+    "title_key": "Event name",
+    "title_value": "Flood Report",
+    "sub_title_key": "Publication Date",
+    "sub_text": "This is an automated report. Information should be treated as preliminary",
+    "areas_legend_definition": {
+      "title": "Areas",
+      "items": [
+        {
+          "title": "Province",
+          "color": "#000000"
+        },
+        {
+          "title": "District",
+          "color": "#999797"
+        },
+        {
+          "title": "Township",
+          "color": "#D8D6D6"
+        }
+      ]
+    },
+    "type_legend_definition": {
+      "title": "Potential Flooding",
+      "items": [
+        {
+          "title": "Flooded",
+          "color": "#a50f15"
+        }
+      ]
+    },
+    "sources_primary_text": "Sources WFP, UNGIWG, OCHA, GAUL, USGS, NASA, UCSB",
+    "sources_secondary_text": "The designations employed and the presentation of material in the map(s) do not imply the expression of any opinion on the part of WFP concerning the legal or constitutional status of any country, territory, city or sea, or concerning the delimitation of its frontiers or boundaries.",
+    "table_name": "Population Exposure",
+    "signature_text": "PRISM automated report"
+  },
+  "adamts_buffers_report": {
+    "layer_id": "adamts_buffers",
+    "type": "tropical storms",
+    "title_key": "Event name",
+    "title_value": "Storm Report",
+    "sub_title_key": "Publication Date",
+    "sub_text": "This is an automated report. Information should be treated as preliminary",
+    "areas_legend_definition": {
+      "title": "Areas",
+      "items": [
+        {
+          "title": "Province",
+          "color": "#000000"
+        },
+        {
+          "title": "District",
+          "color": "#999797"
+        },
+        {
+          "title": "Township",
+          "color": "#D8D6D6"
+        }
+      ]
+    },
+    "type_legend_definition": {
+      "title": "Tropical Storms - Wind buffers",
+      "items": [
+        {
+          "title": "Uncertainty Cones",
+          "color": "#ffffff",
+          "border": "#b8b1b1"
+        },
+        {
+          "title": "Wind Buffer 60 km/h",
+          "color": "#fffcf1",
+          "border": "#f7e705"
+        },
+        {
+          "title": "Wind Buffer 90 km/h",
+          "color": "#ffeed8",
+          "border": "#f99408"
+        },
+        {
+          "title": "Wind Buffer 120 km/h",
+          "color": "#fcd4ce",
+          "border": "#f90c08"
+        }
+      ]
+    },
+    "sources_primary_text": "Sources WFP, UNGIWG, OCHA, GAUL, USGS, NASA, UCSB",
+    "sources_secondary_text": "The designations employed and the presentation of material in the map(s) do not imply the expression of any opinion on the part of WFP concerning the legal or constitutional status of any country, territory, city or sea, or concerning the delimitation of its frontiers or boundaries.",
+    "table_name": "Population Exposure",
+    "signature_text": "PRISM automated report"
+  }
+}

--- a/frontend/src/config/namibia/index.ts
+++ b/frontend/src/config/namibia/index.ts
@@ -2,10 +2,12 @@ import appConfig from './prism.json';
 import rawLayers from './layers.json';
 
 const rawTables = {};
+const rawReports = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   defaultBoundariesFile: 'nam_admin2.json',
 };

--- a/frontend/src/config/nigeria/index.ts
+++ b/frontend/src/config/nigeria/index.ts
@@ -2,12 +2,14 @@ import appConfig from './prism.json';
 import rawLayers from './layers.json';
 
 const rawTables = {};
+const rawReports = {};
 const translation = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'nga_admbnda_adm2_osgof_20190417.json',
 };

--- a/frontend/src/config/rbd/index.ts
+++ b/frontend/src/config/rbd/index.ts
@@ -5,11 +5,13 @@ import frTranslation from './translation.json';
 const translation = { fr: frTranslation };
 
 const rawTables = {};
+const rawReports = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'wca_admbnda_adm2_ocha.json',
 };

--- a/frontend/src/config/sierraleone/index.ts
+++ b/frontend/src/config/sierraleone/index.ts
@@ -2,12 +2,14 @@ import appConfig from './prism.json';
 import rawLayers from './layers.json';
 
 const rawTables = {};
+const rawReports = {};
 const translation = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'sle_admin2new_boundary_20200309.json',
 };

--- a/frontend/src/config/southsudan/index.ts
+++ b/frontend/src/config/southsudan/index.ts
@@ -2,10 +2,12 @@ import appConfig from './prism.json';
 import rawLayers from './layers.json';
 
 const rawTables = {};
+const rawReports = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   defaultBoundariesFile: 'ssd_admbnda_adm2_imwg_nbs_20180817.json',
 };

--- a/frontend/src/config/srilanka/index.ts
+++ b/frontend/src/config/srilanka/index.ts
@@ -3,11 +3,13 @@ import rawLayers from './layers.json';
 
 const rawTables = {};
 const translation = {};
+const rawReports = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'lka_bnd_adm3.json',
 };

--- a/frontend/src/config/tajikistan/index.ts
+++ b/frontend/src/config/tajikistan/index.ts
@@ -2,10 +2,12 @@ import appConfig from './prism.json';
 import rawLayers from './layers.json';
 
 const rawTables = {};
+const rawReports = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   defaultBoundariesFile: 'tjk_admin2_wgs84_clean.json',
 };

--- a/frontend/src/config/types.ts
+++ b/frontend/src/config/types.ts
@@ -3,7 +3,7 @@ import { every, map } from 'lodash';
 import { FillPaint, LinePaint } from 'mapbox-gl';
 import 'reflect-metadata';
 import { rawLayers } from '.';
-import type { TableKey } from './utils';
+import type { ReportKey, TableKey } from './utils';
 
 // TODO currently unused. Could be harnessed within admin levels key typing
 export type BoundaryKey = 'CODE' | 'CODE1' | 'CODE2';
@@ -630,6 +630,49 @@ export interface ChartConfig {
   fill?: boolean;
   displayLegend?: boolean;
   colors?: string[]; // Array of hex codes.
+}
+
+export enum ReportTypeEnum {
+  FLOODS = 'floods',
+  TROPICAL_STORMS = 'tropical storms',
+}
+
+export interface ReportLegendDefinitionItem {
+  title: string;
+  color: string;
+  border?: string;
+}
+
+export interface ReportLegendDefinition {
+  title: string;
+  items: ReportLegendDefinitionItem[];
+}
+
+export class ReportType {
+  id: ReportKey;
+  layerId: LayerKey;
+  type: ReportTypeEnum;
+  titleKey: string;
+  titleValue: string;
+  subTitleKey: string;
+
+  @optional
+  subText?: string;
+
+  areasLegendDefinition: ReportLegendDefinition;
+  typeLegendDefinition: ReportLegendDefinition;
+
+  @optional
+  sourcesPrimaryText?: string;
+
+  @optional
+  sourcesSecondaryText?: string;
+
+  @optional
+  tableName?: string;
+
+  @optional
+  signatureText?: string;
 }
 
 export class TableType {

--- a/frontend/src/config/ukraine/index.ts
+++ b/frontend/src/config/ukraine/index.ts
@@ -3,11 +3,13 @@ import rawLayers from './layers.json';
 
 const rawTables = {};
 const translation = {};
+const rawReports = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'ukr_admbnda_adm2_sspe_20220114.json',
 };

--- a/frontend/src/config/zimbabwe/index.ts
+++ b/frontend/src/config/zimbabwe/index.ts
@@ -2,12 +2,14 @@ import appConfig from './prism.json';
 import rawLayers from './layers.json';
 
 const rawTables = {};
+const rawReports = {};
 const translation = {};
 
 export default {
   appConfig,
   rawLayers,
   rawTables,
+  rawReports,
   translation,
   defaultBoundariesFile: 'zim_admin2_boundaries_v2.json',
 };

--- a/frontend/src/context/analysisResultStateSlice.ts
+++ b/frontend/src/context/analysisResultStateSlice.ts
@@ -76,6 +76,7 @@ type AnalysisResultState = {
   tableData?: TableData;
   result?: AnalysisResult;
   error?: string;
+  exposureLayerId: string;
   isLoading: boolean;
   isMapLayerActive: boolean;
   isDataTableDrawerActive: boolean;
@@ -99,6 +100,7 @@ const initialState: AnalysisResultState = {
   isLoading: false,
   isMapLayerActive: true,
   isDataTableDrawerActive: false,
+  exposureLayerId: '',
   isExposureLoading: false,
   analysisResultDataSortByKey: 'name',
   analysisResultDataSortOrder: 'asc',
@@ -802,6 +804,10 @@ export const analysisResultSlice = createSlice({
       ...state,
       isMapLayerActive: payload,
     }),
+    setExposureLayerId: (state, { payload }: PayloadAction<string>) => ({
+      ...state,
+      exposureLayerId: payload,
+    }),
     setIsDataTableDrawerActive: (
       state,
       { payload }: PayloadAction<boolean>,
@@ -942,6 +948,9 @@ export const analysisResultSortOrderSelector = (
   state: RootState,
 ): 'asc' | 'desc' => state.analysisResultState.analysisResultDataSortOrder;
 
+export const exposureLayerIdSelector = (state: RootState): string =>
+  state.analysisResultState.exposureLayerId;
+
 export const analysisResultOpacitySelector = (state: RootState): number =>
   state.analysisResultState.opacity;
 
@@ -962,6 +971,7 @@ export const {
   setIsMapLayerActive,
   setIsDataTableDrawerActive,
   setAnalysisLayerOpacity,
+  setExposureLayerId,
   setCurrentDataDefinition,
   hideDataTableDrawer,
   clearAnalysisResult,


### PR DESCRIPTION
This PR tries to add `reports.json` to existing countries for dynamic configuration of reports. Everything will be dynamically rendered with the following structure:

**Flood Reports**
```
  "flood_extent_report": {
    "layer_id": "flood_extent",
    "type": "floods",
    "title_key": "Event name",
    "title_value": "Flood Report",
    "sub_title_key": "Publication Date",
    "sub_text": "This is an automated report. Information should be treated as preliminary",
    "areas_legend_definition": {
      "title": "Areas",
      "items": [
        {
          "title": "Province",
          "color": "#000000"
        },
        {
          "title": "District",
          "color": "#999797"
        },
        {
          "title": "Township",
          "color": "#D8D6D6"
        }
      ]
    },
    "type_legend_definition": {
      "title": "Potential Flooding",
      "items": [
        {
          "title": "Flooded",
          "color": "#a50f15"
        }
      ]
    },
    "sources_primary_text": "Sources WFP, UNGIWG, OCHA, GAUL, USGS, NASA, UCSB",
    "sources_secondary_text": "The designations employed and the presentation of material in the map(s) do not imply the expression of any opinion on the part of WFP concerning the legal or constitutional status of any country, territory, city or sea, or concerning the delimitation of its frontiers or boundaries.",
    "table_name": "Population Exposure",
    "signature_text": "PRISM automated report"
  }

```
Every report will be associated with a layer based on a  `layer_id`, which will be in sync with 1 - 1 with the layer in a future enhancement, we may have multiple exposure analysis reports for the same layer with this approach. Key notes:

 - `layerId` -> exact same name as a layer key in `layers.json`
 - `type` -> will be either `floods` or `tropical storms` at the moment based on the `ReportTypeEnum` through the codebase
 - Everything on the title will be dynamic such as `title_key`, `title_value`, `sub_title_key`, `sub_text`, 
 - `areas_legend_definition` -> will be the `LegendDefinition` of the report for the admin codes, I added it as an array with items so we can configure it as we may not always have 3 admin levels. Colors are also added here so that we may need to configure them
 - `type_legend_definition` -> will be the legend definition of the specifi type currently we have `floods` or `tropical storms` it will have a title which will be added in the report and items to render below, there is also an optional property `border` specifically for `tropical storms` inside an item. By default will always have a title and a color and optionally a border see `tropical storms` structure below.
 - Also added dynamic texts such as `sources_primary_text`, `sources_secondary_text`, `table_name` and `signature_text`, they are all optionally added, so we can ignore them. Keep in mind that if an optional text is missing we are not rendering a default at the moment except for the `signature_text`, which will render `PRISM automated report` if its missing.
 
 Right now if a country config has exposure analysis reports and does not have a layer id inside of a report the `ExposureAnalysis` button is not rendered in the layer in the left panel. 
 
 Currently we have exposure analysis reports. Cambodia, Mozambique, Myanmar and Tajikistan. The `reports.json`, have been created for all except Tajikistan, so at the moment Tajikistan is not configured.
 
 @ericboucher @wadhwamatic I'd like your thoughts on this. Anything that you feel like it shouldn't be in the config we can easily revert it and reevaluated. Below there is a config with `tropical storms`:
 
 ```
 {
  "adamts_buffers_report": {
    "layer_id": "adamts_buffers",
    "type": "tropical storms",
    "title_key": "Event name",
    "title_value": "Storm Report",
    "sub_title_key": "Publication Date",
    "sub_text": "This is an automated report. Information should be treated as preliminary",
    "areas_legend_definition": {
      "title": "Areas",
      "items": [
        {
          "title": "Province",
          "color": "#000000"
        },
        {
          "title": "District",
          "color": "#999797"
        },
        {
          "title": "Township",
          "color": "#D8D6D6"
        }
      ]
    },
    "type_legend_definition": {
      "title": "Tropical Storms - Wind buffers",
      "items": [
        {
          "title": "Uncertainty Cones",
          "color": "#ffffff",
          "border": "#b8b1b1"
        },
        {
          "title": "Wind Buffer 60 km/h",
          "color": "#fffcf1",
          "border": "#f7e705"
        },
        {
          "title": "Wind Buffer 90 km/h",
          "color": "#ffeed8",
          "border": "#f99408"
        },
        {
          "title": "Wind Buffer 120 km/h",
          "color": "#fcd4ce",
          "border": "#f90c08"
        }
      ]
    },
    "sources_primary_text": "Sources WFP, UNGIWG, OCHA, GAUL, USGS, NASA, UCSB",
    "sources_secondary_text": "The designations employed and the presentation of material in the map(s) do not imply the expression of any opinion on the part of WFP concerning the legal or constitutional status of any country, territory, city or sea, or concerning the delimitation of its frontiers or boundaries.",
    "table_name": "Population Exposure",
    "signature_text": "PRISM automated report"
  }
}

 ```
