### PR TITLE
Testing deployment script on new machine

### DIFF
--- a/alerting/docker-compose.yml
+++ b/alerting/docker-compose.yml
@@ -26,5 +26,5 @@ services:
       - POSTGRES_DB=postgres
       - POSTGRES_PASSWORD=!ChangeMe!
       - DATABASE_URL
-      - EMAIL_PASSWORD
-      - EMAIL_USER
+      - EMAIL_PASSWORD=${ALERTING_EMAIL_PASSWORD} # Set from secrets in api/set_envs.sh
+      - EMAIL_USER=${ALERTING_EMAIL_USER}

--- a/api/README.md
+++ b/api/README.md
@@ -106,13 +106,13 @@ Generate a geotiff for any wfp raster using the stac API and saves it in S3. It 
 To run the api locally, run:
 
 ```
-make api
+source set_envs.sh && make api
 ```
 
 To run flask api together with database within same network, run:
 
 ```
-docker-compose -f ./docker-compose.develop.yml -f ../alerting/docker-compose.yml up
+source set_envs.sh && docker-compose -f ./docker-compose.develop.yml -f ../alerting/docker-compose.yml up
 ```
 
 ### Tests
@@ -120,7 +120,7 @@ docker-compose -f ./docker-compose.develop.yml -f ../alerting/docker-compose.yml
 To run linting and tests, run:
 
 ```
-make test
+source set_envs.sh && make test
 ```
 
 ## Deployments
@@ -132,7 +132,7 @@ Specifically, update `info@ovio.org` with a domain admin email and `prism-api.ov
 To deploy, run:
 
 ```
-make deploy
+source set_envs.sh && make deploy
 ```
 
 There are a few known issues happening from time to time

--- a/api/docker-compose.deploy.yml
+++ b/api/docker-compose.deploy.yml
@@ -46,12 +46,12 @@ services:
     environment:
       - "RUN=uvicorn app.main:app --host 0.0.0.0 --port 80"
       # make sure that the alert password is properly set
-      - DATABASE_URL=${DATABASE_URL:?"Provide a URL for the alerts database."}
-      - KOBO_PW=${KOBO_PW:?"Add a password to access KOBO data."}
+      - DATABASE_URL=${PRISM_ALERTS_DATABASE_URL:?"Provide a URL for the alerts database."}
+      - KOBO_PW=${KOBO_PASSWORD:?"Add a password to access KOBO data."}
       - KOBO_USERNAME=${KOBO_USERNAME:-kobo_user}
       - HDC_TOKEN=${HDC_TOKEN:?"Provide a token to access HDC chart data."}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?"Provide the AWS access key for the stac api."}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?"Provide the AWS secret key for the stac api."}
+      - AWS_ACCESS_KEY_ID=${STAC_AWS_ACCESS_KEY_ID:?"Provide the AWS access key for the stac api."}
+      - AWS_SECRET_ACCESS_KEY=${STAC_AWS_SECRET_ACCESS_KEY:?"Provide the AWS secret key for the stac api."}
     command: uvicorn app.main:app --host 0.0.0.0 --port 80
     restart: always
     # adding a DNS to allow self lookup of the api

--- a/api/docker-compose.deploy.yml
+++ b/api/docker-compose.deploy.yml
@@ -40,7 +40,7 @@ services:
       - "80:80"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.whoami.rule=Host(`prism-api.ovio.org`)"
+      - "traefik.http.routers.whoami.rule=Host(${HOSTNAME:?'Must provide hostname'})"
       - "traefik.http.routers.whoami.entrypoints=websecure"
       - "traefik.http.routers.whoami.tls.certresolver=myresolver"
     environment:

--- a/api/docker-compose.develop.yml
+++ b/api/docker-compose.develop.yml
@@ -14,8 +14,8 @@ services:
       - POSTGRES_DB=postgres
       - POSTGRES_PORT=54321
       - POSTGRES_PASSWORD=!ChangeMe!
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_ACCESS_KEY_ID=${STAC_AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${STAC_AWS_SECRET_ACCESS_KEY}
     command: uvicorn app.main:app --host 0.0.0.0 --port 80 --reload
     network_mode: "host"
     # Infinite loop, to keep it alive, for debugging

--- a/api/set_envs.sh
+++ b/api/set_envs.sh
@@ -11,3 +11,11 @@ export PRISM_ALERTS_DATABASE_URL=$(aws secretsmanager get-secret-value     --sec
 
 # HDC Token
 export HDC_TOKEN=$(aws secretsmanager get-secret-value     --secret-id HDC_TOKEN | jq .SecretString | jq fromjson | jq .HDC_TOKEN)
+
+# Alerting Email
+export ALERTING_EMAIL_USER=$(aws secretsmanager get-secret-value     --secret-id ALERTING_EMAIL | jq .SecretString | jq fromjson | jq .ALERTING_EMAIL_USER)
+export ALERTING_EMAIL_PASSWORD=$(aws secretsmanager get-secret-value     --secret-id ALERTING_EMAIL | jq .SecretString | jq fromjson | jq .ALERTING_EMAIL_PASSWORD)
+
+# Commenting out for now while I get Eric's advice on deploying 
+# HOSTNAME_SUFFIX=${1:?"Must set deployment env as first arg"}
+# export HOSTNAME=prism-api${HOSTNAME_SUFFIX}.ovio.org

--- a/api/set_envs.sh
+++ b/api/set_envs.sh
@@ -1,0 +1,13 @@
+# STAC Credentials
+export STAC_AWS_ACCESS_KEY_ID=$(aws secretsmanager get-secret-value     --secret-id STAC_Credentials | jq .SecretString | jq fromjson | jq .AWS_ACCESS_KEY_ID)
+export STAC_AWS_SECRET_ACCESS_KEY=$(aws secretsmanager get-secret-value     --secret-id STAC_Credentials | jq .SecretString | jq fromjson | jq .AWS_SECRET_ACCESS_KEY)
+
+# Kobo Credentials
+export KOBO_USERNAME=$(aws secretsmanager get-secret-value     --secret-id KOBO_AUTHENTICATION | jq .SecretString | jq fromjson | jq .KOBO_USERNAME)
+export KOBO_PASSWORD=$(aws secretsmanager get-secret-value     --secret-id KOBO_AUTHENTICATION | jq .SecretString | jq fromjson | jq .KOBO_PASSWORD)
+
+# PRISM Alerts
+export PRISM_ALERTS_DATABASE_URL=$(aws secretsmanager get-secret-value     --secret-id PRISM_ALERTS_DATABASE_URL | jq .SecretString | jq fromjson | jq .PRISM_ALERTS_DATABASE_URL)
+
+# HDC Token
+export HDC_TOKEN=$(aws secretsmanager get-secret-value     --secret-id HDC_TOKEN | jq .SecretString | jq fromjson | jq .HDC_TOKEN)


### PR DESCRIPTION
This introduces a deployment script for working with secrets.  

Notes:
- Not sure about the process for deploying `alerts` at the moment, since it's not running on Docker on the existing machine I'm replicating.
- Also not sure about the process for deploying to a new hostname.  Didn't want to push that and accidentally replace the existing API, @ericboucher if you could advise.


