### PR TITLE
Align charts to top when comparing

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -102,6 +102,7 @@ const useStyles = makeStyles(() =>
       color: 'black',
     },
     chartsPanelCharts: {
+      alignContent: 'start',
       overflowY: 'auto',
       overflowX: 'hidden',
       display: 'flex',
@@ -445,7 +446,7 @@ const ChartsPanel = memo(
         return (
           <Box
             style={{
-              maxHeight: '50vh',
+              height: '240px',
               width: '100%',
             }}
           >


### PR DESCRIPTION
This fixes issue #952.

How to test the feature:

- [ ] In the charts panel, activate comparison (location or period)
- [ ] Select a layer to chart
- [ ] Charts should now be top aligned

Screenshot/video of feature:
![image](https://github.com/WFP-VAM/prism-app/assets/1745184/fedc5966-b116-44ec-906b-df248a55bab6)
