### PR TITLE
Hotfix charts dropdown issue

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/LocationSelector/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/LocationSelector/index.tsx
@@ -96,25 +96,25 @@ const LocationSelector = memo(
         : [];
     };
 
+    const admin0BoundaryTree = admin0Key
+      ? adminBoundaryTree.children[admin0Key]?.children
+      : adminBoundaryTree.children;
+
     const orderedAdmin1areas: () => AdminBoundaryTree[] = () => {
-      if (data && admin0Key) {
-        return sortBy(
-          Object.values(adminBoundaryTree?.children[admin0Key]?.children),
-          'label',
-        );
+      if (!data) {
+        return [];
       }
-      if (data && !multiCountry) {
-        return sortBy(Object.values(adminBoundaryTree.children), 'label');
+      if (multiCountry && !admin0Key) {
+        return [];
       }
-      return [];
+      return sortBy(Object.values(admin0BoundaryTree), 'label');
     };
 
-    const selectedAdmin1Area = () =>
-      adminBoundaryTree.children[admin0Key]?.children[admin1Key];
+    const selectedAdmin1Area = () => admin0BoundaryTree[admin1Key];
 
     const orderedAdmin2areas: () => AdminBoundaryTree[] = () => {
-      return data && admin0Key && admin1Key
-        ? sortBy(Object.values(selectedAdmin1Area()?.children), 'label')
+      return data && admin1Key
+        ? sortBy(Object.values(selectedAdmin1Area().children), 'label')
         : [];
     };
 
@@ -128,11 +128,7 @@ const LocationSelector = memo(
     };
 
     const renderAdmin1Value = (admin1keyValue: any) => {
-      if (admin0Key === '') {
-        return '';
-      }
-      return adminBoundaryTree.children[admin0Key]?.children[admin1keyValue]
-        ?.label;
+      return admin0BoundaryTree[admin1keyValue]?.label;
     };
 
     const renderAdmin2Value = (admin2KeyValue: any) => {
@@ -166,10 +162,7 @@ const LocationSelector = memo(
       }
       setAdmin1Key(event.target.value);
       // update the parent component state
-      setSelectedAdmin1Area(
-        adminBoundaryTree.children[admin0Key].children[event.target.value]
-          .label,
-      );
+      setSelectedAdmin1Area(admin0BoundaryTree[event.target.value]?.label);
       setAdmin2Key('');
       setAdminLevel(1);
     };
@@ -238,6 +231,7 @@ const LocationSelector = memo(
             }}
             onChange={onChangeAdmin1Area}
             variant="outlined"
+            disabled={orderedAdmin1areas().length === 0}
           >
             <MenuItem divider>
               <Box className={styles.removeAdmin}> {t('Remove Admin 1')}</Box>

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/LocationSelector/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/LocationSelector/index.tsx
@@ -97,12 +97,16 @@ const LocationSelector = memo(
     };
 
     const orderedAdmin1areas: () => AdminBoundaryTree[] = () => {
-      return data && admin0Key
-        ? sortBy(
-            Object.values(adminBoundaryTree?.children[admin0Key]?.children),
-            'label',
-          )
-        : [];
+      if (data && admin0Key) {
+        return sortBy(
+          Object.values(adminBoundaryTree?.children[admin0Key]?.children),
+          'label',
+        );
+      }
+      if (data && !multiCountry) {
+        return sortBy(Object.values(adminBoundaryTree.children), 'label');
+      }
+      return [];
     };
 
     const selectedAdmin1Area = () =>

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/LocationSelector/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/LocationSelector/index.tsx
@@ -96,21 +96,18 @@ const LocationSelector = memo(
         : [];
     };
 
-    const admin0BoundaryTree = admin0Key
+    const admin0BoundaryTree = multiCountry
       ? adminBoundaryTree.children[admin0Key]?.children
       : adminBoundaryTree.children;
 
     const orderedAdmin1areas: () => AdminBoundaryTree[] = () => {
-      if (!data) {
-        return [];
-      }
-      if (multiCountry && !admin0Key) {
+      if (!data || !admin0BoundaryTree) {
         return [];
       }
       return sortBy(Object.values(admin0BoundaryTree), 'label');
     };
 
-    const selectedAdmin1Area = () => admin0BoundaryTree[admin1Key];
+    const selectedAdmin1Area = () => admin0BoundaryTree?.[admin1Key];
 
     const orderedAdmin2areas: () => AdminBoundaryTree[] = () => {
       return data && admin1Key

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -53,7 +53,8 @@ import { oneDayInMs, oneYearInMs } from '../utils';
 
 // Load boundary layer for Admin2
 // WARNING - Make sure the dataviz_ids are available in the boundary file for Admin2
-const MAX_ADMIN_LEVEL = appConfig.multiCountry ? 3 : 2;
+const { multiCountry } = appConfig;
+const MAX_ADMIN_LEVEL = multiCountry ? 3 : 2;
 const boundaryLayer = getBoundaryLayersByAdminLevel(MAX_ADMIN_LEVEL);
 
 const chartLayers = getWMSLayersWithChart();
@@ -72,10 +73,10 @@ function getProperties(
     // does not go anywhere anyway
     return layerData.features[0].properties;
   }
+  const indexLevel = multiCountry ? adminLevel : adminLevel - 1;
+  const adminCode = boundaryLayer.adminLevelCodes[indexLevel];
   const item = layerData.features.find(
-    elem =>
-      elem.properties &&
-      elem.properties[boundaryLayer.adminLevelCodes[adminLevel]] === id,
+    elem => elem.properties && elem.properties[adminCode] === id,
   );
   return item?.properties ?? {};
 }
@@ -184,7 +185,7 @@ const menuProps: Partial<MenuProps> = {
 
 const ChartsPanel = memo(
   ({ setPanelSize, setResultsPage }: ChartsPanelProps) => {
-    const { countryAdmin0Id, country, multiCountry } = appConfig;
+    const { countryAdmin0Id, country } = appConfig;
     const boundaryLayerData = useSelector(
       layerDataSelector(boundaryLayer.id),
     ) as LayerData<BoundaryLayerProps> | undefined;
@@ -522,7 +523,6 @@ const ChartsPanel = memo(
       country,
       endDate1,
       endDate2,
-      multiCountry,
       secondAdminProperties,
       secondAdminLevel,
       secondAdmin0Key,


### PR DESCRIPTION
The admin1 dropdown was not populating properly for admin 1 in single country deployments

<img width="397" alt="Screenshot 2023-11-24 at 2 54 15 PM" src="https://github.com/WFP-VAM/prism-app/assets/16843267/169b49fc-bce4-4110-aa8b-51eedf5cb9a0">
