### PR TITLE
Removes relative paths from imports

### DIFF
--- a/frontend/src/components/404Page/index.tsx
+++ b/frontend/src/components/404Page/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 
-import { colors } from '../../muiTheme';
+import { colors } from 'muiTheme';
 
 function NotFound({ classes }: NotFoundProps) {
   return (

--- a/frontend/src/components/App/index.test.tsx
+++ b/frontend/src/components/App/index.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from '.';
 
-jest.mock('../NavBar', () => 'mock-NavBar');
-jest.mock('../MapView', () => 'mock-MapView');
-jest.mock('../404Page', () => 'mock-NotFound');
-jest.mock('../Notifier', () => 'mock-Notifier');
-jest.mock('../AuthModal', () => 'mock-AuthModal');
+jest.mock('components/NavBar', () => 'mock-NavBar');
+jest.mock('components/MapView', () => 'mock-MapView');
+jest.mock('components/404Page', () => 'mock-NotFound');
+jest.mock('components/Notifier', () => 'mock-Notifier');
+jest.mock('components/AuthModal', () => 'mock-AuthModal');
 
 test('renders as expected', () => {
   const { container } = render(<App />);

--- a/frontend/src/components/App/index.tsx
+++ b/frontend/src/components/App/index.tsx
@@ -4,15 +4,15 @@ import { useIsAuthenticated } from '@azure/msal-react';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { Font } from '@react-pdf/renderer';
-import { authRequired } from '../../config';
+import { authRequired } from 'config';
+import NavBar from 'components/NavBar';
+import MapView from 'components/MapView';
+import Login from 'components/Login';
+import muiTheme from 'muiTheme';
+import Notifier from 'components/Notifier';
+import AuthModal from 'components/AuthModal';
 // Basic CSS Layout for the whole page
 import './app.css';
-import NavBar from '../NavBar';
-import MapView from '../MapView';
-import Login from '../Login';
-import muiTheme from '../../muiTheme';
-import Notifier from '../Notifier';
-import AuthModal from '../AuthModal';
 
 if (process.env.NODE_ENV && process.env.NODE_ENV !== 'development') {
   if (process.env.REACT_APP_SENTRY_URL) {

--- a/frontend/src/components/AuthModal/index.tsx
+++ b/frontend/src/components/AuthModal/index.tsx
@@ -20,16 +20,12 @@ import {
   withStyles,
 } from '@material-ui/core';
 import { TFunctionKeys } from 'i18next';
-import { useSafeTranslation } from '../../i18n';
-import { layersSelector } from '../../context/mapStateSlice/selectors';
-
-import {
-  setUserAuthGlobal,
-  userAuthSelector,
-} from '../../context/serverStateSlice';
-import { UserAuth } from '../../config/types';
-import { getUrlKey, useUrlHistory } from '../../utils/url-utils';
-import { removeLayer } from '../../context/mapStateSlice';
+import { useSafeTranslation } from 'i18n';
+import { layersSelector } from 'context/mapStateSlice/selectors';
+import { setUserAuthGlobal, userAuthSelector } from 'context/serverStateSlice';
+import { UserAuth } from 'config/types';
+import { getUrlKey, useUrlHistory } from 'utils/url-utils';
+import { removeLayer } from 'context/mapStateSlice';
 
 const AuthModal = ({ classes }: AuthModalProps) => {
   const initialAuthState: UserAuth = {

--- a/frontend/src/components/Common/BoundaryDropdown/goto.tsx
+++ b/frontend/src/components/Common/BoundaryDropdown/goto.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { makeStyles, Theme } from '@material-ui/core';
 import { CenterFocusWeak } from '@material-ui/icons';
+import { useSafeTranslation } from 'i18n';
 import BoundaryDropdown, { MapInteraction } from '.';
-
-import { useSafeTranslation } from '../../../i18n';
 
 // TODO - Dedup files and styling in BoundaryDropdown.tsx
 const useStyles = makeStyles((theme: Theme) => ({

--- a/frontend/src/components/Common/BoundaryDropdown/index.tsx
+++ b/frontend/src/components/Common/BoundaryDropdown/index.tsx
@@ -12,8 +12,8 @@ import { uniq } from 'lodash';
 import {
   mapSelector,
   boundaryRelationSelector,
-} from '../../../context/mapStateSlice/selectors';
-import { useSafeTranslation } from '../../../i18n';
+} from 'context/mapStateSlice/selectors';
+import { useSafeTranslation } from 'i18n';
 
 import SearchBar from './searchBar';
 import { setMenuItemStyle, containsText, createMatchesTree } from './utils';

--- a/frontend/src/components/Common/BoundaryDropdown/utils.ts
+++ b/frontend/src/components/Common/BoundaryDropdown/utils.ts
@@ -1,7 +1,7 @@
 import type { Feature, MultiPolygon, BBox } from '@turf/helpers';
 import { sortBy } from 'lodash';
 import bbox from '@turf/bbox';
-import { BoundaryLayerData } from '../../../context/layers/boundary';
+import { BoundaryLayerData } from 'context/layers/boundary';
 
 export type BoundaryRelationsDict = { [key: string]: BoundaryRelationData };
 

--- a/frontend/src/components/Common/Chart/index.tsx
+++ b/frontend/src/components/Common/Chart/index.tsx
@@ -4,9 +4,9 @@ import { ChartOptions } from 'chart.js';
 import { Bar, Line } from 'react-chartjs-2';
 import { TFunctionKeys } from 'i18next';
 import moment, { LocaleSpecifier } from 'moment';
-import { ChartConfig, DatasetField } from '../../../config/types';
-import { TableData } from '../../../context/tableStateSlice';
-import { useSafeTranslation } from '../../../i18n';
+import { ChartConfig, DatasetField } from 'config/types';
+import { TableData } from 'context/tableStateSlice';
+import { useSafeTranslation } from 'i18n';
 
 type ChartProps = {
   title: string;

--- a/frontend/src/components/Common/MultiOptionsButton/index.tsx
+++ b/frontend/src/components/Common/MultiOptionsButton/index.tsx
@@ -10,7 +10,7 @@ import {
 import Menu, { MenuProps } from '@material-ui/core/Menu';
 import { ArrowDropDown } from '@material-ui/icons';
 import React, { useState } from 'react';
-import { useSafeTranslation } from '../../../i18n';
+import { useSafeTranslation } from 'i18n';
 
 const StyledMenu = withStyles((theme: Theme) => ({
   paper: {

--- a/frontend/src/components/Common/ReportDialog/ReportDocTable.tsx
+++ b/frontend/src/components/Common/ReportDialog/ReportDocTable.tsx
@@ -2,11 +2,11 @@ import React, { memo, useCallback, useMemo } from 'react';
 import { Theme } from '@material-ui/core';
 import { StyleSheet, Text, View } from '@react-pdf/renderer';
 import { chunk } from 'lodash';
-import { TFunction } from '../../../utils/data-utils';
+import { TFunction } from 'utils/data-utils';
+import { TableRow as AnalysisTableRow } from 'context/analysisResultStateSlice';
+import { Column } from 'utils/analysis-utils';
 import { FIRST_PAGE_TABLE_ROWS, MAX_TABLE_ROWS_PER_PAGE } from './types';
-import { TableRow as AnalysisTableRow } from '../../../context/analysisResultStateSlice';
 import ReportDocTableHeader from './ReportDocTableHeader';
-import { Column } from '../../../utils/analysis-utils';
 
 const makeStyles = (theme: Theme) =>
   StyleSheet.create({

--- a/frontend/src/components/Common/ReportDialog/ReportDocTableHeader.tsx
+++ b/frontend/src/components/Common/ReportDialog/ReportDocTableHeader.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useMemo } from 'react';
 import { StyleSheet, Text, View } from '@react-pdf/renderer';
 import { Theme } from '@material-ui/core';
-import { Column } from '../../../utils/analysis-utils';
+import { Column } from 'utils/analysis-utils';
 
 const makeStyles = (theme: Theme) =>
   StyleSheet.create({

--- a/frontend/src/components/Common/ReportDialog/index.tsx
+++ b/frontend/src/components/Common/ReportDialog/index.tsx
@@ -19,16 +19,16 @@ import { ArrowBack } from '@material-ui/icons';
 import { PDFDownloadLink, PDFViewer } from '@react-pdf/renderer';
 import { snakeCase } from 'lodash';
 import moment from 'moment';
-import { useSafeTranslation } from '../../../i18n';
-import { mapSelector } from '../../../context/mapStateSlice/selectors';
+import { useSafeTranslation } from 'i18n';
+import { mapSelector } from 'context/mapStateSlice/selectors';
 import {
   analysisResultSelector,
   TableRow as AnalysisTableRow,
-} from '../../../context/analysisResultStateSlice';
-import { Column, ExposedPopulationResult } from '../../../utils/analysis-utils';
+} from 'context/analysisResultStateSlice';
+import { Column, ExposedPopulationResult } from 'utils/analysis-utils';
+import LoadingBlinkingDots from 'components/Common/LoadingBlinkingDots';
 import ReportDoc from './reportDoc';
 import { ReportType } from './types';
-import LoadingBlinkingDots from '../LoadingBlinkingDots';
 
 type Format = 'png' | 'jpeg';
 

--- a/frontend/src/components/Common/ReportDialog/reportDoc.tsx
+++ b/frontend/src/components/Common/ReportDialog/reportDoc.tsx
@@ -8,14 +8,14 @@ import {
   Image,
 } from '@react-pdf/renderer';
 import { Theme } from '@material-ui/core';
-import { TableRow as AnalysisTableRow } from '../../../context/analysisResultStateSlice';
-import { getLegendItemLabel } from '../../MapView/utils';
-import { LegendDefinition } from '../../../config/types';
-import { TFunction } from '../../../utils/data-utils';
+import { TableRow as AnalysisTableRow } from 'context/analysisResultStateSlice';
+import { getLegendItemLabel } from 'components/MapView/utils';
+import { LegendDefinition } from 'config/types';
+import { TFunction } from 'utils/data-utils';
+import { Column } from 'utils/analysis-utils';
 import { PDFLegendDefinition, ReportType } from './types';
 import ReportDocLegend from './ReportDocLegend';
 import ReportDocTable from './ReportDocTable';
-import { Column } from '../../../utils/analysis-utils';
 
 const makeStyles = (theme: Theme) =>
   StyleSheet.create({

--- a/frontend/src/components/Common/SimpleDropdown/index.tsx
+++ b/frontend/src/components/Common/SimpleDropdown/index.tsx
@@ -1,6 +1,6 @@
 import { FormControl, MenuItem, Select, Typography } from '@material-ui/core';
 import React from 'react';
-import { useSafeTranslation } from '../../../i18n';
+import { useSafeTranslation } from 'i18n';
 
 type OptionLabel = string;
 

--- a/frontend/src/components/DataViewer/index.tsx
+++ b/frontend/src/components/DataViewer/index.tsx
@@ -22,12 +22,12 @@ import {
   EWSParams,
   DatasetRequestParams,
   CHART_DATA_PREFIXES,
-} from '../../context/datasetStateSlice';
-import { dateRangeSelector } from '../../context/mapStateSlice/selectors';
-import Chart from '../Common/Chart';
-import { ChartConfig } from '../../config/types';
-import { useSafeTranslation } from '../../i18n';
-import { appConfig } from '../../config';
+} from 'context/datasetStateSlice';
+import { dateRangeSelector } from 'context/mapStateSlice/selectors';
+import Chart from 'components/Common/Chart';
+import { ChartConfig } from 'config/types';
+import { useSafeTranslation } from 'i18n';
+import { appConfig } from 'config';
 
 const isAdminBoundary = (
   params: AdminBoundaryParams | EWSParams,

--- a/frontend/src/components/Login/index.tsx
+++ b/frontend/src/components/Login/index.tsx
@@ -8,9 +8,9 @@ import {
   Grid,
 } from '@material-ui/core';
 import { useMsal } from '@azure/msal-react';
-import { msalRequest } from '../../config';
+import { msalRequest } from 'config';
 
-import { colors } from '../../muiTheme';
+import { colors } from 'muiTheme';
 
 const Login = ({ classes }: LoginProps) => {
   const { instance } = useMsal();

--- a/frontend/src/components/MapView/AlertForm/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/AlertForm/__snapshots__/index.test.tsx.snap
@@ -44,11 +44,594 @@ exports[`renders as expected 1`] = `
           >
             Hazard Layer
           </mock-typography>
-          <mock-layer-dropdown
-            classname="AlertForm-selector-10"
-            placeholder="Choose hazard layer"
-            type="wms"
-          />
+          <div
+            class="MuiFormControl-root AlertForm-selector-10"
+          >
+            <mock-textfield
+              classes="[object Object]"
+              inputlabelprops="[object Object]"
+              inputprops="[object Object]"
+              select="true"
+              variant="outlined"
+            >
+              <mock-menuitem
+                disabled="true"
+                value="placeholder"
+              >
+                Choose hazard layer
+              </mock-menuitem>
+              <li
+                class="MuiListSubheader-root MuiListSubheader-sticky MuiListSubheader-gutters"
+              >
+                <mock-typography
+                  color="primary"
+                  variant="body2"
+                >
+                  INAM Rainfall Data
+                </mock-typography>
+              </li>
+              <mock-menuitem
+                value="precip_blended_dekad"
+              >
+                Blended rainfall aggregate (10-day)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="precip_blended_dekad_anomaly"
+              >
+                Blended rainfall anomaly (10-day)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <li
+                class="MuiListSubheader-root MuiListSubheader-sticky MuiListSubheader-gutters"
+              >
+                <mock-typography
+                  color="primary"
+                  variant="body2"
+                >
+                  Global Rainfall Products
+                </mock-typography>
+              </li>
+              <mock-menuitem
+                value="rainfall_dekad"
+              >
+                10-day rainfall estimate (mm)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="rainfall_agg_1month"
+              >
+                1-month rainfall aggregate
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="rainfall_agg_3month"
+              >
+                3-month rainfall aggregate (mm)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="rainfall_agg_6month"
+              >
+                6-month rainfall aggregate (mm)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="rainfall_agg_9month"
+              >
+                9-month rainfall aggregate (mm)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="rainfall_agg_1year"
+              >
+                1-year rainfall aggregate (mm)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="rain_anomaly_dekad"
+              >
+                10-day rainfall anomaly
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="rain_anomaly_1month"
+              >
+                1-month rainfall anomaly
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="rain_anomaly_3month"
+              >
+                3-month rainfall anomaly
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="rain_anomaly_6month"
+              >
+                6-month rainfall anomaly
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="rain_anomaly_9month"
+              >
+                9-month rainfall anomaly
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="rain_anomaly_1year"
+              >
+                1-year rainfall anomaly
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="spi_1m"
+              >
+                SPI - 1-month
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="spi_3m"
+              >
+                SPI - 3-month
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="spi_6m"
+              >
+                SPI - 6-month
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="spi_9m"
+              >
+                SPI - 9-month
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="spi_1y"
+              >
+                SPI - 1-year
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <li
+                class="MuiListSubheader-root MuiListSubheader-sticky MuiListSubheader-gutters"
+              >
+                <mock-typography
+                  color="primary"
+                  variant="body2"
+                >
+                  Dry Periods
+                </mock-typography>
+              </li>
+              <mock-menuitem
+                value="days_dry"
+              >
+                Days since last rain
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="streak_dry_days"
+              >
+                Longest dry spell
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <li
+                class="MuiListSubheader-root MuiListSubheader-sticky MuiListSubheader-gutters"
+              >
+                <mock-typography
+                  color="primary"
+                  variant="body2"
+                >
+                  Extreme Rain Events
+                </mock-typography>
+              </li>
+              <mock-menuitem
+                value="days_heavy_rain"
+              >
+                Number of days with heavy rainfall in the last 30 days
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="days_intense_rain"
+              >
+                Number of days with intense rainfall in the last 30 days
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="days_extreme_rain"
+              >
+                Number of days with extreme rainfall in the last 30 days
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="streak_heavy_rain"
+              >
+                Longest consecutive heavy rainfall days
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="streak_intense_rain"
+              >
+                Longest consecutive intense rainfall days
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="streak_extreme_rain"
+              >
+                Longest consecutive extreme rainfall days
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <li
+                class="MuiListSubheader-root MuiListSubheader-sticky MuiListSubheader-gutters"
+              >
+                <mock-typography
+                  color="primary"
+                  variant="body2"
+                >
+                  Vegetation Conditions
+                </mock-typography>
+              </li>
+              <mock-menuitem
+                value="ndvi_dekad"
+              >
+                10-day NDVI (MODIS)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="ndvi_dekad_anomaly"
+              >
+                10-day NDVI anomaly (MODIS)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <li
+                class="MuiListSubheader-root MuiListSubheader-sticky MuiListSubheader-gutters"
+              >
+                <mock-typography
+                  color="primary"
+                  variant="body2"
+                >
+                  INAM Air Temperature
+                </mock-typography>
+              </li>
+              <mock-menuitem
+                value="lst_daytime_blended"
+              >
+                INAM mean maximum air temperature (10-day)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="lst_day_anomaly_blended"
+              >
+                INAM mean maximum air temperature anomaly (10-day)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <li
+                class="MuiListSubheader-root MuiListSubheader-sticky MuiListSubheader-gutters"
+              >
+                <mock-typography
+                  color="primary"
+                  variant="body2"
+                >
+                  Land Surface Temperature
+                </mock-typography>
+              </li>
+              <mock-menuitem
+                value="lst_daytime"
+              >
+                Daytime Land Surface Temperature - 10-day (MODIS)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="lst_day_anomaly"
+              >
+                Daytime Land Surface Temperature - 10-day Anomaly (MODIS)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <mock-menuitem
+                value="lst_amplitude"
+              >
+                Land Surface Temperature - 10-day Amplitude (MODIS)
+                <mock-tooltip
+                  title="raster"
+                >
+                  <img
+                    alt="raster"
+                    src="images/icon_raster.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+              <li
+                class="MuiListSubheader-root MuiListSubheader-sticky MuiListSubheader-gutters"
+              >
+                <mock-typography
+                  color="primary"
+                  variant="body2"
+                >
+                  Tropical Storms
+                </mock-typography>
+              </li>
+              <mock-menuitem
+                value="adamts_buffers"
+              >
+                Tropical Storms - Wind buffers
+                <mock-tooltip
+                  title="polygon"
+                >
+                  <img
+                    alt="polygon"
+                    src="images/icon_polygon.svg"
+                    style="margin-left: 0.5em; margin-bottom: -2px; height: 1em;"
+                  />
+                </mock-tooltip>
+              </mock-menuitem>
+            </mock-textfield>
+          </div>
         </div>
         <div
           class="AlertForm-alertFormOptions-7"

--- a/frontend/src/components/MapView/AlertForm/index.test.tsx
+++ b/frontend/src/components/MapView/AlertForm/index.test.tsx
@@ -3,10 +3,8 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { ThemeProvider } from '@material-ui/styles';
 import { createMuiTheme } from '@material-ui/core/styles';
+import { store } from '@/context/store';
 import AlertForm from '.';
-import { store } from '../../../context/store';
-
-jest.mock('../Layers/LayerDropdown', () => 'mock-Layer-Dropdown');
 
 test('renders as expected', () => {
   const rendered = render(

--- a/frontend/src/components/MapView/AlertForm/index.tsx
+++ b/frontend/src/components/MapView/AlertForm/index.tsx
@@ -17,27 +17,16 @@ import React, {
   useState,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  BoundaryLayerProps,
-  LayerKey,
-  WMSLayerProps,
-} from '../../../config/types';
-import {
-  getBoundaryLayerSingleton,
-  LayerDefinitions,
-} from '../../../config/utils';
-import { LayerData } from '../../../context/layers/layer-data';
-import { layerDataSelector } from '../../../context/mapStateSlice/selectors';
-import {
-  AlertRequest,
-  fetchApiData,
-  getPrismUrl,
-} from '../../../utils/analysis-utils';
-import LayerDropdown from '../Layers/LayerDropdown';
-import BoundaryDropdown from '../Layers/BoundaryDropdown';
-import { getSelectedBoundaries } from '../../../context/mapSelectionLayerStateSlice';
-import { addNotification } from '../../../context/notificationStateSlice';
-import { useSafeTranslation } from '../../../i18n';
+import { BoundaryLayerProps, LayerKey, WMSLayerProps } from 'config/types';
+import { getBoundaryLayerSingleton, LayerDefinitions } from 'config/utils';
+import { LayerData } from 'context/layers/layer-data';
+import { layerDataSelector } from 'context/mapStateSlice/selectors';
+import { AlertRequest, fetchApiData, getPrismUrl } from 'utils/analysis-utils';
+import LayerDropdown from 'components/MapView/Layers/LayerDropdown';
+import BoundaryDropdown from 'components/MapView/Layers/BoundaryDropdown';
+import { getSelectedBoundaries } from 'context/mapSelectionLayerStateSlice';
+import { addNotification } from 'context/notificationStateSlice';
+import { useSafeTranslation } from 'i18n';
 
 // Not fully RFC-compliant, but should filter out obviously-invalid emails.
 // Source: https://stackoverflow.com/questions/46155/how-to-validate-an-email-address-in-javascript

--- a/frontend/src/components/MapView/BoundaryInfoBox/index.tsx
+++ b/frontend/src/components/MapView/BoundaryInfoBox/index.tsx
@@ -11,7 +11,7 @@ import { useSelector } from 'react-redux';
 import {
   boundsSelector,
   zoomSelector,
-} from '../../../context/mapBoundaryInfoStateSlice';
+} from 'context/mapBoundaryInfoStateSlice';
 
 function LocationBox({ classes }: LocationBoxProps) {
   const bounds = useSelector(boundsSelector);

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineItem/index.test.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineItem/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { DateItem } from 'config/types';
 import TimelineItem, { TimelineItemProps } from '.';
-import { DateItem } from '../../../../../config/types';
 
 test('TimelineItem renders as expected', () => {
   // Arrange

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineItem/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineItem/index.tsx
@@ -1,8 +1,8 @@
 import { WithStyles, createStyles, withStyles } from '@material-ui/core';
 import React, { memo } from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
-import { DateItem, DateRangeType } from '../../../../../config/types';
-import { datesAreEqualWithoutTime } from '../../../../../utils/date-utils';
+import { DateItem, DateRangeType } from 'config/types';
+import { datesAreEqualWithoutTime } from 'utils/date-utils';
 
 const TimelineItem = memo(
   ({

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/index.tsx
@@ -5,9 +5,9 @@ import {
   Typography,
 } from '@material-ui/core';
 import React from 'react';
-import { DateRangeType } from '../../../../../config/types';
-import { moment } from '../../../../../i18n';
-import { MONTH_YEAR_DATE_FORMAT } from '../../../../../utils/name-utils';
+import { DateRangeType } from 'config/types';
+import { moment } from 'i18n';
+import { MONTH_YEAR_DATE_FORMAT } from 'utils/name-utils';
 
 const TimelineLabel = ({ classes, locale, date }: TimelineLabelProps) => {
   if (date.isFirstDay) {

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
@@ -9,12 +9,12 @@ import {
 import { CreateCSSProperties } from '@material-ui/styles';
 import { compact, merge } from 'lodash';
 import React, { memo, useCallback, useMemo } from 'react';
-import { DateItem, DateRangeType } from '../../../../config/types';
-import { useSafeTranslation } from '../../../../i18n';
+import { DateItem, DateRangeType } from 'config/types';
+import { useSafeTranslation } from 'i18n';
 import {
   DateCompatibleLayerWithDateItems,
   TIMELINE_ITEM_WIDTH,
-} from '../utils';
+} from 'components/MapView/DateSelector/utils';
 import TimelineItem from './TimelineItem';
 import TimelineLabel from './TimelineLabel';
 import TooltipItem from './TooltipItem';

--- a/frontend/src/components/MapView/DateSelector/index.test.tsx
+++ b/frontend/src/components/MapView/DateSelector/index.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
+import { store } from 'context/store';
 import DateSelector from '.';
-
-import { store } from '../../../context/store';
 
 jest.mock('react-router-dom', () => ({
   useHistory: () => ({
@@ -13,7 +12,7 @@ jest.mock('react-router-dom', () => ({
     },
   }),
 }));
-jest.mock('../../Notifier', () => 'mock-Notifier');
+jest.mock('components/Notifier', () => 'mock-Notifier');
 jest.mock('./TimelineItems', () => 'mock-TimelineItems');
 
 test('renders as expected', () => {

--- a/frontend/src/components/MapView/DateSelector/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/index.tsx
@@ -21,18 +21,18 @@ import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import Draggable, { DraggableEvent } from 'react-draggable';
 import { useDispatch, useSelector } from 'react-redux';
-import { ReactComponent as TickSvg } from './tick.svg';
-import { DateRangeType } from '../../../config/types';
-import { dateRangeSelector } from '../../../context/mapStateSlice/selectors';
-import { addNotification } from '../../../context/notificationStateSlice';
-import { moment, useSafeTranslation } from '../../../i18n';
-import { datesAreEqualWithoutTime } from '../../../utils/date-utils';
+import { DateRangeType } from 'config/types';
+import { dateRangeSelector } from 'context/mapStateSlice/selectors';
+import { addNotification } from 'context/notificationStateSlice';
+import { moment, useSafeTranslation } from 'i18n';
+import { datesAreEqualWithoutTime } from 'utils/date-utils';
 import {
   DEFAULT_DATE_FORMAT,
   MONTH_FIRST_DATE_FORMAT,
   MONTH_ONLY_DATE_FORMAT,
-} from '../../../utils/name-utils';
-import { useUrlHistory } from '../../../utils/url-utils';
+} from 'utils/name-utils';
+import { useUrlHistory } from 'utils/url-utils';
+import { ReactComponent as TickSvg } from './tick.svg';
 import DateSelectorInput from './DateSelectorInput';
 import TimelineItems from './TimelineItems';
 import {

--- a/frontend/src/components/MapView/DateSelector/utils.ts
+++ b/frontend/src/components/MapView/DateSelector/utils.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
-import { MONTH_FIRST_DATE_FORMAT } from '../../../utils/name-utils';
-import { DateCompatibleLayer } from '../../../utils/server-utils';
-import { DateItem } from '../../../config/types';
+import { MONTH_FIRST_DATE_FORMAT } from 'utils/name-utils';
+import { DateCompatibleLayer } from 'utils/server-utils';
+import { DateItem } from 'config/types';
 
 export const TIMELINE_ITEM_WIDTH = 10;
 

--- a/frontend/src/components/MapView/FoldButton/index.tsx
+++ b/frontend/src/components/MapView/FoldButton/index.tsx
@@ -9,8 +9,8 @@ import {
 import DragIndicatorIcon from '@material-ui/icons/DragIndicator';
 import React, { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { useSafeTranslation } from '../../../i18n';
-import { analysisResultSelector } from '../../../context/analysisResultStateSlice';
+import { useSafeTranslation } from 'i18n';
+import { analysisResultSelector } from 'context/analysisResultStateSlice';
 
 interface IProps {
   isPanelHidden: boolean;

--- a/frontend/src/components/MapView/Layers/AdminLevelDataLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/AdminLevelDataLayer/index.tsx
@@ -5,32 +5,26 @@ import {
   AdminLevelDataLayerProps,
   BoundaryLayerProps,
   LayerKey,
-} from '../../../../config/types';
-import {
-  LayerData,
-  loadLayerData,
-} from '../../../../context/layers/layer-data';
+} from 'config/types';
+import { LayerData, loadLayerData } from 'context/layers/layer-data';
 import {
   layerDataSelector,
   mapSelector,
-} from '../../../../context/mapStateSlice/selectors';
-import { addLayer, removeLayer } from '../../../../context/mapStateSlice';
-import { useDefaultDate } from '../../../../utils/useDefaultDate';
-import { getBoundaryLayers, LayerDefinitions } from '../../../../config/utils';
-import { addNotification } from '../../../../context/notificationStateSlice';
+} from 'context/mapStateSlice/selectors';
+import { addLayer, removeLayer } from 'context/mapStateSlice';
+import { useDefaultDate } from 'utils/useDefaultDate';
+import { getBoundaryLayers, LayerDefinitions } from 'config/utils';
+import { addNotification } from 'context/notificationStateSlice';
+import { firstBoundaryOnView, isLayerOnView } from 'utils/map-utils';
+import { useSafeTranslation } from 'i18n';
+import { fillPaintData } from 'components/MapView/Layers/styles';
+import { availableDatesSelector } from 'context/serverStateSlice';
+import { getRequestDate } from 'utils/server-utils';
 import {
-  firstBoundaryOnView,
-  isLayerOnView,
-} from '../../../../utils/map-utils';
-import { useSafeTranslation } from '../../../../i18n';
-import { fillPaintData } from '../styles';
-import { availableDatesSelector } from '../../../../context/serverStateSlice';
-import { getRequestDate } from '../../../../utils/server-utils';
-import { addPopupParams, legendToStops } from '../layer-utils';
-import {
-  convertSvgToPngBase64Image,
-  getSVGShape,
-} from '../../../../utils/image-utils';
+  addPopupParams,
+  legendToStops,
+} from 'components/MapView/Layers/layer-utils';
+import { convertSvgToPngBase64Image, getSVGShape } from 'utils/image-utils';
 
 function AdminLevelDataLayers({
   layer,

--- a/frontend/src/components/MapView/Layers/AnalysisLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/AnalysisLayer/index.tsx
@@ -3,21 +3,21 @@ import { get } from 'lodash';
 import { GeoJSONLayer } from 'react-mapbox-gl';
 import * as MapboxGL from 'mapbox-gl';
 import { useDispatch, useSelector } from 'react-redux';
-import { addPopupData } from '../../../../context/tooltipStateSlice';
+import { addPopupData } from 'context/tooltipStateSlice';
 import {
   analysisResultSelector,
   isAnalysisLayerActiveSelector,
-} from '../../../../context/analysisResultStateSlice';
-import { legendToStops } from '../layer-utils';
-import { LegendDefinition } from '../../../../config/types';
+} from 'context/analysisResultStateSlice';
+import { legendToStops } from 'components/MapView/Layers/layer-utils';
+import { LegendDefinition } from 'config/types';
 import {
   BaselineLayerResult,
   ExposedPopulationResult,
   PolygonAnalysisResult,
-} from '../../../../utils/analysis-utils';
-import { getRoundedData } from '../../../../utils/data-utils';
-import { useSafeTranslation } from '../../../../i18n';
-import { LayerDefinitions } from '../../../../config/utils';
+} from 'utils/analysis-utils';
+import { getRoundedData } from 'utils/data-utils';
+import { useSafeTranslation } from 'i18n';
+import { LayerDefinitions } from 'config/utils';
 
 function AnalysisLayer({ before }: { before?: string }) {
   // TODO maybe in the future we can try add this to LayerType so we don't need exclusive code in Legends and MapView to make this display correctly

--- a/frontend/src/components/MapView/Layers/BoundaryDropdown.tsx
+++ b/frontend/src/components/MapView/Layers/BoundaryDropdown.tsx
@@ -19,16 +19,16 @@ import React, { forwardRef, ReactNode, useEffect, useState } from 'react';
 import i18n from 'i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Search } from '@material-ui/icons';
-import { BoundaryLayerProps } from '../../../config/types';
+import { BoundaryLayerProps } from 'config/types';
 import {
   getSelectedBoundaries,
   setIsSelectionMode,
   setSelectedBoundaries as setSelectedBoundariesRedux,
-} from '../../../context/mapSelectionLayerStateSlice';
-import { getBoundaryLayerSingleton } from '../../../config/utils';
-import { layerDataSelector } from '../../../context/mapStateSlice/selectors';
-import { LayerData } from '../../../context/layers/layer-data';
-import { isEnglishLanguageSelected, useSafeTranslation } from '../../../i18n';
+} from 'context/mapSelectionLayerStateSlice';
+import { getBoundaryLayerSingleton } from 'config/utils';
+import { layerDataSelector } from 'context/mapStateSlice/selectors';
+import { LayerData } from 'context/layers/layer-data';
+import { isEnglishLanguageSelected, useSafeTranslation } from 'i18n';
 
 const boundaryLayer = getBoundaryLayerSingleton();
 const ClickableListSubheader = styled(ListSubheader)(({ theme }) => ({

--- a/frontend/src/components/MapView/Layers/BoundaryLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/BoundaryLayer/index.tsx
@@ -2,21 +2,21 @@ import * as MapboxGL from 'mapbox-gl';
 import React, { useEffect } from 'react';
 import { GeoJSONLayer } from 'react-mapbox-gl';
 import { useDispatch, useSelector } from 'react-redux';
-import { BoundaryLayerProps } from '../../../../config/types';
-import { LayerData } from '../../../../context/layers/layer-data';
-import { hidePopup, showPopup } from '../../../../context/tooltipStateSlice';
+import { BoundaryLayerProps } from 'config/types';
+import { LayerData } from 'context/layers/layer-data';
+import { hidePopup, showPopup } from 'context/tooltipStateSlice';
 
-import { setBoundaryRelationData } from '../../../../context/mapStateSlice';
+import { setBoundaryRelationData } from 'context/mapStateSlice';
 import {
   loadBoundaryRelations,
   BoundaryRelationData,
-} from '../../../Common/BoundaryDropdown/utils';
-import { isPrimaryBoundaryLayer } from '../../../../config/utils';
-import { toggleSelectedBoundary } from '../../../../context/mapSelectionLayerStateSlice';
-import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
-import { getFullLocationName } from '../../../../utils/name-utils';
+} from 'components/Common/BoundaryDropdown/utils';
+import { isPrimaryBoundaryLayer } from 'config/utils';
+import { toggleSelectedBoundary } from 'context/mapSelectionLayerStateSlice';
+import { layerDataSelector } from 'context/mapStateSlice/selectors';
+import { getFullLocationName } from 'utils/name-utils';
 
-import { languages } from '../../../../i18n';
+import { languages } from 'i18n';
 
 function onToggleHover(cursor: string, targetMap: MapboxGL.Map) {
   // eslint-disable-next-line no-param-reassign, fp/no-mutation

--- a/frontend/src/components/MapView/Layers/ImpactLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/ImpactLayer/index.tsx
@@ -4,24 +4,21 @@ import { GeoJSONLayer } from 'react-mapbox-gl';
 import { FillPaint, LinePaint } from 'mapbox-gl';
 import { get } from 'lodash';
 import { createStyles, withStyles, WithStyles, Theme } from '@material-ui/core';
-import { getExtent, Extent } from '../raster-utils';
-import { legendToStops } from '../layer-utils';
-import { ImpactLayerProps } from '../../../../config/types';
-import { LayerDefinitions } from '../../../../config/utils';
-import {
-  LayerData,
-  loadLayerData,
-} from '../../../../context/layers/layer-data';
+import { getExtent, Extent } from 'components/MapView/Layers/raster-utils';
+import { legendToStops } from 'components/MapView/Layers/layer-utils';
+import { ImpactLayerProps } from 'config/types';
+import { LayerDefinitions } from 'config/utils';
+import { LayerData, loadLayerData } from 'context/layers/layer-data';
 
-import { addPopupData } from '../../../../context/tooltipStateSlice';
+import { addPopupData } from 'context/tooltipStateSlice';
 import {
   dateRangeSelector,
   layerDataSelector,
   mapSelector,
-} from '../../../../context/mapStateSlice/selectors';
-import { getFeatureInfoPropsData } from '../../utils';
-import { i18nTranslator, useSafeTranslation } from '../../../../i18n';
-import { getRoundedData } from '../../../../utils/data-utils';
+} from 'context/mapStateSlice/selectors';
+import { getFeatureInfoPropsData } from 'components/MapView/utils';
+import { i18nTranslator, useSafeTranslation } from 'i18n';
+import { getRoundedData } from 'utils/data-utils';
 
 const linePaint: LinePaint = {
   'line-color': 'grey',

--- a/frontend/src/components/MapView/Layers/LayerDropdown.tsx
+++ b/frontend/src/components/MapView/Layers/LayerDropdown.tsx
@@ -9,13 +9,10 @@ import {
 } from '@material-ui/core';
 import React, { ReactElement } from 'react';
 import { startCase } from 'lodash';
-import { menuList } from '../LeftPanel/utils';
-import { LayerKey, LayerType } from '../../../config/types';
-import {
-  getDisplayBoundaryLayers,
-  LayerDefinitions,
-} from '../../../config/utils';
-import { useSafeTranslation } from '../../../i18n';
+import { menuList } from 'components/MapView/LeftPanel/utils';
+import { LayerKey, LayerType } from 'config/types';
+import { getDisplayBoundaryLayers, LayerDefinitions } from 'config/utils';
+import { useSafeTranslation } from 'i18n';
 import { getLayerGeometryIcon } from './layer-utils';
 
 const useStyles = makeStyles(() =>

--- a/frontend/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -3,30 +3,28 @@ import moment from 'moment';
 import { GeoJSONLayer } from 'react-mapbox-gl';
 import { FeatureCollection } from 'geojson';
 import { useDispatch, useSelector } from 'react-redux';
-import { PointDataLayerProps, PointDataLoader } from '../../../../config/types';
+import { PointDataLayerProps, PointDataLoader } from 'config/types';
 import {
   clearUserAuthGlobal,
   userAuthSelector,
   availableDatesSelector,
-} from '../../../../context/serverStateSlice';
+} from 'context/serverStateSlice';
+import { LayerData, loadLayerData } from 'context/layers/layer-data';
+import { layerDataSelector } from 'context/mapStateSlice/selectors';
+import { removeLayerData } from 'context/mapStateSlice';
+import { addNotification } from 'context/notificationStateSlice';
+import { useDefaultDate } from 'utils/useDefaultDate';
+import { getRequestDate } from 'utils/server-utils';
+import { useUrlHistory } from 'utils/url-utils';
+import { useSafeTranslation } from 'i18n';
 import {
-  LayerData,
-  loadLayerData,
-} from '../../../../context/layers/layer-data';
-import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
-import { removeLayerData } from '../../../../context/mapStateSlice';
-import { addNotification } from '../../../../context/notificationStateSlice';
-import { useDefaultDate } from '../../../../utils/useDefaultDate';
-import { getRequestDate } from '../../../../utils/server-utils';
-import { useUrlHistory } from '../../../../utils/url-utils';
-import { useSafeTranslation } from '../../../../i18n';
-import { circleLayout, circlePaint, fillPaintData } from '../styles';
-import {
-  setEWSParams,
-  clearDataset,
-} from '../../../../context/datasetStateSlice';
-import { createEWSDatasetParams } from '../../../../utils/ews-utils';
-import { addPopupParams } from '../layer-utils';
+  circleLayout,
+  circlePaint,
+  fillPaintData,
+} from 'components/MapView/Layers/styles';
+import { setEWSParams, clearDataset } from 'context/datasetStateSlice';
+import { createEWSDatasetParams } from 'utils/ews-utils';
+import { addPopupParams } from 'components/MapView/Layers/layer-utils';
 
 // Point Data, takes any GeoJSON of points and shows it.
 function PointDataLayer({ layer, before }: LayersProps) {

--- a/frontend/src/components/MapView/Layers/SelectionLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/SelectionLayer/index.tsx
@@ -5,11 +5,11 @@ import * as MapboxGL from 'mapbox-gl';
 import {
   getIsSelectionMode,
   getSelectedBoundaries,
-} from '../../../../context/mapSelectionLayerStateSlice';
-import { getBoundaryLayerSingleton } from '../../../../config/utils';
-import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
-import { LayerData } from '../../../../context/layers/layer-data';
-import { BoundaryLayerProps } from '../../../../config/types';
+} from 'context/mapSelectionLayerStateSlice';
+import { getBoundaryLayerSingleton } from 'config/utils';
+import { layerDataSelector } from 'context/mapStateSlice/selectors';
+import { LayerData } from 'context/layers/layer-data';
+import { BoundaryLayerProps } from 'config/types';
 
 const boundaryLayer = getBoundaryLayerSingleton();
 const LINE_PAINT_DATA: MapboxGL.LinePaint = {

--- a/frontend/src/components/MapView/Layers/StaticRasterLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/StaticRasterLayer/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import moment from 'moment';
 import { Layer, Source } from 'react-mapbox-gl';
-import { StaticRasterLayerProps } from '../../../../config/types';
-import { useDefaultDate } from '../../../../utils/useDefaultDate';
-import { DEFAULT_DATE_FORMAT_SNAKE_CASE } from '../../../../utils/name-utils';
+import { StaticRasterLayerProps } from 'config/types';
+import { useDefaultDate } from 'utils/useDefaultDate';
+import { DEFAULT_DATE_FORMAT_SNAKE_CASE } from 'utils/name-utils';
 
 function StaticRasterLayer({
   layer: { id, baseUrl, opacity, minZoom, maxZoom, dates },

--- a/frontend/src/components/MapView/Layers/WMSLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/WMSLayer/index.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import moment from 'moment';
 import { useSelector } from 'react-redux';
 import { Layer, Source } from 'react-mapbox-gl';
-import { WMSLayerProps } from '../../../../config/types';
-import { getWMSUrl } from '../raster-utils';
-import { useDefaultDate } from '../../../../utils/useDefaultDate';
-import { DEFAULT_DATE_FORMAT } from '../../../../utils/name-utils';
-import { getRequestDate } from '../../../../utils/server-utils';
-import { availableDatesSelector } from '../../../../context/serverStateSlice';
+import { WMSLayerProps } from 'config/types';
+import { getWMSUrl } from 'components/MapView/Layers/raster-utils';
+import { useDefaultDate } from 'utils/useDefaultDate';
+import { DEFAULT_DATE_FORMAT } from 'utils/name-utils';
+import { getRequestDate } from 'utils/server-utils';
+import { availableDatesSelector } from 'context/serverStateSlice';
 
 function WMSLayers({
   layer: { id, baseUrl, serverLayerName, additionalQueryParams, opacity },

--- a/frontend/src/components/MapView/Layers/layer-utils.tsx
+++ b/frontend/src/components/MapView/Layers/layer-utils.tsx
@@ -7,11 +7,11 @@ import {
   LegendDefinition,
   AdminLevelDataLayerProps,
   PointDataLayerProps,
-} from '../../../config/types';
-import { addPopupData } from '../../../context/tooltipStateSlice';
-import { getRoundedData } from '../../../utils/data-utils';
-import { i18nTranslator } from '../../../i18n';
-import { getFeatureInfoPropsData } from '../utils';
+} from 'config/types';
+import { addPopupData } from 'context/tooltipStateSlice';
+import { getRoundedData } from 'utils/data-utils';
+import { i18nTranslator } from 'i18n';
+import { getFeatureInfoPropsData } from 'components/MapView/utils';
 
 export function legendToStops(legend: LegendDefinition = []) {
   // TODO - Make this function easier to use for point data and explicit its behavior.

--- a/frontend/src/components/MapView/Layers/raster-utils.ts
+++ b/frontend/src/components/MapView/Layers/raster-utils.ts
@@ -6,10 +6,10 @@ import * as GeoTIFF from 'geotiff';
 import { Map as MapBoxMap } from 'mapbox-gl';
 import { createGetMapUrl } from 'prism-common';
 import { Dispatch } from 'redux';
-import { BACKEND_URL } from '../../../utils/constants';
-import { fetchWithTimeout } from '../../../utils/fetch-with-timeout';
-import { LocalError } from '../../../utils/error-utils';
-import { addNotification } from '../../../context/notificationStateSlice';
+import { BACKEND_URL } from 'utils/constants';
+import { fetchWithTimeout } from 'utils/fetch-with-timeout';
+import { LocalError } from 'utils/error-utils';
+import { addNotification } from 'context/notificationStateSlice';
 
 export type TransformMatrix = [number, number, number, number, number, number];
 export type TypedArray =

--- a/frontend/src/components/MapView/Layers/styles.ts
+++ b/frontend/src/components/MapView/Layers/styles.ts
@@ -4,7 +4,7 @@ import {
   DataFieldType,
   LegendDefinitionItem,
   PointDataLayerProps,
-} from '../../../config/types';
+} from 'config/types';
 import { legendToStops } from './layer-utils';
 
 export const circleLayout: MapboxGL.CircleLayout = { visibility: 'visible' };

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
@@ -16,12 +16,12 @@ import {
 } from '@material-ui/core';
 
 import { useDispatch } from 'react-redux';
-import { TableRow as AnalysisTableRow } from '../../../../../../context/analysisResultStateSlice';
+import { TableRow as AnalysisTableRow } from 'context/analysisResultStateSlice';
 
-import { useSafeTranslation } from '../../../../../../i18n';
+import { useSafeTranslation } from 'i18n';
 
-import { Column } from '../../../../../../utils/analysis-utils';
-import { showPopup } from '../../../../../../context/tooltipStateSlice';
+import { Column } from 'utils/analysis-utils';
+import { showPopup } from 'context/tooltipStateSlice';
 
 const ExposureAnalysisTable = memo(
   ({

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
@@ -15,10 +15,10 @@ import {
   WithStyles,
 } from '@material-ui/core';
 import { useDispatch } from 'react-redux';
-import { TableRow as AnalysisTableRow } from '../../../../../context/analysisResultStateSlice';
-import { showPopup } from '../../../../../context/tooltipStateSlice';
-import { Column } from '../../../../../utils/analysis-utils';
-import { useSafeTranslation } from '../../../../../i18n';
+import { TableRow as AnalysisTableRow } from 'context/analysisResultStateSlice';
+import { showPopup } from 'context/tooltipStateSlice';
+import { Column } from 'utils/analysis-utils';
+import { useSafeTranslation } from 'i18n';
 
 const AnalysisTable = memo(
   ({

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/ExposureAnalysisActions/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/ExposureAnalysisActions/index.tsx
@@ -9,20 +9,17 @@ import {
 } from '@material-ui/core';
 import { snakeCase } from 'lodash';
 import { useSelector } from 'react-redux';
-import { downloadToFile } from '../../../utils';
-import { useSafeTranslation } from '../../../../../i18n';
+import { downloadToFile } from 'components/MapView/utils';
+import { useSafeTranslation } from 'i18n';
 import {
   getCurrentDefinition,
   TableRow,
   TableRow as AnalysisTableRow,
-} from '../../../../../context/analysisResultStateSlice';
-import { layersSelector } from '../../../../../context/mapStateSlice/selectors';
-import { ReportType } from '../../../../Common/ReportDialog/types';
-import ReportDialog from '../../../../Common/ReportDialog';
-import {
-  Column,
-  quoteAndEscapeCell,
-} from '../../../../../utils/analysis-utils';
+} from 'context/analysisResultStateSlice';
+import { layersSelector } from 'context/mapStateSlice/selectors';
+import { ReportType } from 'components/Common/ReportDialog/types';
+import ReportDialog from 'components/Common/ReportDialog';
+import { Column, quoteAndEscapeCell } from 'utils/analysis-utils';
 
 function ExposureAnalysisActions({
   analysisButton,

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
@@ -40,9 +40,9 @@ import {
   mapSelector,
   layersSelector,
   layerDataSelector,
-} from '../../../../context/mapStateSlice/selectors';
-import { useUrlHistory } from '../../../../utils/url-utils';
-import { availableDatesSelector } from '../../../../context/serverStateSlice';
+} from 'context/mapStateSlice/selectors';
+import { useUrlHistory } from 'utils/url-utils';
+import { availableDatesSelector } from 'context/serverStateSlice';
 import {
   AnalysisDispatchParams,
   PolygonAnalysisDispatchParams,
@@ -57,7 +57,7 @@ import {
   analysisResultSortOrderSelector,
   setAnalysisResultSortByKey,
   setAnalysisResultSortOrder,
-} from '../../../../context/analysisResultStateSlice';
+} from 'context/analysisResultStateSlice';
 import {
   AdminLevelType,
   AggregationOperations,
@@ -69,19 +69,13 @@ import {
   BoundaryLayerProps,
   GeometryType,
   PanelSize,
-} from '../../../../config/types';
-import {
-  getAdminLevelCount,
-  getAdminLevelLayer,
-} from '../../../../utils/admin-utils';
-import { LayerData } from '../../../../context/layers/layer-data';
-import {
-  LayerDefinitions,
-  getDisplayBoundaryLayers,
-} from '../../../../config/utils';
-import { useSafeTranslation } from '../../../../i18n';
-import { getDateFromList } from '../../../../utils/data-utils';
-import { getPossibleDatesForLayer } from '../../../../utils/server-utils';
+} from 'config/types';
+import { getAdminLevelCount, getAdminLevelLayer } from 'utils/admin-utils';
+import { LayerData } from 'context/layers/layer-data';
+import { LayerDefinitions, getDisplayBoundaryLayers } from 'config/utils';
+import { useSafeTranslation } from 'i18n';
+import { getDateFromList } from 'utils/data-utils';
+import { getPossibleDatesForLayer } from 'utils/server-utils';
 import {
   downloadCSVFromTableData,
   BaselineLayerResult,
@@ -89,25 +83,25 @@ import {
   PolygonAnalysisResult,
   useAnalysisTableColumns,
   Column,
-} from '../../../../utils/analysis-utils';
+} from 'utils/analysis-utils';
 import {
   refreshBoundaries,
   safeDispatchRemoveLayer,
   safeDispatchAddLayer,
-} from '../../../../utils/map-utils';
-import { removeLayer } from '../../../../context/mapStateSlice';
-import { DEFAULT_DATE_FORMAT } from '../../../../utils/name-utils';
-import LayerDropdown from '../../Layers/LayerDropdown';
-import SimpleDropdown from '../../../Common/SimpleDropdown';
-import AnalysisTable from './AnalysisTable';
-import { Extent } from '../../Layers/raster-utils';
-import ExposureAnalysisTable from './AnalysisTable/ExposureAnalysisTable';
-import ExposureAnalysisActions from './ExposureAnalysisActions';
+} from 'utils/map-utils';
+import { removeLayer } from 'context/mapStateSlice';
+import { DEFAULT_DATE_FORMAT } from 'utils/name-utils';
+import LayerDropdown from 'components/MapView/Layers/LayerDropdown';
+import SimpleDropdown from 'components/Common/SimpleDropdown';
+import { Extent } from 'components/MapView/Layers/raster-utils';
 import {
   leftPanelTabValueSelector,
   setTabValue,
-} from '../../../../context/leftPanelStateSlice';
-import LoadingBlinkingDots from '../../../Common/LoadingBlinkingDots';
+} from 'context/leftPanelStateSlice';
+import LoadingBlinkingDots from 'components/Common/LoadingBlinkingDots';
+import AnalysisTable from './AnalysisTable';
+import ExposureAnalysisTable from './AnalysisTable/ExposureAnalysisTable';
+import ExposureAnalysisActions from './ExposureAnalysisActions';
 
 const tabIndex = 2;
 

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
@@ -10,21 +10,17 @@ import { GeoJsonProperties } from 'geojson';
 import { omit } from 'lodash';
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { appConfig } from '../../../../../config';
-import {
-  ChartConfig,
-  DatasetField,
-  WMSLayerProps,
-} from '../../../../../config/types';
+import { appConfig } from 'config';
+import { ChartConfig, DatasetField, WMSLayerProps } from 'config/types';
 import {
   CHART_DATA_PREFIXES,
   DatasetRequestParams,
   loadAdminBoundaryDataset,
-} from '../../../../../context/datasetStateSlice';
-import { TableData } from '../../../../../context/tableStateSlice';
-import { useSafeTranslation } from '../../../../../i18n';
-import { getChartAdminBoundaryParams } from '../../../../../utils/admin-utils';
-import Chart from '../../../../Common/Chart';
+} from 'context/datasetStateSlice';
+import { TableData } from 'context/tableStateSlice';
+import { useSafeTranslation } from 'i18n';
+import { getChartAdminBoundaryParams } from 'utils/admin-utils';
+import Chart from 'components/Common/Chart';
 
 const ChartSection = memo(
   ({

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.test.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.test.tsx
@@ -1,6 +1,6 @@
 import { MutableRefObject } from 'react';
+import { downloadToFile } from 'components/MapView/utils';
 import { downloadCsv } from '.';
-import { downloadToFile } from '../../utils';
 
 jest.mock('../../utils', () => ({
   downloadToFile: jest.fn(),

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -30,23 +30,22 @@ import React, {
 import DatePicker from 'react-datepicker';
 import { useSelector } from 'react-redux';
 import { TFunctionKeys } from 'i18next';
-import { appConfig } from '../../../../config';
-import {
-  BoundaryLayerProps,
-  PanelSize,
-  WMSLayerProps,
-} from '../../../../config/types';
+import { appConfig } from 'config';
+import { BoundaryLayerProps, PanelSize, WMSLayerProps } from 'config/types';
 import {
   getBoundaryLayersByAdminLevel,
   getWMSLayersWithChart,
-} from '../../../../config/utils';
-import { LayerData } from '../../../../context/layers/layer-data';
-import { leftPanelTabValueSelector } from '../../../../context/leftPanelStateSlice';
-import { layerDataSelector } from '../../../../context/mapStateSlice/selectors';
-import { useSafeTranslation } from '../../../../i18n';
-import { castObjectsArrayToCsv } from '../../../../utils/csv-utils';
-import { getOrderedAreas, OrderedArea } from '../../Layers/BoundaryDropdown';
-import { downloadToFile } from '../../utils';
+} from 'config/utils';
+import { LayerData } from 'context/layers/layer-data';
+import { leftPanelTabValueSelector } from 'context/leftPanelStateSlice';
+import { layerDataSelector } from 'context/mapStateSlice/selectors';
+import { useSafeTranslation } from 'i18n';
+import { castObjectsArrayToCsv } from 'utils/csv-utils';
+import {
+  getOrderedAreas,
+  OrderedArea,
+} from 'components/MapView/Layers/BoundaryDropdown';
+import { downloadToFile } from 'components/MapView/utils';
 import ChartSection from './ChartSection';
 
 // Load boundary layer for Admin2

--- a/frontend/src/components/MapView/LeftPanel/LeftPanelTabs/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/LeftPanelTabs/index.tsx
@@ -16,15 +16,15 @@ import {
 import React, { memo, useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { sum } from 'lodash';
-import { PanelSize } from '../../../../config/types';
-import { getWMSLayersWithChart } from '../../../../config/utils';
+import { PanelSize } from 'config/types';
+import { getWMSLayersWithChart } from 'config/utils';
 import {
   leftPanelTabValueSelector,
   setTabValue,
-} from '../../../../context/leftPanelStateSlice';
-import { useSafeTranslation } from '../../../../i18n';
+} from 'context/leftPanelStateSlice';
+import { useSafeTranslation } from 'i18n';
+import { analysisResultSelector } from 'context/analysisResultStateSlice';
 import TabPanel from './TabPanel';
-import { analysisResultSelector } from '../../../../context/analysisResultStateSlice';
 
 interface StyleProps {
   tabValue: number;

--- a/frontend/src/components/MapView/LeftPanel/TablesPanel/DataTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/TablesPanel/DataTable/index.tsx
@@ -15,15 +15,12 @@ import {
   Typography,
 } from '@material-ui/core';
 import { orderBy } from 'lodash';
-import { useSafeTranslation } from '../../../../../i18n';
-import { ChartConfig } from '../../../../../config/types';
-import {
-  TableData,
-  TableRowType,
-} from '../../../../../context/tableStateSlice';
-import Chart from '../../../../Common/Chart';
-import LoadingBlinkingDots from '../../../../Common/LoadingBlinkingDots';
-import { getTableCellVal } from '../../../../../utils/data-utils';
+import { useSafeTranslation } from 'i18n';
+import { ChartConfig } from 'config/types';
+import { TableData, TableRowType } from 'context/tableStateSlice';
+import Chart from 'components/Common/Chart';
+import LoadingBlinkingDots from 'components/Common/LoadingBlinkingDots';
+import { getTableCellVal } from 'utils/data-utils';
 
 const DataTable = memo(
   ({

--- a/frontend/src/components/MapView/LeftPanel/TablesPanel/TablesActions/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/TablesPanel/TablesActions/index.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useCallback, useMemo } from 'react';
 import { createStyles, withStyles, WithStyles } from '@material-ui/styles';
 import { Button, Typography } from '@material-ui/core';
-import { useSafeTranslation } from '../../../../../i18n';
+import { useSafeTranslation } from 'i18n';
 
 const TablesActions = memo(
   ({

--- a/frontend/src/components/MapView/LeftPanel/TablesPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/TablesPanel/index.tsx
@@ -20,17 +20,17 @@ import {
   MenuItemType,
   PanelSize,
   TableType,
-} from '../../../../config/types';
-import { useSafeTranslation } from '../../../../i18n';
+} from 'config/types';
+import { useSafeTranslation } from 'i18n';
 import {
   getCurrentData as getTableData,
   getCurrentDefinition as getTableDefinition,
   getIsShowing as getTableIsShowing,
   isLoading as tableLoading,
   loadTable,
-} from '../../../../context/tableStateSlice';
+} from 'context/tableStateSlice';
+import { leftPanelTabValueSelector } from 'context/leftPanelStateSlice';
 import TablesActions from './TablesActions';
-import { leftPanelTabValueSelector } from '../../../../context/leftPanelStateSlice';
 import DataTable from './DataTable';
 
 const tabIndex = 3;

--- a/frontend/src/components/MapView/LeftPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/index.tsx
@@ -1,11 +1,7 @@
 import { createStyles, Drawer, makeStyles, Theme } from '@material-ui/core';
 import React, { memo, useMemo } from 'react';
-import {
-  LayersCategoryType,
-  MenuItemType,
-  PanelSize,
-} from '../../../config/types';
-import { Extent } from '../Layers/raster-utils';
+import { LayersCategoryType, MenuItemType, PanelSize } from 'config/types';
+import { Extent } from 'components/MapView/Layers/raster-utils';
 import AnalysisPanel from './AnalysisPanel';
 import ChartsPanel from './ChartsPanel';
 import LayersPanel from './layersPanel';

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerMenuItem/index.test.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerMenuItem/index.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import React from 'react';
-import { store } from '../../../../../context/store';
+import { store } from 'context/store';
 import AnalysisLayerMenuItem from '.';
 
 test('renders as expected', () => {

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerMenuItem/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerMenuItem/index.tsx
@@ -10,13 +10,13 @@ import {
   Typography,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { useSafeTranslation } from '../../../../../i18n';
-import AnalysisLayerSwitchItem from '../AnalysisLayerSwitchItem';
+import { useSafeTranslation } from 'i18n';
+import AnalysisLayerSwitchItem from 'components/MapView/LeftPanel/layersPanel/AnalysisLayerSwitchItem';
 import {
   BaselineLayerResult,
   ExposedPopulationResult,
   PolygonAnalysisResult,
-} from '../../../../../utils/analysis-utils';
+} from 'utils/analysis-utils';
 
 interface AnalysisLayerMenuItemProps {
   title: string;

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerSwitchItem/AnalysisLayerSwitchItemDownloadOptions/index.test.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerSwitchItem/AnalysisLayerSwitchItemDownloadOptions/index.test.tsx
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import React from 'react';
+import { store } from 'context/store';
 import AnalysisLayerSwitchItemDownloadOptions from '.';
-import { store } from '../../../../../../context/store';
 
 test('renders as expected', () => {
   const { container } = render(

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerSwitchItem/AnalysisLayerSwitchItemDownloadOptions/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerSwitchItem/AnalysisLayerSwitchItemDownloadOptions/index.tsx
@@ -1,8 +1,8 @@
 import React, { memo, useMemo, useCallback, useState } from 'react';
 import { IconButton, Menu, MenuItem, Tooltip } from '@material-ui/core';
 import GetAppIcon from '@material-ui/icons/GetApp';
-import { useSafeTranslation } from '../../../../../../i18n';
-import { downloadToFile } from '../../../../utils';
+import { useSafeTranslation } from 'i18n';
+import { downloadToFile } from 'components/MapView/utils';
 import {
   BaselineLayerResult,
   downloadCSVFromTableData,
@@ -10,7 +10,7 @@ import {
   generateAnalysisFilename,
   PolygonAnalysisResult,
   useAnalysisTableColumns,
-} from '../../../../../../utils/analysis-utils';
+} from 'utils/analysis-utils';
 
 const AnalysisLayerSwitchItemDownloadOptions = memo(
   ({

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerSwitchItem/index.test.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerSwitchItem/index.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import React from 'react';
-import { store } from '../../../../../context/store';
+import { store } from 'context/store';
 import AnalysisLayerSwitchItem from '.';
 
 test('renders as expected', () => {

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerSwitchItem/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/AnalysisLayerSwitchItem/index.tsx
@@ -20,15 +20,15 @@ import OpacityIcon from '@material-ui/icons/Opacity';
 import {
   clearAnalysisResult,
   setAnalysisLayerOpacity,
-} from '../../../../../context/analysisResultStateSlice';
-import { handleChangeOpacity } from '../../../Legends/handleChangeOpacity';
-import { mapSelector } from '../../../../../context/mapStateSlice/selectors';
-import AnalysisLayerSwitchItemDownloadOptions from './AnalysisLayerSwitchItemDownloadOptions';
+} from 'context/analysisResultStateSlice';
+import { handleChangeOpacity } from 'components/MapView/Legends/handleChangeOpacity';
+import { mapSelector } from 'context/mapStateSlice/selectors';
 import {
   BaselineLayerResult,
   ExposedPopulationResult,
   PolygonAnalysisResult,
-} from '../../../../../utils/analysis-utils';
+} from 'utils/analysis-utils';
+import AnalysisLayerSwitchItemDownloadOptions from './AnalysisLayerSwitchItemDownloadOptions';
 
 const AnalysisLayerSwitchItem = memo(
   ({

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/index.test.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/index.test.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 
+import { store } from 'context/store';
+import { LayerKey, MenuItemType } from 'config/types';
 import MenuItem from '.';
-import { store } from '../../../../../context/store';
-import { LayerKey, MenuItemType } from '../../../../../config/types';
 
-jest.mock('../MenuSwitch', () => 'mock-MenuSwitch');
+jest.mock(
+  'components/MapView/LeftPanel/layersPanel/MenuSwitch',
+  () => 'mock-MenuSwitch',
+);
 
 const props: MenuItemType = {
   title: 'title',

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/index.tsx
@@ -11,12 +11,12 @@ import {
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { useSelector } from 'react-redux';
-import { LayersCategoryType } from '../../../../../config/types';
-import MenuSwitch from '../MenuSwitch';
-import { useSafeTranslation } from '../../../../../i18n';
-import { Extent } from '../../../Layers/raster-utils';
-import { layersSelector } from '../../../../../context/mapStateSlice/selectors';
-import { filterActiveLayers } from '../../../utils';
+import { LayersCategoryType } from 'config/types';
+import MenuSwitch from 'components/MapView/LeftPanel/layersPanel/MenuSwitch';
+import { useSafeTranslation } from 'i18n';
+import { Extent } from 'components/MapView/Layers/raster-utils';
+import { layersSelector } from 'context/mapStateSlice/selectors';
+import { filterActiveLayers } from 'components/MapView/utils';
 
 const useStyles = makeStyles(() =>
   createStyles({

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/ExposureAnalysisOption.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/ExposureAnalysisOption.tsx
@@ -7,20 +7,20 @@ import {
   ExposedPopulationDefinition,
   GeometryType,
   LayerType,
-} from '../../../../../../config/types';
-import { TableKey } from '../../../../../../config/utils';
+} from 'config/types';
+import { TableKey } from 'config/utils';
 import {
   analysisResultSelector,
   clearAnalysisResult,
   ExposedPopulationDispatchParams,
   requestAndStoreExposedPopulation,
   setCurrentDataDefinition,
-} from '../../../../../../context/analysisResultStateSlice';
-import { setTabValue } from '../../../../../../context/leftPanelStateSlice';
-import { dateRangeSelector } from '../../../../../../context/mapStateSlice/selectors';
-import { useSafeTranslation } from '../../../../../../i18n';
-import { Extent } from '../../../../Layers/raster-utils';
-import { generateUniqueTableKey } from '../../../../utils';
+} from 'context/analysisResultStateSlice';
+import { setTabValue } from 'context/leftPanelStateSlice';
+import { dateRangeSelector } from 'context/mapStateSlice/selectors';
+import { useSafeTranslation } from 'i18n';
+import { Extent } from 'components/MapView/Layers/raster-utils';
+import { generateUniqueTableKey } from 'components/MapView/utils';
 
 function ExposureAnalysisOption({
   layer,

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -15,21 +15,24 @@ import {
   AdminLevelDataLayerProps,
   LayerType,
   WMSLayerProps,
-} from '../../../../../../config/types';
+} from 'config/types';
 import {
   dateRangeSelector,
   layerDataSelector,
-} from '../../../../../../context/mapStateSlice/selectors';
-import { LayerData } from '../../../../../../context/layers/layer-data';
-import { downloadToFile } from '../../../../utils';
+} from 'context/mapStateSlice/selectors';
+import { LayerData } from 'context/layers/layer-data';
+import { downloadToFile } from 'components/MapView/utils';
 import {
   DEFAULT_DATE_FORMAT,
   DEFAULT_DATE_FORMAT_SNAKE_CASE,
-} from '../../../../../../utils/name-utils';
-import { castObjectsArrayToCsv } from '../../../../../../utils/csv-utils';
-import { downloadGeotiff, Extent } from '../../../../Layers/raster-utils';
-import { useSafeTranslation } from '../../../../../../i18n';
-import { isExposureAnalysisLoadingSelector } from '../../../../../../context/analysisResultStateSlice';
+} from 'utils/name-utils';
+import { castObjectsArrayToCsv } from 'utils/csv-utils';
+import {
+  downloadGeotiff,
+  Extent,
+} from 'components/MapView/Layers/raster-utils';
+import { useSafeTranslation } from 'i18n';
+import { isExposureAnalysisLoadingSelector } from 'context/analysisResultStateSlice';
 
 function LayerDownloadOptions({
   layer,

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.test.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 
+import { store } from 'context/store';
+import { LayerType } from 'config/types';
 import SwitchItem from '.';
-import { store } from '../../../../../../context/store';
-import { LayerType } from '../../../../../../config/types';
 
 jest.mock('react-router-dom', () => ({
   useHistory: () => ({

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.tsx
@@ -21,31 +21,25 @@ import React, {
   useState,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { LayerKey, LayerType } from '../../../../../../config/types';
-import {
-  getDisplayBoundaryLayers,
-  LayerDefinitions,
-} from '../../../../../../config/utils';
-import { clearDataset } from '../../../../../../context/datasetStateSlice';
-import { removeLayer } from '../../../../../../context/mapStateSlice';
-import {
-  layersSelector,
-  mapSelector,
-} from '../../../../../../context/mapStateSlice/selectors';
-import { useSafeTranslation } from '../../../../../../i18n';
+import { LayerKey, LayerType } from 'config/types';
+import { getDisplayBoundaryLayers, LayerDefinitions } from 'config/utils';
+import { clearDataset } from 'context/datasetStateSlice';
+import { removeLayer } from 'context/mapStateSlice';
+import { layersSelector, mapSelector } from 'context/mapStateSlice/selectors';
+import { useSafeTranslation } from 'i18n';
 import {
   refreshBoundaries,
   safeDispatchAddLayer,
   safeDispatchRemoveLayer,
-} from '../../../../../../utils/map-utils';
-import { getUrlKey, useUrlHistory } from '../../../../../../utils/url-utils';
-import { handleChangeOpacity } from '../../../../Legends/handleChangeOpacity';
-import { Extent } from '../../../../Layers/raster-utils';
+} from 'utils/map-utils';
+import { getUrlKey, useUrlHistory } from 'utils/url-utils';
+import { handleChangeOpacity } from 'components/MapView/Legends/handleChangeOpacity';
+import { Extent } from 'components/MapView/Layers/raster-utils';
+import { availableDatesSelector } from 'context/serverStateSlice';
+import { checkLayerAvailableDatesAndContinueOrRemove } from 'components/MapView/utils';
+import { LocalError } from 'utils/error-utils';
 import LayerDownloadOptions from './LayerDownloadOptions';
 import ExposureAnalysisOption from './ExposureAnalysisOption';
-import { availableDatesSelector } from '../../../../../../context/serverStateSlice';
-import { checkLayerAvailableDatesAndContinueOrRemove } from '../../../../utils';
-import { LocalError } from '../../../../../../utils/error-utils';
 
 const SwitchItem = memo(({ classes, layer, extent }: SwitchItemProps) => {
   const {

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/index.test.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/index.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 
+import { store } from 'context/store';
+import { LayerKey, LayersCategoryType } from 'config/types';
 import MenuSwitch from '.';
-import { store } from '../../../../../context/store';
-import { LayerKey, LayersCategoryType } from '../../../../../config/types';
 
 jest.mock('./SwitchItem', () => 'mock-SwitchItem');
 

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/index.tsx
@@ -19,12 +19,12 @@ import React, {
   useState,
 } from 'react';
 import { useSelector } from 'react-redux';
-import { LayerType } from '../../../../../config/types';
-import { useSafeTranslation } from '../../../../../i18n';
-import { Extent } from '../../../Layers/raster-utils';
+import { LayerType } from 'config/types';
+import { useSafeTranslation } from 'i18n';
+import { Extent } from 'components/MapView/Layers/raster-utils';
+import { layersSelector } from 'context/mapStateSlice/selectors';
+import { filterActiveLayers } from 'components/MapView/utils';
 import SwitchItem from './SwitchItem';
-import { layersSelector } from '../../../../../context/mapStateSlice/selectors';
-import { filterActiveLayers } from '../../../utils';
 
 const useStyles = makeStyles(() =>
   createStyles({

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/index.tsx
@@ -1,17 +1,17 @@
 import { Box } from '@material-ui/core';
 import React, { memo, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { Extent } from '../../Layers/raster-utils';
-import MenuItem from './MenuItem';
-import { MenuItemType } from '../../../../config/types';
+import { Extent } from 'components/MapView/Layers/raster-utils';
+import { MenuItemType } from 'config/types';
 import {
   analysisResultOpacitySelector,
   analysisResultSelector,
   analysisResultSortByKeySelector,
   analysisResultSortOrderSelector,
-} from '../../../../context/analysisResultStateSlice';
+} from 'context/analysisResultStateSlice';
+import { useSafeTranslation } from 'i18n';
 import AnalysisLayerMenuItem from './AnalysisLayerMenuItem';
-import { useSafeTranslation } from '../../../../i18n';
+import MenuItem from './MenuItem';
 
 const LayersPanel = memo(({ extent, layersMenuItems }: LayersPanelProps) => {
   const analysisData = useSelector(analysisResultSelector);

--- a/frontend/src/components/MapView/LeftPanel/utils.ts
+++ b/frontend/src/components/MapView/LeftPanel/utils.ts
@@ -1,19 +1,19 @@
 import { camelCase, get, map, mapKeys, startCase } from 'lodash';
 
-import { appConfig } from '../../../config';
 import {
   isTableKey,
   LayerDefinitions,
   TableDefinitions,
   TableKey,
-} from '../../../config/utils';
+} from 'config/utils';
 import {
   isLayerKey,
   LayerKey,
   LayersCategoryType,
   MenuGroup,
   MenuItemType,
-} from '../../../config/types';
+} from 'config/types';
+import { appConfig } from 'config';
 
 type LayersCategoriesType = LayersCategoryType[];
 

--- a/frontend/src/components/MapView/Legends/AnalysisDownloadButton.tsx
+++ b/frontend/src/components/MapView/Legends/AnalysisDownloadButton.tsx
@@ -4,8 +4,8 @@ import {
   analysisResultSelector,
   analysisResultSortByKeySelector,
   analysisResultSortOrderSelector,
-} from '../../../context/analysisResultStateSlice';
-import { useSafeTranslation } from '../../../i18n';
+} from 'context/analysisResultStateSlice';
+import { useSafeTranslation } from 'i18n';
 import {
   BaselineLayerResult,
   downloadCSVFromTableData,
@@ -13,9 +13,9 @@ import {
   generateAnalysisFilename,
   PolygonAnalysisResult,
   useAnalysisTableColumns,
-} from '../../../utils/analysis-utils';
-import MultiOptionsButton from '../../Common/MultiOptionsButton';
-import { downloadToFile } from '../utils';
+} from 'utils/analysis-utils';
+import MultiOptionsButton from 'components/Common/MultiOptionsButton';
+import { downloadToFile } from 'components/MapView/utils';
 
 function AnalysisDownloadButton() {
   const analysisResult = useSelector(analysisResultSelector);

--- a/frontend/src/components/MapView/Legends/ColorIndicator/index.test.tsx
+++ b/frontend/src/components/MapView/Legends/ColorIndicator/index.test.tsx
@@ -6,6 +6,7 @@ import ColorIndicator from '.';
 const props = {
   value: 'Vegetation',
   color: '#EF3202',
+  opacity: 0.7,
 };
 
 test('renders as expected', () => {

--- a/frontend/src/components/MapView/Legends/LegendImpactResult/index.tsx
+++ b/frontend/src/components/MapView/Legends/LegendImpactResult/index.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from 'react';
-import { useSafeTranslation } from '../../../../i18n';
+import { useSafeTranslation } from 'i18n';
 
 interface LegendImpactProps {
   legendText: string;

--- a/frontend/src/components/MapView/Legends/LegendItem/index.test.tsx
+++ b/frontend/src/components/MapView/Legends/LegendItem/index.test.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import { Provider } from 'react-redux';
-import { store } from '../../../../context/store';
+import { store } from 'context/store';
 import LegendItem from '.';
-
-jest.mock('../ColorIndicator', () => 'mock-ColorIndicator');
 
 test('renders as expected', () => {
   const { container } = render(

--- a/frontend/src/components/MapView/Legends/LegendItem/index.tsx
+++ b/frontend/src/components/MapView/Legends/LegendItem/index.tsx
@@ -19,15 +19,15 @@ import {
   WithStyles,
 } from '@material-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
-import { LayerType, LegendDefinitionItem } from '../../../../config/types';
-import { mapSelector } from '../../../../context/mapStateSlice/selectors';
-import { useSafeTranslation } from '../../../../i18n';
-import { setAnalysisLayerOpacity } from '../../../../context/analysisResultStateSlice';
-import LayerContentPreview from '../layerContentPreview';
-import { handleChangeOpacity } from '../handleChangeOpacity';
-import ColorIndicator from '../ColorIndicator';
-import { getLegendItemLabel } from '../../utils';
-import LoadingBar from '../LoadingBar';
+import { LayerType, LegendDefinitionItem } from 'config/types';
+import { mapSelector } from 'context/mapStateSlice/selectors';
+import { useSafeTranslation } from 'i18n';
+import { setAnalysisLayerOpacity } from 'context/analysisResultStateSlice';
+import LayerContentPreview from 'components/MapView/Legends/layerContentPreview';
+import { handleChangeOpacity } from 'components/MapView/Legends/handleChangeOpacity';
+import ColorIndicator from 'components/MapView/Legends/ColorIndicator';
+import { getLegendItemLabel } from 'components/MapView/utils';
+import LoadingBar from 'components/MapView/Legends/LoadingBar';
 
 // Children here is legendText
 const LegendItem = memo(

--- a/frontend/src/components/MapView/Legends/LoadingBar.tsx
+++ b/frontend/src/components/MapView/Legends/LoadingBar.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { makeStyles, LinearProgress } from '@material-ui/core';
 import { useSelector } from 'react-redux';
-import { LayerKey } from '../../../config/types';
-import { loadingLayerIdsSelector as tileLayerIdsSelector } from '../../../context/mapTileLoadingStateSlice';
-import { loadingLayerIdsSelector as vectorLayerIdsSelector } from '../../../context/mapStateSlice/selectors';
+import { LayerKey } from 'config/types';
+import { loadingLayerIdsSelector as tileLayerIdsSelector } from 'context/mapTileLoadingStateSlice';
+import { loadingLayerIdsSelector as vectorLayerIdsSelector } from 'context/mapStateSlice/selectors';
 
 export interface LoadingBarProps {
   layerId: LayerKey | undefined;

--- a/frontend/src/components/MapView/Legends/handleChangeOpacity.ts
+++ b/frontend/src/components/MapView/Legends/handleChangeOpacity.ts
@@ -1,5 +1,5 @@
 import { Map as MapBoxMap } from 'mapbox-gl';
-import { LayerType } from '../../../config/types';
+import { LayerType } from 'config/types';
 
 export const handleChangeOpacity = (
   event: React.ChangeEvent<{}>,

--- a/frontend/src/components/MapView/Legends/index.test.tsx
+++ b/frontend/src/components/MapView/Legends/index.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import { Provider } from 'react-redux';
+import { store } from 'context/store';
 import Legends from '.';
-import { store } from '../../../context/store';
 
 jest.mock('./ColorIndicator', () => 'mock-ColorIndicator');
 

--- a/frontend/src/components/MapView/Legends/index.tsx
+++ b/frontend/src/components/MapView/Legends/index.tsx
@@ -14,16 +14,14 @@ import React, { useState, memo, useMemo, useCallback } from 'react';
 
 import { createGetLegendGraphicUrl } from 'prism-common';
 import { useSelector } from 'react-redux';
-import { LayerType } from '../../../config/types';
 import {
   analysisResultOpacitySelector,
   analysisResultSelector,
   isAnalysisLayerActiveSelector,
-} from '../../../context/analysisResultStateSlice';
-
-import { BaselineLayerResult } from '../../../utils/analysis-utils';
-
-import { useSafeTranslation } from '../../../i18n';
+} from 'context/analysisResultStateSlice';
+import { LayerType } from 'config/types';
+import { BaselineLayerResult } from 'utils/analysis-utils';
+import { useSafeTranslation } from 'i18n';
 
 import AnalysisDownloadButton from './AnalysisDownloadButton';
 import LegendItem from './LegendItem';

--- a/frontend/src/components/MapView/Legends/layerContentPreview.tsx
+++ b/frontend/src/components/MapView/Legends/layerContentPreview.tsx
@@ -9,10 +9,10 @@ import {
 } from '@material-ui/core';
 import InfoIcon from '@material-ui/icons/Info';
 import { useDispatch } from 'react-redux';
-import { LayerType } from '../../../config/types';
-import { LayerDefinitions } from '../../../config/utils';
-import ContentDialog from '../../NavBar/ContentDialog';
-import { loadLayerContent } from '../../../utils/load-layer-utils';
+import { LayerType } from 'config/types';
+import { LayerDefinitions } from 'config/utils';
+import ContentDialog from 'components/NavBar/ContentDialog';
+import { loadLayerContent } from 'utils/load-layer-utils';
 
 const LayerContentPreview = memo(({ layerId, classes }: PreviewProps) => {
   const [content, setContent] = useState<string | undefined>(undefined);

--- a/frontend/src/components/MapView/Map/index.test.tsx
+++ b/frontend/src/components/MapView/Map/index.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import React from 'react';
-import { store } from '../../../context/store';
+import { store } from 'context/store';
 import MapComponent from '.';
 
 jest.mock('react-mapbox-gl', () => ({

--- a/frontend/src/components/MapView/Map/index.tsx
+++ b/frontend/src/components/MapView/Map/index.tsx
@@ -11,20 +11,17 @@ import React, {
 import { Map, MapSourceDataEvent } from 'mapbox-gl';
 import ReactMapboxGl from 'react-mapbox-gl';
 import { useDispatch, useSelector } from 'react-redux';
-import AnalysisLayer from '../Layers/AnalysisLayer';
-import SelectionLayer from '../Layers/SelectionLayer';
-import MapTooltip from '../MapTooltip';
-import { setMap } from '../../../context/mapStateSlice';
-import { appConfig } from '../../../config';
-import useMapOnClick from '../useMapOnClick';
-import {
-  setBounds,
-  setLocation,
-} from '../../../context/mapBoundaryInfoStateSlice';
-import { DiscriminateUnion, LayerKey, LayerType } from '../../../config/types';
-import { setLoadingLayerIds } from '../../../context/mapTileLoadingStateSlice';
-import { firstBoundaryOnView, isLayerOnView } from '../../../utils/map-utils';
-import { mapSelector } from '../../../context/mapStateSlice/selectors';
+import AnalysisLayer from 'components/MapView/Layers/AnalysisLayer';
+import SelectionLayer from 'components/MapView/Layers/SelectionLayer';
+import MapTooltip from 'components/MapView/MapTooltip';
+import { setMap } from 'context/mapStateSlice';
+import { appConfig } from 'config';
+import useMapOnClick from 'components/MapView/useMapOnClick';
+import { setBounds, setLocation } from 'context/mapBoundaryInfoStateSlice';
+import { DiscriminateUnion, LayerKey, LayerType } from 'config/types';
+import { setLoadingLayerIds } from 'context/mapTileLoadingStateSlice';
+import { firstBoundaryOnView, isLayerOnView } from 'utils/map-utils';
+import { mapSelector } from 'context/mapStateSlice/selectors';
 import {
   AdminLevelDataLayer,
   BoundaryLayer,
@@ -32,7 +29,7 @@ import {
   PointDataLayer,
   StaticRasterLayer,
   WMSLayer,
-} from '../Layers';
+} from 'components/MapView/Layers';
 
 interface MapComponentProps {
   setIsAlertFormOpen: Dispatch<SetStateAction<boolean>>;

--- a/frontend/src/components/MapView/MapTooltip/index.tsx
+++ b/frontend/src/components/MapView/MapTooltip/index.tsx
@@ -8,8 +8,8 @@ import {
   LinearProgress,
 } from '@material-ui/core';
 import { isEqual } from 'lodash';
-import { tooltipSelector } from '../../../context/tooltipStateSlice';
-import { isEnglishLanguageSelected, useSafeTranslation } from '../../../i18n';
+import { tooltipSelector } from 'context/tooltipStateSlice';
+import { isEnglishLanguageSelected, useSafeTranslation } from 'i18n';
 
 const MapTooltip = memo(({ classes }: TooltipProps) => {
   const popup = useSelector(tooltipSelector);

--- a/frontend/src/components/MapView/index.test.tsx
+++ b/frontend/src/components/MapView/index.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 
+import { store } from 'context/store';
 import MapView from '.';
-import { store } from '../../context/store';
 
 jest.mock('./Layers/WMSLayer', () => 'mock-WMSLayer');
 jest.mock('./Layers/ImpactLayer', () => 'mock-ImpactLayer');

--- a/frontend/src/components/MapView/index.tsx
+++ b/frontend/src/components/MapView/index.tsx
@@ -12,62 +12,59 @@ import { countBy, get, pickBy } from 'lodash';
 import moment from 'moment';
 // map
 import bbox from '@turf/bbox';
-import Legends from './Legends';
-
 import {
   BoundaryLayerProps,
   isMainLayer,
   LayerKey,
   LayerType,
   PanelSize,
-} from '../../config/types';
-
-import { Extent } from './Layers/raster-utils';
-import { getUrlKey, UrlLayerKey, useUrlHistory } from '../../utils/url-utils';
-
+} from 'config/types';
+import { getUrlKey, UrlLayerKey, useUrlHistory } from 'utils/url-utils';
 import {
   getBoundaryLayerSingleton,
   getDisplayBoundaryLayers,
   LayerDefinitions,
-} from '../../config/utils';
-
-import DateSelector from './DateSelector';
-import { findClosestDate } from './DateSelector/utils';
+} from 'config/utils';
 import {
   dateRangeSelector,
   layerDataSelector,
   layersSelector,
-} from '../../context/mapStateSlice/selectors';
+} from 'context/mapStateSlice/selectors';
+
 import {
   addLayer,
   layerOrdering,
   removeLayer,
   updateDateRange,
-} from '../../context/mapStateSlice';
-import { hidePopup } from '../../context/tooltipStateSlice';
+} from 'context/mapStateSlice';
+import { hidePopup } from 'context/tooltipStateSlice';
 import {
   availableDatesSelector,
   isLoading as areDatesLoading,
   loadAvailableDates,
-} from '../../context/serverStateSlice';
+} from 'context/serverStateSlice';
 
-import { appConfig } from '../../config';
-import { LayerData, loadLayerData } from '../../context/layers/layer-data';
+import { appConfig } from 'config';
+import { LayerData, loadLayerData } from 'context/layers/layer-data';
 import {
   DateCompatibleLayer,
   getPossibleDatesForLayer,
-} from '../../utils/server-utils';
-import { addNotification } from '../../context/notificationStateSlice';
+} from 'utils/server-utils';
+import { addNotification } from 'context/notificationStateSlice';
+import GoToBoundaryDropdown from 'components/Common/BoundaryDropdown/goto';
+import { DEFAULT_DATE_FORMAT } from 'utils/name-utils';
+import DataViewer from 'components/DataViewer';
+import { LocalError } from 'utils/error-utils';
 import AlertForm from './AlertForm';
-import GoToBoundaryDropdown from '../Common/BoundaryDropdown/goto';
 import BoundaryInfoBox from './BoundaryInfoBox';
-import { DEFAULT_DATE_FORMAT } from '../../utils/name-utils';
-import DataViewer from '../DataViewer';
 import LeftPanel from './LeftPanel';
 import FoldButton from './FoldButton';
 import MapComponent from './Map';
 import { checkLayerAvailableDatesAndContinueOrRemove } from './utils';
-import { LocalError } from '../../utils/error-utils';
+import DateSelector from './DateSelector';
+import { findClosestDate } from './DateSelector/utils';
+import { Extent } from './Layers/raster-utils';
+import Legends from './Legends';
 
 const dateSupportLayerTypes: Array<LayerType['type']> = [
   'impact',

--- a/frontend/src/components/MapView/useMapOnClick.ts
+++ b/frontend/src/components/MapView/useMapOnClick.ts
@@ -7,17 +7,17 @@ import { useCallback, useMemo } from 'react';
 import {
   dateRangeSelector,
   layerDataSelector,
-} from '../../context/mapStateSlice/selectors';
-import { LayerData } from '../../context/layers/layer-data';
-import { BoundaryLayerProps } from '../../config/types';
+} from 'context/mapStateSlice/selectors';
+import { LayerData } from 'context/layers/layer-data';
+import { BoundaryLayerProps } from 'config/types';
 import {
   addPopupData,
   hidePopup,
   setWMSGetFeatureInfoLoading,
-} from '../../context/tooltipStateSlice';
+} from 'context/tooltipStateSlice';
+import { DEFAULT_DATE_FORMAT } from 'utils/name-utils';
+import { makeFeatureInfoRequest } from 'utils/server-utils';
 import { getActiveFeatureInfoLayers, getFeatureInfoParams } from './utils';
-import { DEFAULT_DATE_FORMAT } from '../../utils/name-utils';
-import { makeFeatureInfoRequest } from '../../utils/server-utils';
 
 const useMapOnClick = (
   setIsAlertFormOpen: (value: boolean) => void,

--- a/frontend/src/components/MapView/utils.ts
+++ b/frontend/src/components/MapView/utils.ts
@@ -2,9 +2,8 @@ import { values } from 'lodash';
 import { Map } from 'mapbox-gl';
 import { TFunction } from 'i18next';
 import { Dispatch } from 'redux';
-import { LayerDefinitions } from '../../config/utils';
-import { formatFeatureInfo } from '../../utils/server-utils';
-import { getExtent } from './Layers/raster-utils';
+import { LayerDefinitions } from 'config/utils';
+import { formatFeatureInfo } from 'utils/server-utils';
 import {
   AvailableDates,
   FeatureInfoObject,
@@ -12,11 +11,12 @@ import {
   LayerType,
   LegendDefinitionItem,
   WMSLayerProps,
-} from '../../config/types';
-import { TableData } from '../../context/tableStateSlice';
-import { getUrlKey, UrlLayerKey } from '../../utils/url-utils';
-import { addNotification } from '../../context/notificationStateSlice';
-import { LocalError } from '../../utils/error-utils';
+} from 'config/types';
+import { TableData } from 'context/tableStateSlice';
+import { getUrlKey, UrlLayerKey } from 'utils/url-utils';
+import { addNotification } from 'context/notificationStateSlice';
+import { LocalError } from 'utils/error-utils';
+import { getExtent } from './Layers/raster-utils';
 
 export const getActiveFeatureInfoLayers = (map: Map): WMSLayerProps[] => {
   const matchStr = 'layer-';

--- a/frontend/src/components/NavBar/About/index.tsx
+++ b/frontend/src/components/NavBar/About/index.tsx
@@ -3,10 +3,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Typography, Grid } from '@material-ui/core';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { useDispatch } from 'react-redux';
-import { appConfig } from '../../../config';
-import ContentDialog from '../ContentDialog';
-import { useSafeTranslation } from '../../../i18n';
-import { loadLayerContent } from '../../../utils/load-layer-utils';
+import { appConfig } from 'config';
+import ContentDialog from 'components/NavBar/ContentDialog';
+import { useSafeTranslation } from 'i18n';
+import { loadLayerContent } from 'utils/load-layer-utils';
 
 const About = memo(() => {
   const [content, setContent] = useState<string | undefined>(undefined);

--- a/frontend/src/components/NavBar/LanguageSelector/index.tsx
+++ b/frontend/src/components/NavBar/LanguageSelector/index.tsx
@@ -8,7 +8,7 @@ import {
   withStyles,
   WithStyles,
 } from '@material-ui/core';
-import { languages, useSafeTranslation } from '../../../i18n';
+import { languages, useSafeTranslation } from 'i18n';
 
 function LanguageSelector({ classes }: LanguageSelectorProps) {
   const { i18n } = useSafeTranslation();

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -12,8 +12,8 @@ import {
 } from '@material-ui/core';
 import { jsPDF } from 'jspdf';
 import React from 'react';
-import { useSafeTranslation } from '../../../i18n';
-import { downloadToFile } from '../../MapView/utils';
+import { useSafeTranslation } from 'i18n';
+import { downloadToFile } from 'components/MapView/utils';
 
 function DownloadImage({
   classes,

--- a/frontend/src/components/NavBar/PrintImage/index.test.tsx
+++ b/frontend/src/components/NavBar/PrintImage/index.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import { Provider } from 'react-redux';
+import { store } from 'context/store';
 import Download from '.';
-import { store } from '../../../context/store';
 
 test('renders as expected', () => {
   const { container } = render(

--- a/frontend/src/components/NavBar/PrintImage/index.tsx
+++ b/frontend/src/components/NavBar/PrintImage/index.tsx
@@ -8,8 +8,8 @@ import {
 } from '@material-ui/core';
 import { useSelector } from 'react-redux';
 import Print from '@material-ui/icons/Print';
-import { mapSelector } from '../../../context/mapStateSlice/selectors';
-import { useSafeTranslation } from '../../../i18n';
+import { mapSelector } from 'context/mapStateSlice/selectors';
+import { useSafeTranslation } from 'i18n';
 import DownloadImage from './image';
 
 function PrintImage({ classes }: PrintImageProps) {

--- a/frontend/src/components/NavBar/index.test.tsx
+++ b/frontend/src/components/NavBar/index.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
+import { store } from 'context/store';
 import NavBar from '.';
-import { store } from '../../context/store';
 
 jest.mock('./PrintImage', () => 'mock-PrintImage');
 

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -18,11 +18,11 @@ import {
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { get } from 'lodash';
-import { useSafeTranslation } from '../../i18n';
+import { useSafeTranslation } from 'i18n';
+import { appConfig } from 'config';
 import About from './About';
 import LanguageSelector from './LanguageSelector';
 import PrintImage from './PrintImage';
-import { appConfig } from '../../config';
 
 function NavBar({ classes }: NavBarProps) {
   const { t } = useSafeTranslation();

--- a/frontend/src/components/Notifier/index.tsx
+++ b/frontend/src/components/Notifier/index.tsx
@@ -7,7 +7,7 @@ import {
   Notification,
   notificationsSelector,
   removeNotification,
-} from '../../context/notificationStateSlice';
+} from 'context/notificationStateSlice';
 
 const AUTO_CLOSE_TIME = 10 * 1000;
 

--- a/frontend/src/context/analysisResultStateSlice.ts
+++ b/frontend/src/context/analysisResultStateSlice.ts
@@ -10,10 +10,9 @@ import {
 import moment from 'moment';
 import { get, groupBy as _groupBy, uniq } from 'lodash';
 import { createGetCoverageUrl } from 'prism-common';
-import { calculate } from '../utils/zonal-utils';
+import { calculate } from 'utils/zonal-utils';
 
-import type { CreateAsyncThunkTypes, RootState } from './store';
-import { defaultBoundariesPath } from '../config';
+import { defaultBoundariesPath } from 'config';
 import {
   AdminLevelDataLayerProps,
   AdminLevelType,
@@ -29,8 +28,8 @@ import {
   WfsRequestParams,
   WMSLayerProps,
   ZonalPolygonRow,
-} from '../config/types';
-import { getAdminLevelLayer, getAdminNameProperty } from '../utils/admin-utils';
+} from 'config/types';
+import { getAdminLevelLayer, getAdminNameProperty } from 'utils/admin-utils';
 import {
   AnalysisResult,
   ApiData,
@@ -47,21 +46,22 @@ import {
   PolygonAnalysisResult,
   scaleAndFilterAggregateData,
   scaleFeatureStat,
-} from '../utils/analysis-utils';
-import { getRoundedData } from '../utils/data-utils';
-import { DEFAULT_DATE_FORMAT, getFullLocationName } from '../utils/name-utils';
+} from 'utils/analysis-utils';
+import { getRoundedData } from 'utils/data-utils';
+import { DEFAULT_DATE_FORMAT, getFullLocationName } from 'utils/name-utils';
 import {
   getBoundaryLayersByAdminLevel,
   getBoundaryLayerSingleton,
   LayerDefinitions,
-} from '../config/utils';
-import { Extent } from '../components/MapView/Layers/raster-utils';
-import { fetchWMSLayerAsGeoJSON } from '../utils/server-utils';
+} from 'config/utils';
+import { Extent } from 'components/MapView/Layers/raster-utils';
+import { fetchWMSLayerAsGeoJSON } from 'utils/server-utils';
+import { isLocalhost } from 'serviceWorker';
 import { layerDataSelector } from './mapStateSlice/selectors';
 import { LayerData, LayerDataParams, loadLayerData } from './layers/layer-data';
 import { DataRecord } from './layers/admin_level_data';
 import { BoundaryLayerData } from './layers/boundary';
-import { isLocalhost } from '../serviceWorker';
+import type { CreateAsyncThunkTypes, RootState } from './store';
 
 const ANALYSIS_API_URL = 'https://prism-api.ovio.org/stats'; // TODO both needs to be stored somewhere
 

--- a/frontend/src/context/datasetStateSlice.ts
+++ b/frontend/src/context/datasetStateSlice.ts
@@ -2,17 +2,16 @@ import moment from 'moment';
 import { orderBy } from 'lodash';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Dispatch } from 'redux';
-import type { CreateAsyncThunkTypes, RootState } from './store';
-import { TableData } from './tableStateSlice';
-import { ChartType, DatasetField } from '../config/types';
-import { DEFAULT_DATE_FORMAT } from '../utils/name-utils';
-
+import { ChartType, DatasetField } from 'config/types';
+import { DEFAULT_DATE_FORMAT } from 'utils/name-utils';
 import {
   EWSSensorData,
   EWSTriggersConfig,
   fetchEWSDataPointsByLocation,
-} from '../utils/ews-utils';
-import { fetchWithTimeout } from '../utils/fetch-with-timeout';
+} from 'utils/ews-utils';
+import { fetchWithTimeout } from 'utils/fetch-with-timeout';
+import type { CreateAsyncThunkTypes, RootState } from './store';
+import { TableData } from './tableStateSlice';
 
 export type EWSParams = {
   externalId: string;

--- a/frontend/src/context/layers/admin_level_data.ts
+++ b/frontend/src/context/layers/admin_level_data.ts
@@ -5,15 +5,12 @@ import {
   BoundaryLayerProps,
   AdminLevelDataLayerProps,
   LayerKey,
-} from '../../config/types';
-import type { RootState, ThunkApi } from '../store';
-import {
-  getBoundaryLayerSingleton,
-  LayerDefinitions,
-} from '../../config/utils';
+} from 'config/types';
+import type { RootState, ThunkApi } from 'context/store';
+import { getBoundaryLayerSingleton, LayerDefinitions } from 'config/utils';
+import { layerDataSelector } from 'context/mapStateSlice/selectors';
+import { fetchWithTimeout } from 'utils/fetch-with-timeout';
 import type { LayerData, LayerDataParams, LazyLoader } from './layer-data';
-import { layerDataSelector } from '../mapStateSlice/selectors';
-import { fetchWithTimeout } from '../../utils/fetch-with-timeout';
 
 export type DataRecord = {
   adminKey: string; // refers to a specific admin boundary feature (cell on map). Could be several based off admin level

--- a/frontend/src/context/layers/boundary.ts
+++ b/frontend/src/context/layers/boundary.ts
@@ -1,10 +1,10 @@
 import { FeatureCollection } from 'geojson';
+import { BoundaryLayerProps } from 'config/types';
+import { coordFirst } from 'utils/data-utils';
+import { fetchWithTimeout } from 'utils/fetch-with-timeout';
+import { LocalError } from 'utils/error-utils';
+import { addNotification } from 'context/notificationStateSlice';
 import type { LayerDataParams, LazyLoader } from './layer-data';
-import { BoundaryLayerProps } from '../../config/types';
-import { coordFirst } from '../../utils/data-utils';
-import { fetchWithTimeout } from '../../utils/fetch-with-timeout';
-import { LocalError } from '../../utils/error-utils';
-import { addNotification } from '../notificationStateSlice';
 
 export interface BoundaryLayerData extends FeatureCollection {}
 

--- a/frontend/src/context/layers/impact.ts
+++ b/frontend/src/context/layers/impact.ts
@@ -1,25 +1,22 @@
 import { FeatureCollection } from 'geojson';
-import type { LayerData, LayerDataParams, LazyLoader } from './layer-data';
 import {
   AggregationOperations,
   BoundaryLayerProps,
   ImpactLayerProps,
   AdminLevelDataLayerProps,
   WMSLayerProps,
-} from '../../config/types';
-import type { ThunkApi } from '../store';
+} from 'config/types';
+import type { ThunkApi } from 'context/store';
 
-import {
-  getBoundaryLayerSingleton,
-  LayerDefinitions,
-} from '../../config/utils';
-import { layerDataSelector } from '../mapStateSlice/selectors';
-import type { BaselineLayerData } from '../../utils/analysis-utils';
+import { getBoundaryLayerSingleton, LayerDefinitions } from 'config/utils';
+import { layerDataSelector } from 'context/mapStateSlice/selectors';
+import type { BaselineLayerData } from 'utils/analysis-utils';
 import {
   checkBaselineDataLayer,
   loadFeaturesClientSide,
   loadFeaturesFromApi,
-} from '../../utils/analysis-utils';
+} from 'utils/analysis-utils';
+import type { LayerData, LayerDataParams, LazyLoader } from './layer-data';
 
 export type ImpactLayerData = {
   boundaries: FeatureCollection;

--- a/frontend/src/context/layers/layer-data.ts
+++ b/frontend/src/context/layers/layer-data.ts
@@ -4,9 +4,10 @@ import {
   LayerType,
   PointLayerData,
   StaticRasterLayerProps,
-} from '../../config/types';
-import { Extent } from '../../components/MapView/Layers/raster-utils';
+} from 'config/types';
+import { Extent } from 'components/MapView/Layers/raster-utils';
 
+import type { CreateAsyncThunkTypes, ThunkApi } from 'context/store';
 import {
   fetchAdminLevelDataLayerData,
   AdminLevelDataLayerData,
@@ -15,8 +16,6 @@ import { fetchWCSLayerData, WMSLayerData } from './wms';
 import { fetchPointLayerData } from './point_data';
 import { BoundaryLayerData, fetchBoundaryLayerData } from './boundary';
 import { fetchImpactLayerData, ImpactLayerData } from './impact';
-
-import type { CreateAsyncThunkTypes, ThunkApi } from '../store';
 
 export type LayerAcceptingDataType = Exclude<LayerType, StaticRasterLayerProps>;
 

--- a/frontend/src/context/layers/point_data.ts
+++ b/frontend/src/context/layers/point_data.ts
@@ -1,17 +1,13 @@
 import GeoJSON from 'geojson';
 import moment from 'moment';
-import type { LazyLoader } from './layer-data';
-import {
-  PointDataLayerProps,
-  PointDataLoader,
-  PointData,
-} from '../../config/types';
-import { DEFAULT_DATE_FORMAT } from '../../utils/name-utils';
-import { fetchEWSData } from '../../utils/ews-utils';
+import { PointDataLayerProps, PointDataLoader, PointData } from 'config/types';
+import { DEFAULT_DATE_FORMAT } from 'utils/name-utils';
+import { fetchEWSData } from 'utils/ews-utils';
+import { fetchACLEDIncidents } from 'utils/acled-utils';
+import { queryParamsToString } from 'utils/url-utils';
+import { fetchWithTimeout } from 'utils/fetch-with-timeout';
 import { getAdminLevelDataLayerData } from './admin_level_data';
-import { fetchACLEDIncidents } from '../../utils/acled-utils';
-import { queryParamsToString } from '../../utils/url-utils';
-import { fetchWithTimeout } from '../../utils/fetch-with-timeout';
+import type { LazyLoader } from './layer-data';
 
 declare module 'geojson' {
   export const version: string;

--- a/frontend/src/context/layers/wms.ts
+++ b/frontend/src/context/layers/wms.ts
@@ -1,12 +1,12 @@
 import { createGetCoverageUrl } from 'prism-common';
-import type { LayerDataParams, LazyLoader } from './layer-data';
-import { WMSLayerProps } from '../../config/types';
+import { WMSLayerProps } from 'config/types';
 import {
   GeoTiffImage,
   loadGeoTiff,
   Rasters,
   TransformMatrix,
-} from '../../components/MapView/Layers/raster-utils';
+} from 'components/MapView/Layers/raster-utils';
+import type { LayerDataParams, LazyLoader } from './layer-data';
 
 export type WMSLayerData = {
   image: GeoTiffImage;

--- a/frontend/src/context/mapStateSlice/index.ts
+++ b/frontend/src/context/mapStateSlice/index.ts
@@ -1,10 +1,14 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Map as MapBoxMap } from 'mapbox-gl';
-import { LayerKey, LayerType } from '../../config/types';
-import { LayerDefinitions } from '../../config/utils';
-import { LayerData, LayerDataTypes, loadLayerData } from '../layers/layer-data';
-import { BoundaryRelationsDict } from '../../components/Common/BoundaryDropdown/utils';
-import { keepLayer } from '../../utils/keep-layer-utils';
+import { LayerKey, LayerType } from 'config/types';
+import { LayerDefinitions } from 'config/utils';
+import {
+  LayerData,
+  LayerDataTypes,
+  loadLayerData,
+} from 'context/layers/layer-data';
+import { BoundaryRelationsDict } from 'components/Common/BoundaryDropdown/utils';
+import { keepLayer } from 'utils/keep-layer-utils';
 
 interface DateRange {
   startDate?: number;

--- a/frontend/src/context/mapStateSlice/selectors.ts
+++ b/frontend/src/context/mapStateSlice/selectors.ts
@@ -2,12 +2,12 @@
 // layerDataSelector(used to be mapStateSlice) -> nso/impact -> layer-data -> mapStateSlice
 // x -> y .. x is used by y
 import { Map as MapBoxMap } from 'mapbox-gl';
-import type { RootState } from '../store';
-import type { LayerDataTypes } from '../layers/layer-data';
+import type { RootState } from 'context/store';
+import type { LayerDataTypes } from 'context/layers/layer-data';
+import type { LayerKey, LayerType } from 'config/types';
+import { BoundaryRelationsDict } from 'components/Common/BoundaryDropdown/utils';
+import { datesAreEqualWithoutTime } from 'utils/date-utils';
 import type { MapState } from '.';
-import type { LayerKey, LayerType } from '../../config/types';
-import { BoundaryRelationsDict } from '../../components/Common/BoundaryDropdown/utils';
-import { datesAreEqualWithoutTime } from '../../utils/date-utils';
 
 export const layersSelector = (state: RootState): MapState['layers'] =>
   state.mapState.layers;

--- a/frontend/src/context/mapTileLoadingStateSlice.ts
+++ b/frontend/src/context/mapTileLoadingStateSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { LayerKey } from '../config/types';
+import { LayerKey } from 'config/types';
 import type { RootState } from './store';
 
 type MapTileLoadingState = {

--- a/frontend/src/context/notificationStateSlice.ts
+++ b/frontend/src/context/notificationStateSlice.ts
@@ -5,8 +5,8 @@ import {
   PayloadAction,
 } from '@reduxjs/toolkit';
 import { Color } from '@material-ui/lab';
+import { stringHash } from 'utils/string-utils';
 import type { AppDispatch, RootState } from './store';
-import { stringHash } from '../utils/string-utils';
 
 // to test notification reaction to various error codes, http://httpstat.us/404 can be used where 404 is the status to test.
 type NotificationConstructor = {

--- a/frontend/src/context/serverStateSlice.ts
+++ b/frontend/src/context/serverStateSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
-import { AvailableDates, UserAuth } from '../config/types';
-import { getLayersAvailableDates } from '../utils/server-utils';
+import { AvailableDates, UserAuth } from 'config/types';
+import { getLayersAvailableDates } from 'utils/server-utils';
 import type { CreateAsyncThunkTypes, RootState } from './store';
 
 type ServerState = {

--- a/frontend/src/context/tableStateSlice.ts
+++ b/frontend/src/context/tableStateSlice.ts
@@ -1,9 +1,9 @@
 import { createSlice, PayloadAction, createAsyncThunk } from '@reduxjs/toolkit';
 import * as Papa from 'papaparse';
-import { TableType } from '../config/types';
-import { TableDefinitions } from '../config/utils';
+import { TableType } from 'config/types';
+import { TableDefinitions } from 'config/utils';
+import { EWSChartItemsObject } from 'utils/ews-utils';
 import type { CreateAsyncThunkTypes, RootState } from './store';
-import { EWSChartItemsObject } from '../utils/ews-utils';
 
 export type TableRowType = { [key: string]: string | number };
 export type TableData = {

--- a/frontend/src/utils/acled-utils.ts
+++ b/frontend/src/utils/acled-utils.ts
@@ -2,11 +2,11 @@ import { sortBy } from 'lodash';
 import GeoJSON from 'geojson';
 import moment from 'moment';
 import { Dispatch } from 'redux';
-import { PointLayerData, PointDataLayerProps } from '../config/types';
+import { PointLayerData, PointDataLayerProps } from 'config/types';
+import { addNotification } from 'context/notificationStateSlice';
 import { DEFAULT_DATE_FORMAT } from './name-utils';
 import { queryParamsToString } from './url-utils';
 import { fetchWithTimeout } from './fetch-with-timeout';
-import { addNotification } from '../context/notificationStateSlice';
 import { LocalError } from './error-utils';
 
 export const fetchACLEDDates = async (

--- a/frontend/src/utils/admin-utils.ts
+++ b/frontend/src/utils/admin-utils.ts
@@ -3,14 +3,13 @@ import {
   DatasetLevel,
   BoundaryLayerProps,
   WMSLayerProps,
-} from '../config/types';
+} from 'config/types';
 import {
   getBoundaryLayerSingleton,
   getDisplayBoundaryLayers,
-} from '../config/utils';
+} from 'config/utils';
+import { AdminBoundaryParams } from 'context/datasetStateSlice';
 import { CHART_API_URL } from './constants';
-
-import { AdminBoundaryParams } from '../context/datasetStateSlice';
 
 export function getAdminLevelLayer(
   adminLevel: AdminLevelType = 1,

--- a/frontend/src/utils/analysis-utils.ts
+++ b/frontend/src/utils/analysis-utils.ts
@@ -32,32 +32,32 @@ import {
   ThresholdDefinition,
   WfsRequestParams,
   WMSLayerProps,
-} from '../config/types';
-import type { ThunkApi } from '../context/store';
-import { layerDataSelector } from '../context/mapStateSlice/selectors';
+} from 'config/types';
+import type { ThunkApi } from 'context/store';
+import { layerDataSelector } from 'context/mapStateSlice/selectors';
 import {
   Extent,
   featureIntersectsImage,
   GeoJsonBoundary,
   pixelsInFeature,
-} from '../components/MapView/Layers/raster-utils';
-import { BoundaryLayerData } from '../context/layers/boundary';
-import { AdminLevelDataLayerData } from '../context/layers/admin_level_data';
-import { WMSLayerData } from '../context/layers/wms';
+} from 'components/MapView/Layers/raster-utils';
+import { BoundaryLayerData } from 'context/layers/boundary';
+import { AdminLevelDataLayerData } from 'context/layers/admin_level_data';
+import { WMSLayerData } from 'context/layers/wms';
 import type {
   LayerAcceptingDataType,
   LayerData,
   LayerDataParams,
   LoadLayerDataFuncType,
-} from '../context/layers/layer-data';
-import { LayerDefinitions } from '../config/utils';
-import type { TableRow } from '../context/analysisResultStateSlice';
-import { isLocalhost } from '../serviceWorker';
+} from 'context/layers/layer-data';
+import { LayerDefinitions } from 'config/utils';
+import type { TableRow } from 'context/analysisResultStateSlice';
+import { isLocalhost } from 'serviceWorker';
 import {
   i18nTranslator,
   isEnglishLanguageSelected,
   useSafeTranslation,
-} from '../i18n';
+} from 'i18n';
 import { getRoundedData } from './data-utils';
 import { DEFAULT_DATE_FORMAT_SNAKE_CASE } from './name-utils';
 import {

--- a/frontend/src/utils/data-utils.ts
+++ b/frontend/src/utils/data-utils.ts
@@ -1,8 +1,8 @@
 import { GeoJSON } from 'geojson';
 import { TFunction as _TFunction } from 'i18next';
 import { isNumber } from 'lodash';
-import { TableRowType } from '../context/tableStateSlice';
-import { i18nTranslator } from '../i18n';
+import { TableRowType } from 'context/tableStateSlice';
+import { i18nTranslator } from 'i18n';
 
 export type TFunction = _TFunction;
 

--- a/frontend/src/utils/ews-utils.ts
+++ b/frontend/src/utils/ews-utils.ts
@@ -1,7 +1,7 @@
 import GeoJSON, { FeatureCollection, Point } from 'geojson';
 import moment from 'moment';
 import { Dispatch } from 'redux';
-import { PointData, PointLayerData } from '../config/types';
+import { PointData, PointLayerData } from 'config/types';
 import { fetchWithTimeout } from './fetch-with-timeout';
 
 type EWSChartConfig = {

--- a/frontend/src/utils/fetch-with-timeout.ts
+++ b/frontend/src/utils/fetch-with-timeout.ts
@@ -1,5 +1,5 @@
 import { Dispatch } from 'redux';
-import { addNotification } from '../context/notificationStateSlice';
+import { addNotification } from 'context/notificationStateSlice';
 
 interface FetchWithTimeoutOptions extends RequestInit {
   timeout?: number;

--- a/frontend/src/utils/keep-layer-utils.ts
+++ b/frontend/src/utils/keep-layer-utils.ts
@@ -1,4 +1,4 @@
-import { LayerType } from '../config/types';
+import { LayerType } from 'config/types';
 
 // Layer types that are allowed to have multiple layers overlap on the map.
 export const TYPES_ALLOWED_TO_OVERLAP = [

--- a/frontend/src/utils/map-utils.ts
+++ b/frontend/src/utils/map-utils.ts
@@ -1,7 +1,7 @@
 import { AnyLayer, AnySourceData, Map as MapBoxMap } from 'mapbox-gl';
-import { LayerKey, BoundaryLayerProps, LayerType } from '../config/types';
-import { getDisplayBoundaryLayers } from '../config/utils';
-import { addLayer, removeLayer } from '../context/mapStateSlice';
+import { LayerKey, BoundaryLayerProps, LayerType } from 'config/types';
+import { getDisplayBoundaryLayers } from 'config/utils';
+import { addLayer, removeLayer } from 'context/mapStateSlice';
 
 // fixes the issue that property 'source' is not guaranteed to exist on type 'AnyLayer'
 // because 'CustomLayerInterface' does not specify a 'source' property

--- a/frontend/src/utils/server-utils.ts
+++ b/frontend/src/utils/server-utils.ts
@@ -2,8 +2,8 @@ import moment from 'moment';
 import { get, merge, snakeCase, sortBy, sortedUniqBy } from 'lodash';
 import { fetchCoverageLayerDays, formatUrl, WFS, WMS } from 'prism-common';
 import { Dispatch } from 'redux';
-import { appConfig } from '../config';
-import { LayerDefinitions } from '../config/utils';
+import { appConfig } from 'config';
+import { LayerDefinitions } from 'config/utils';
 import type {
   AvailableDates,
   DateItem,
@@ -11,7 +11,7 @@ import type {
   RequestFeatureInfo,
   Validity,
   ValidityLayer,
-} from '../config/types';
+} from 'config/types';
 import {
   AdminLevelDataLayerProps,
   DataType,
@@ -21,13 +21,13 @@ import {
   PointDataLoader,
   StaticRasterLayerProps,
   WMSLayerProps,
-} from '../config/types';
+} from 'config/types';
+import { addNotification } from 'context/notificationStateSlice';
 import { queryParamsToString } from './url-utils';
 import { createEWSDatesArray } from './ews-utils';
 import { fetchACLEDDates } from './acled-utils';
 import { fetchWithTimeout } from './fetch-with-timeout';
 import { LocalError } from './error-utils';
-import { addNotification } from '../context/notificationStateSlice';
 import { datesAreEqualWithoutTime } from './date-utils';
 
 /**

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -1,4 +1,4 @@
-import { LayerKey } from '../config/types';
+import { LayerKey } from 'config/types';
 
 export type AnalysisParams = {
   analysisBaselineLayerId?: LayerKey;

--- a/frontend/src/utils/url-utils.ts
+++ b/frontend/src/utils/url-utils.ts
@@ -1,7 +1,7 @@
 import { camelCase } from 'lodash';
 import { useHistory } from 'react-router-dom';
+import { LayerType } from 'config/types';
 import { AnalysisParams } from './types';
-import { LayerType } from '../config/types';
 import { keepLayer } from './keep-layer-utils';
 
 /*

--- a/frontend/src/utils/useDefaultDate.ts
+++ b/frontend/src/utils/useDefaultDate.ts
@@ -1,12 +1,12 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
 import moment from 'moment';
-import { AvailableDates, isMainLayer, LayerKey } from '../config/types';
-import { availableDatesSelector } from '../context/serverStateSlice';
+import { AvailableDates, isMainLayer, LayerKey } from 'config/types';
+import { availableDatesSelector } from 'context/serverStateSlice';
 import {
   dateRangeSelector,
   layersSelector,
-} from '../context/mapStateSlice/selectors';
+} from 'context/mapStateSlice/selectors';
 
 import { useUrlHistory } from './url-utils';
 import { DEFAULT_DATE_FORMAT } from './name-utils';

--- a/frontend/src/utils/zonal-utils.ts
+++ b/frontend/src/utils/zonal-utils.ts
@@ -1,5 +1,5 @@
 import * as Comlink from 'comlink';
-import { ZonalOptions } from '../config/types';
+import { ZonalOptions } from 'config/types';
 
 // instantiate worker to handle zonal statistics requests
 const text = `

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
+    "baseUrl": "./src",
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This PR removes the relative paths from appplication's imports, throughout all the files.

Adds: 

```
"compilerOptions": {
    ...
    "baseUrl": "./src"
  }
```
to tsconfig.json to enable us to import directly from src instead of using relative paths
`(eg. '../../context/dataStateSlice'` => `'context/dataStateSlice')`