### PR TITLE
Fix broken link in navbar

### DIFF
--- a/frontend/src/components/NavBar/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/NavBar/__snapshots__/index.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`renders as expected 1`] = `
             >
               <mock-typography
                 component="a"
-                href="https://github.com/oviohub/prism-app"
+                href="https://github.com/wfp-VAM/prism-app"
                 target="_blank"
                 variant="body2"
               >
@@ -175,7 +175,7 @@ exports[`renders as expected 1`] = `
                 >
                   <mock-typography
                     component="a"
-                    href="https://github.com/oviohub/prism-app"
+                    href="https://github.com/wfp-VAM/prism-app"
                     target="_blank"
                     variant="body2"
                   >

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -31,7 +31,7 @@ function NavBar({ classes }: NavBarProps) {
     {
       title: 'GitHub',
       icon: faGithub,
-      href: 'https://github.com/oviohub/prism-app',
+      href: 'https://github.com/wfp-VAM/prism-app',
     },
   ];
 


### PR DESCRIPTION
Tiny fix to correct the broken link to github in the navbar which was returning a 404.
