### PR TITLE
Deactivate layers after failing to load dates

### DIFF
--- a/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/__snapshots__/index.test.tsx.snap
@@ -2,11 +2,8 @@
 
 exports[`TimelineLabel renders as expected 1`] = `
 <div>
-  <mock-typography
-    classname="TimelineLabel-dateItemLabel-1"
-    variant="body2"
-  >
-    juillet 2023
-  </mock-typography>
+  <div
+    class="TimelineLabel-dayItem-2"
+  />
 </div>
 `;

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TimelineLabel renders as expected 1`] = `
     classname="TimelineLabel-dateItemLabel-1"
     variant="body2"
   >
-    juin 2023
+    juillet 2023
   </mock-typography>
 </div>
 `;

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/index.test.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/index.test.tsx
@@ -7,11 +7,11 @@ test('TimelineLabel renders as expected', () => {
   const props: Omit<TimelineLabelProps, 'classes'> = {
     locale: 'fr',
     date: {
-      value: new Date().getTime(),
-      date: new Date().toISOString(),
-      label: '',
-      month: '',
-      isFirstDay: true,
+      value: 1640883600000,
+      label: '31 Dec 2021',
+      month: 'Dec 2021',
+      isFirstDay: false,
+      date: '2021-12-31',
     },
   };
 

--- a/frontend/src/components/MapView/FoldButton/index.tsx
+++ b/frontend/src/components/MapView/FoldButton/index.tsx
@@ -10,14 +10,12 @@ import DragIndicatorIcon from '@material-ui/icons/DragIndicator';
 import React, { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useSafeTranslation } from '../../../i18n';
-import { activeLayersSelector } from '../../../context/mapStateSlice/selectors';
 import { analysisResultSelector } from '../../../context/analysisResultStateSlice';
-import { LayerType } from '../../../config/types';
-import { filterActiveLayers } from '../utils';
 
 interface IProps {
   isPanelHidden: boolean;
   setIsPanelHidden: React.Dispatch<React.SetStateAction<boolean>>;
+  activeLayers: number;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -43,28 +41,25 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const FoldButton = ({ isPanelHidden, setIsPanelHidden }: IProps) => {
+const FoldButton = ({
+  isPanelHidden,
+  setIsPanelHidden,
+  activeLayers,
+}: IProps) => {
   const classes = useStyles();
   const { t } = useSafeTranslation();
-  const activeLayers = useSelector(activeLayersSelector);
   const analysisData = useSelector(analysisResultSelector);
 
   const onClick = useCallback(() => {
     setIsPanelHidden(value => !value);
   }, [setIsPanelHidden]);
 
-  const groupedActiveLayers = useMemo(() => {
-    return activeLayers.filter((activeLayer: LayerType) => {
-      return filterActiveLayers(activeLayer, activeLayer);
-    });
-  }, [activeLayers]);
-
   const badgeContent = useMemo(() => {
     if (!analysisData) {
-      return groupedActiveLayers.length;
+      return activeLayers;
     }
-    return groupedActiveLayers.length + 1;
-  }, [groupedActiveLayers.length, analysisData]);
+    return activeLayers + 1;
+  }, [activeLayers, analysisData]);
 
   const renderedIcon = useMemo(() => {
     if (isPanelHidden && badgeContent >= 1) {

--- a/frontend/src/components/MapView/FoldButton/index.tsx
+++ b/frontend/src/components/MapView/FoldButton/index.tsx
@@ -13,7 +13,7 @@ import { useSafeTranslation } from '../../../i18n';
 import { activeLayersSelector } from '../../../context/mapStateSlice/selectors';
 import { analysisResultSelector } from '../../../context/analysisResultStateSlice';
 import { LayerType } from '../../../config/types';
-import { filterActiveGroupedLayers } from '../utils';
+import { filterActiveLayers } from '../utils';
 
 interface IProps {
   isPanelHidden: boolean;
@@ -55,7 +55,7 @@ const FoldButton = ({ isPanelHidden, setIsPanelHidden }: IProps) => {
 
   const groupedActiveLayers = useMemo(() => {
     return activeLayers.filter((activeLayer: LayerType) => {
-      return filterActiveGroupedLayers(activeLayer, activeLayer);
+      return filterActiveLayers(activeLayer, activeLayer);
     });
   }, [activeLayers]);
 

--- a/frontend/src/components/MapView/LeftPanel/LeftPanelTabs/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/LeftPanelTabs/index.tsx
@@ -16,17 +16,15 @@ import {
 import React, { memo, useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { sum } from 'lodash';
-import { LayerType, PanelSize } from '../../../../config/types';
+import { PanelSize } from '../../../../config/types';
 import { getWMSLayersWithChart } from '../../../../config/utils';
 import {
   leftPanelTabValueSelector,
   setTabValue,
 } from '../../../../context/leftPanelStateSlice';
 import { useSafeTranslation } from '../../../../i18n';
-import { activeLayersSelector } from '../../../../context/mapStateSlice/selectors';
 import TabPanel from './TabPanel';
 import { analysisResultSelector } from '../../../../context/analysisResultStateSlice';
-import { filterActiveLayers } from '../../utils';
 
 interface StyleProps {
   tabValue: number;
@@ -79,6 +77,7 @@ interface TabsProps {
   panelSize: PanelSize;
   resultsPage: JSX.Element | null;
   setPanelSize: React.Dispatch<React.SetStateAction<PanelSize>>;
+  activeLayers: number;
 }
 
 const LeftPanelTabs = memo(
@@ -91,19 +90,13 @@ const LeftPanelTabs = memo(
     panelSize,
     resultsPage,
     setPanelSize,
+    activeLayers,
   }: TabsProps) => {
     const { t } = useSafeTranslation();
     const dispatch = useDispatch();
     const tabValue = useSelector(leftPanelTabValueSelector);
-    const activeLayers = useSelector(activeLayersSelector);
     const analysisData = useSelector(analysisResultSelector);
     const classes = useStyles({ panelSize, tabValue });
-
-    const groupedActiveLayers = useMemo(() => {
-      return activeLayers.filter((activeLayer: LayerType) => {
-        return filterActiveLayers(activeLayer, activeLayer);
-      });
-    }, [activeLayers]);
 
     const areChartLayersAvailable = useMemo(() => {
       return getWMSLayersWithChart().length > 0;
@@ -119,10 +112,10 @@ const LeftPanelTabs = memo(
 
     const layersBadgeContent = useMemo(() => {
       if (!analysisData) {
-        return groupedActiveLayers.length;
+        return activeLayers;
       }
-      return groupedActiveLayers.length + 1;
-    }, [groupedActiveLayers.length, analysisData]);
+      return activeLayers + 1;
+    }, [activeLayers, analysisData]);
 
     const renderedLayersTabLabel = useMemo(() => {
       if (

--- a/frontend/src/components/MapView/LeftPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/index.tsx
@@ -30,7 +30,13 @@ const useStyles = makeStyles<Theme, StyleProps>(() =>
 );
 
 const LeftPanel = memo(
-  ({ extent, panelSize, setPanelSize, isPanelHidden }: LeftPanelProps) => {
+  ({
+    extent,
+    panelSize,
+    setPanelSize,
+    isPanelHidden,
+    activeLayers,
+  }: LeftPanelProps) => {
     const classes = useStyles({ panelSize });
     const [resultsPage, setResultsPage] = React.useState<JSX.Element | null>(
       null,
@@ -72,6 +78,7 @@ const LeftPanel = memo(
           setPanelSize={setPanelSize}
           areTablesAvailable={areTablesAvailable}
           resultsPage={resultsPage}
+          activeLayers={activeLayers}
           layersPanel={
             <LayersPanel layersMenuItems={layersMenuItems} extent={extent} />
           }
@@ -107,6 +114,7 @@ interface LeftPanelProps {
   panelSize: PanelSize;
   setPanelSize: React.Dispatch<React.SetStateAction<PanelSize>>;
   isPanelHidden: boolean;
+  activeLayers: number;
 }
 
 export default LeftPanel;

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.tsx
@@ -44,7 +44,8 @@ import { Extent } from '../../../../Layers/raster-utils';
 import LayerDownloadOptions from './LayerDownloadOptions';
 import ExposureAnalysisOption from './ExposureAnalysisOption';
 import { availableDatesSelector } from '../../../../../../context/serverStateSlice';
-import { addNotification } from '../../../../../../context/notificationStateSlice';
+import { checkLayerAvailableDatesAndContinueOrRemove } from '../../../../utils';
+import { LocalError } from '../../../../../../utils/error-utils';
 
 const SwitchItem = memo(({ classes, layer, extent }: SwitchItemProps) => {
   const {
@@ -160,14 +161,15 @@ const SwitchItem = memo(({ classes, layer, extent }: SwitchItemProps) => {
         });
         return;
       }
-      const { serverLayerName } = layer as any;
-      if (serverAvailableDates[serverLayerName]?.length === 0) {
-        dispatch(
-          addNotification({
-            message: `The layer: ${layer.title} does not have available dates to load`,
-            type: 'warning',
-          }),
+      try {
+        checkLayerAvailableDatesAndContinueOrRemove(
+          layer,
+          serverAvailableDates,
+          removeLayerFromUrl,
+          dispatch,
         );
+      } catch (error) {
+        console.error((error as LocalError).getErrorMessage());
         return;
       }
       const updatedUrl = appendLayerToUrl(

--- a/frontend/src/components/MapView/index.tsx
+++ b/frontend/src/components/MapView/index.tsx
@@ -216,12 +216,7 @@ const MapView = memo(({ classes }: MapViewProps) => {
     missingLayers.forEach(layerId => {
       const layer = LayerDefinitions[layerId as LayerKey];
       const { serverLayerName } = layer as any;
-      if (
-        // The layer does not have date support
-        serverAvailableDates[serverLayerName] !== undefined &&
-        // The layer does have date support but no additional available dates are loaded
-        serverAvailableDates[serverLayerName].length === 0
-      ) {
+      if (serverAvailableDates[serverLayerName]?.length === 0) {
         const urlLayerKey = getUrlKey(layer);
         removeLayerFromUrl(urlLayerKey, layerId);
         dispatch(

--- a/frontend/src/components/MapView/index.tsx
+++ b/frontend/src/components/MapView/index.tsx
@@ -215,9 +215,26 @@ const MapView = memo(({ classes }: MapViewProps) => {
   const addMissingLayers = useCallback(() => {
     missingLayers.forEach(layerId => {
       const layer = LayerDefinitions[layerId as LayerKey];
+      const { serverLayerName } = layer as any;
+      if (
+        // The layer does not have date support
+        serverAvailableDates[serverLayerName] !== undefined &&
+        // The layer does have date support but no additional available dates are loaded
+        serverAvailableDates[serverLayerName].length === 0
+      ) {
+        const urlLayerKey = getUrlKey(layer);
+        removeLayerFromUrl(urlLayerKey, layerId);
+        dispatch(
+          addNotification({
+            message: `The layer: ${layer.title} does not have available dates to load`,
+            type: 'warning',
+          }),
+        );
+        return;
+      }
       dispatch(addLayer(layer));
     });
-  }, [dispatch, missingLayers]);
+  }, [dispatch, missingLayers, removeLayerFromUrl, serverAvailableDates]);
 
   // The date integer from url
   const dateInt = useMemo(() => {

--- a/frontend/src/components/MapView/utils.ts
+++ b/frontend/src/components/MapView/utils.ts
@@ -131,7 +131,7 @@ export const generateUniqueTableKey = (activityName: string) => {
 /**
  * Filters the active layers in a group based on the activateAll property
  */
-export const filterActiveGroupedLayers = (
+const filterActiveGroupedLayers = (
   selectedLayer: LayerType,
   categoryLayer: LayerType,
 ): boolean | undefined => {
@@ -153,6 +153,13 @@ export const filterActiveLayers = (
   selectedLayer: LayerType,
   categoryLayer: LayerType,
 ): boolean | undefined => {
+  // Special case for tropical storms `adamts_buffers`
+  if (
+    selectedLayer.id.includes('adamts') &&
+    selectedLayer.id.includes('adamts')
+  ) {
+    return filterActiveGroupedLayers(selectedLayer, categoryLayer);
+  }
   return (
     selectedLayer.id === categoryLayer.id ||
     filterActiveGroupedLayers(selectedLayer, categoryLayer)

--- a/frontend/src/components/MapView/utils.ts
+++ b/frontend/src/components/MapView/utils.ts
@@ -1,10 +1,12 @@
 import { values } from 'lodash';
 import { Map } from 'mapbox-gl';
 import { TFunction } from 'i18next';
+import { Dispatch } from 'redux';
 import { LayerDefinitions } from '../../config/utils';
 import { formatFeatureInfo } from '../../utils/server-utils';
 import { getExtent } from './Layers/raster-utils';
 import {
+  AvailableDates,
   FeatureInfoObject,
   FeatureInfoType,
   LayerType,
@@ -12,6 +14,9 @@ import {
   WMSLayerProps,
 } from '../../config/types';
 import { TableData } from '../../context/tableStateSlice';
+import { getUrlKey, UrlLayerKey } from '../../utils/url-utils';
+import { addNotification } from '../../context/notificationStateSlice';
+import { LocalError } from '../../utils/error-utils';
 
 export const getActiveFeatureInfoLayers = (map: Map): WMSLayerProps[] => {
   const matchStr = 'layer-';
@@ -128,6 +133,27 @@ export const generateUniqueTableKey = (activityName: string) => {
   return `${activityName}_${Date.now()}`;
 };
 
+export const checkLayerAvailableDatesAndContinueOrRemove = (
+  layer: LayerType,
+  serverAvailableDates: AvailableDates,
+  removeLayerFromUrl: (layerKey: UrlLayerKey, layerId: string) => void,
+  dispatch: Dispatch,
+) => {
+  const { serverLayerName } = layer as any;
+  if (serverAvailableDates[serverLayerName]?.length !== 0) {
+    return;
+  }
+  const urlLayerKey = getUrlKey(layer);
+  removeLayerFromUrl(urlLayerKey, layer.id);
+  dispatch(
+    addNotification({
+      message: `The layer: ${layer.title} does not have available dates to load`,
+      type: 'warning',
+    }),
+  );
+  throw new LocalError('Layer does not have available dates to load'); // Stop code execution
+};
+
 /**
  * Filters the active layers in a group based on the activateAll property
  */
@@ -153,13 +179,6 @@ export const filterActiveLayers = (
   selectedLayer: LayerType,
   categoryLayer: LayerType,
 ): boolean | undefined => {
-  // Special case for tropical storms `adamts_buffers`
-  if (
-    selectedLayer.id.includes('adamts') &&
-    selectedLayer.id.includes('adamts')
-  ) {
-    return filterActiveGroupedLayers(selectedLayer, categoryLayer);
-  }
   return (
     selectedLayer.id === categoryLayer.id ||
     filterActiveGroupedLayers(selectedLayer, categoryLayer)

--- a/frontend/src/utils/server-utils.ts
+++ b/frontend/src/utils/server-utils.ts
@@ -310,7 +310,7 @@ const localFetchCoverageLayerDays = async (
     return await fetchCoverageLayerDays(url, { fetch: fetchWithTimeout });
   } catch (error) {
     console.error(error);
-    if (error.name === 'AbortError') {
+    if ((error as Error).name === 'AbortError') {
       dispatch(
         addNotification({
           message: `Request at ${url} timeout`,
@@ -339,7 +339,7 @@ const localWMSGetLayerDates = async (
     return await new WMS(url, { fetch: fetchWithTimeout }).getLayerDays();
   } catch (error) {
     console.error(error);
-    if (error.name === 'AbortError') {
+    if ((error as Error).name === 'AbortError') {
       dispatch(
         addNotification({
           message: `Request at ${url} timeout`,
@@ -356,6 +356,22 @@ const localWMSGetLayerDates = async (
     return {};
   }
 };
+
+// The layer definitions bluerPrint is used as a schema for the availableDates if a request is failed to be fulfilled
+const layerDefinitionsBluePrint: AvailableDates = Object.keys(
+  LayerDefinitions,
+).reduce((acc, layerDefinitionKey) => {
+  const { serverLayerName } = LayerDefinitions[layerDefinitionKey] as any;
+  if (!serverLayerName) {
+    return {
+      ...acc,
+    };
+  }
+  return {
+    ...acc,
+    [serverLayerName]: [],
+  };
+}, {});
 
 /**
  * Load available dates for WMS and WCS using a serverUri defined in prism.json and for GeoJSONs (point data) using their API endpoint.
@@ -421,7 +437,7 @@ export async function getLayersAvailableDates(
       : dates.map((d: number) => createDefaultDateItem(d));
 
     return { ...acc, [layerKey]: updatedDates };
-  }, {});
+  }, layerDefinitionsBluePrint);
 }
 
 /**


### PR DESCRIPTION
This branch deactivates the layers when no available dates are loaded with dispatching a message to info the user. Also this branch fixes a miscalculation of the active layers with the special case of Tropical Storms (Myanmar). Currently this applies to every country. The way to test this is to thow custom exceptions to the different functions that populate the dates to the `getLayersAvailableDates`, such us `localWMSGetLayerDates`, `localFetchCoverageLayerDays`, `getPointDataCoverage`. Those async functions are populating the dates remotely so if one of them throws an error we will not get the possible dates for some layers and we wil be able to test the feature of deactivating those layers that do not have available dates.
