### PR TITLE
Add defaultLanguage configuration option

### DIFF
--- a/frontend/src/components/NavBar/LanguageSelector/index.tsx
+++ b/frontend/src/components/NavBar/LanguageSelector/index.tsx
@@ -9,6 +9,8 @@ import {
   WithStyles,
 } from '@material-ui/core';
 import { languages, useSafeTranslation } from 'i18n';
+import { appConfig } from 'config';
+import { get } from 'lodash';
 
 function LanguageSelector({ classes }: LanguageSelectorProps) {
   const { i18n } = useSafeTranslation();
@@ -16,6 +18,14 @@ function LanguageSelector({ classes }: LanguageSelectorProps) {
   const handleChangeLanguage = (lng: string): void => {
     i18n.changeLanguage(lng);
   };
+
+  React.useEffect(() => {
+    const locale = get(appConfig, 'defaultLanguage', 'en');
+    if (languages.includes(locale)) {
+      i18n.changeLanguage(locale);
+    }
+  }, [i18n]);
+
   // If there is only one language, hide the selector
   if (languages.length <= 1) {
     return null;

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -7,12 +7,7 @@ import colombia from './colombia';
 import cuba from './cuba';
 import ecuador from './ecuador';
 import global from './global';
-import {
-  indonesiaConfig,
-  indonesiaRawLayers,
-  indonesiaRawTables,
-  indonesiaRawReports,
-} from './indonesia';
+import indonesia from './indonesia';
 import jordan from './jordan';
 import kyrgyzstan from './kyrgyzstan';
 import mongolia from './mongolia';
@@ -41,13 +36,7 @@ const configMap = {
   cuba,
   ecuador,
   global,
-  indonesia: {
-    appConfig: indonesiaConfig,
-    rawLayers: indonesiaRawLayers,
-    rawTables: indonesiaRawTables,
-    rawReports: indonesiaRawReports,
-    defaultBoundariesFile: 'idn_admin_boundaries.json',
-  },
+  indonesia,
   jordan,
   kyrgyzstan,
   mongolia,

--- a/frontend/src/config/indonesia/index.ts
+++ b/frontend/src/config/indonesia/index.ts
@@ -1,12 +1,15 @@
-import indonesiaConfig from './prism.json';
+import appConfig from './prism.json';
 import indonesiaRawLayers from './layers.json';
 import indonesiaRawTables from './tables.json';
 
-const indonesiaRawReports = {};
+const rawReports = {};
+const translation = {};
 
-export {
-  indonesiaConfig,
-  indonesiaRawLayers,
-  indonesiaRawTables,
-  indonesiaRawReports,
+export default {
+  appConfig,
+  rawLayers: indonesiaRawLayers,
+  rawTables: indonesiaRawTables,
+  rawReports,
+  translation,
+  defaultBoundariesFile: 'idn_admin_boundaries.json',
 };

--- a/frontend/src/config/mozambique/prism.json
+++ b/frontend/src/config/mozambique/prism.json
@@ -1,5 +1,6 @@
 {
   "country": "Mozambique",
+  "defaultLanguage": "en",
   "countryAdmin0Id": 170,
   "alertFormActive": false,
   "hidePanel": false,


### PR DESCRIPTION
This fixes issue https://github.com/WFP-VAM/prism-app/issues/726.

How to test the feature:

- edit `prism.json`'s `defaultLanguage` field.
- start the app and check the default language selected
