### PR TITLE
add chart fields to admin 3 and update storm layers; COUNTRY=myanmar

### DIFF
--- a/frontend/src/config/myanmar/layers.json
+++ b/frontend/src/config/myanmar/layers.json
@@ -2399,7 +2399,7 @@
     "opacity": 0.7,
     "legend": [],
     "legend_text": "Tropical Storms - Nodes",
-    "base_url": "https://sparc.wfp.org/geoserver",
+    "base_url": "https://ogcserver.gis.wfp.org/geoserver",
     "feature_info_props": {
       "event_name": {
         "type": "text",
@@ -2424,7 +2424,7 @@
     "opacity": 0.7,
     "legend": [],
     "legend_text": "Wind buffers (radii) estimate potential wind speeds along the path of a storm with a buffer estimating the area exposed to each wind speed category. Source: GDACS",
-    "base_url": "https://sparc.wfp.org/geoserver",
+    "base_url": "https://ogcserver.gis.wfp.org/geoserver",
     "feature_info_props": {
       "event_name": {
         "type": "text",
@@ -2491,7 +2491,7 @@
     "opacity": 0.7,
     "legend": [],
     "legend_text": "Tracks visualize the projected path of a storm based on the forecasted position of it's center at various points in time. Source: GDACS",
-    "base_url": "https://sparc.wfp.org/geoserver",
+    "base_url": "https://ogcserver.gis.wfp.org/geoserver",
     "geometry": "linestring"
   },
   "flood_extent": {

--- a/frontend/src/config/myanmar/prism.json
+++ b/frontend/src/config/myanmar/prism.json
@@ -31,7 +31,7 @@
   "serversUrls": {
     "wms": [
       "https://api.earthobservation.vam.wfp.org/ows/wms",
-      "https://sparc.wfp.org/geoserver/prism/wms"
+      "https://ogcserver.gis.wfp.org/geoserver/prism/wms"
     ]
   },
   "categories": {


### PR DESCRIPTION
### Description

This fixes missing admin codes for charts in adm3 boundary file, and reconfigure ADAM layers

## How to test the feature:

Charts:
- load 10-day rainfall layer
- click on an admin area
- select a chart from the tooltip

ADAM layers:
- load a tropical storm layer
- run exposure analysis on the results

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:

