### PR TITLE
Make Khmer default lang & update flood report legend; COUNTRY=cambodia

### DIFF
--- a/frontend/src/config/cambodia/layers.json
+++ b/frontend/src/config/cambodia/layers.json
@@ -1726,21 +1726,31 @@
       {
         "value": 0,
         "label": "0",
-        "color": "#909090"
+        "color": "#f2f0f7"
       },
       {
         "value": 1,
-        "label": "< 5",
+        "label": "< 50",
+        "color": "#dadaeb"
+      },
+      {
+        "value": 50,
+        "label": "50 - 100",
+        "color": "#bcbddc"
+      },
+      {
+        "value": 101,
+        "label": "100 - 200",
         "color": "#9e9ac8"
       },
       {
-        "value": 5,
-        "label": "5 - 10",
+        "value": 201,
+        "label": "200 - 300",
         "color": "#756bb1"
       },
       {
-        "value": 11,
-        "label": "> 10",
+        "value": 301,
+        "label": "> 300",
         "color": "#54278f"
       }
     ]

--- a/frontend/src/config/cambodia/prism.json
+++ b/frontend/src/config/cambodia/prism.json
@@ -1,5 +1,6 @@
 {
   "country": "Cambodia",
+  "defaultLanguage": "kh",
   "countryAdmin0Id": 44,
   "alertFormActive": false,
   "aboutPath": "data/cambodia/about.md",


### PR DESCRIPTION
Configuration updates for Cambodia based on input from WFP Cambodia office:

1. Make Khmer the default language
2. Extend the range of values for flood impact report symbology

Screenshot/video of feature:
<img width="1863" alt="Screenshot 2023-11-17 at 20 12 15" src="https://github.com/WFP-VAM/prism-app/assets/3343536/0785fbcb-15d9-47cb-9f70-31147c551c6c">
