### PR TITLE
Remove tropical storm, set default layer to blended rainfall LKA

### DIFF
--- a/frontend/src/config/srilanka/prism.json
+++ b/frontend/src/config/srilanka/prism.json
@@ -2,7 +2,7 @@
   "country": "Sri Lanka",
   "countryAdmin0Id": 231,
   "alertFormActive": false,
-  "defaultLayer": "rainfall_dekad",
+  "defaultLayer": "precip_blended_dekad",
   "icons": {
     "rainfall": "icon_rain.png",
     "vegetation": "icon_veg.png",

--- a/frontend/src/config/srilanka/prism.json
+++ b/frontend/src/config/srilanka/prism.json
@@ -13,8 +13,7 @@
   },
   "serversUrls": {
     "wms": [
-      "https://api.earthobservation.vam.wfp.org/ows/wms",
-      "https://sparc.wfp.org/geoserver/prism/wms"
+      "https://api.earthobservation.vam.wfp.org/ows/wms"
     ]
   },
   "map": {
@@ -226,29 +225,6 @@
               "id": "streak_extreme_rain",
               "label": "Extreme (>95th percentile)",
               "main": true
-            }
-          ]
-        }
-      ]
-    },
-    "tropical_storms": {
-      "tropical_storms": [
-        {
-          "group_title": "Tropical Storms",
-          "activate_all": true,
-          "layers": [
-            {
-              "id": "adamts_buffers",
-              "label": "Wind buffers",
-              "main": true
-            },
-            {
-              "id": "adamts_nodes",
-              "label": "Nodes"
-            },
-            {
-              "id": "adamts_tracks",
-              "label": "Tracks"
             }
           ]
         }


### PR DESCRIPTION
This PR updates the Sri Lanka deployment to remove tropical storm layers and to make the default layer the blended precipitation layer from the Dept of Meteorology (DoM). We may activate the tropical storm layers again later but for now it's being removed to avoid any potential failures due to unavailability of the storm layers

<img width="1557" alt="Screenshot 2023-10-23 at 16 34 04" src="https://github.com/WFP-VAM/prism-app/assets/3343536/c8f580c0-8c08-4d81-95ea-fa49f7c4fdb6">
