### PR TITLE
Fixed correct importing from app config for the hidePanel and alertFormIsActive properties

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx -c .eslintrc ./src ../common/src",
     "postinstall": "yarn run setup:maplibre",
     "precommit": "lint-staged",
-    "setup:common": "rimraf ./node_modules/prism-common && cd ../common && yarn install && yarn build && cd ../frontend && yarn install --check-files",
+    "setup:common": "rimraf ./node_modules/prism-common && cd ../common && yarn install --network-timeout 100000 && yarn build && cd ../frontend && yarn install --check-files",
     "setup:maplibre": "node -e \"const fs = require('fs'); fs.copyFileSync('./node_modules/mapbox-gl/dist/maplibre-gl.css', './node_modules/mapbox-gl/dist/mapbox-gl.css'); fs.copyFileSync('./node_modules/mapbox-gl/dist/maplibre-gl.js', './node_modules/mapbox-gl/dist/mapbox-gl.js');\""
   },
   "dependencies": {

--- a/frontend/src/components/AuthModal/index.tsx
+++ b/frontend/src/components/AuthModal/index.tsx
@@ -102,9 +102,16 @@ const AuthModal = ({ classes }: AuthModalProps) => {
   }, [dispatch, initialAuthState, layersWithAuthRequired, removeLayerFromUrl]);
 
   // function that handles the close modal
-  const closeModal = useCallback(() => {
-    setOpen(false);
-  }, []);
+  const closeModal = useCallback(
+    (event, reason) => {
+      if (reason === 'backdropClick') {
+        onCancelClick();
+        return;
+      }
+      setOpen(false);
+    },
+    [onCancelClick],
+  );
 
   // renders the Auth modal only if a user isn't already authenticated
   return useMemo(() => {
@@ -115,7 +122,6 @@ const AuthModal = ({ classes }: AuthModalProps) => {
       <Dialog
         maxWidth="xl"
         open={open}
-        onBackdropClick={onCancelClick}
         keepMounted
         onClose={closeModal}
         aria-labelledby="dialog-preview"

--- a/frontend/src/components/MapView/Map/index.tsx
+++ b/frontend/src/components/MapView/Map/index.tsx
@@ -35,6 +35,7 @@ interface MapComponentProps {
   setIsAlertFormOpen: Dispatch<SetStateAction<boolean>>;
   boundaryLayerId: string;
   selectedLayers: LayerType[];
+  panelHidden: boolean;
 }
 
 type LayerComponentsMap<U extends LayerType> = {
@@ -46,9 +47,10 @@ const MapComponent = memo(
     setIsAlertFormOpen,
     boundaryLayerId,
     selectedLayers,
+    panelHidden,
   }: MapComponentProps) => {
     const {
-      map: { boundingBox, hidePanel, minZoom, maxZoom, maxBounds },
+      map: { boundingBox, minZoom, maxZoom, maxBounds },
     } = appConfig;
 
     const dispatch = useDispatch();
@@ -79,12 +81,12 @@ const MapComponent = memo(
         duration: 0,
         padding: {
           bottom: 150, // room for dates.
-          left: hidePanel ? 30 : 500, // room for the left panel if active.
+          left: panelHidden ? 30 : 500, // room for the left panel if active.
           right: 60,
           top: 70,
         },
       };
-    }, [hidePanel]);
+    }, [panelHidden]);
 
     const MapboxMap = useMemo(() => {
       return ReactMapboxGl({

--- a/frontend/src/components/MapView/index.tsx
+++ b/frontend/src/components/MapView/index.tsx
@@ -75,9 +75,7 @@ const dateSupportLayerTypes: Array<LayerType['type']> = [
 
 const MapView = memo(({ classes }: MapViewProps) => {
   // App config attributes
-  const {
-    map: { hidePanel, alertFormActive },
-  } = appConfig;
+  const { alertFormActive, hidePanel } = appConfig;
 
   const boundaryLayer = useMemo(() => {
     return getBoundaryLayerSingleton();
@@ -623,6 +621,7 @@ const MapView = memo(({ classes }: MapViewProps) => {
       </Box>
       {renderedDatesLoader}
       <MapComponent
+        panelHidden={isPanelHidden}
         selectedLayers={selectedLayers}
         setIsAlertFormOpen={setIsAlertFormOpen}
         boundaryLayerId={boundaryLayerId}


### PR DESCRIPTION
This PR fixes a small mistake of falsly importing the `hidePanel` and `alertFormIsActive` from `map` property of `prism.json` file and not from the root which was initially their place.