### PR TITLE
Add background color on tick marks in the timeline UI

### DIFF
--- a/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/index.tsx
@@ -35,7 +35,7 @@ const styles = () =>
 
     dayItem: {
       height: 10,
-      background: '#ededed',
+      borderLeft: '1px solid #ededed',
     },
   });
 

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineLabel/index.tsx
@@ -35,6 +35,7 @@ const styles = () =>
 
     dayItem: {
       height: 10,
+      background: '#ededed',
     },
   });
 

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
@@ -186,7 +186,6 @@ const styles = () =>
     },
     dateItem: {
       color: '#101010',
-      borderLeft: '1px solid white',
       position: 'relative',
       top: -5,
       cursor: 'pointer',


### PR DESCRIPTION
This fixes issue https://github.com/WFP-VAM/prism-app/issues/890.

How to test the feature:

- check timeline

Screenshot/video of feature:
let me know which of the following we would prefer:

![image](https://github.com/WFP-VAM/prism-app/assets/80451946/c6d220fe-da65-4bf9-a011-5ac6b1169653)

![image](https://github.com/WFP-VAM/prism-app/assets/80451946/a8ad4675-1775-4672-a0ba-909534e8c941)

