### PR TITLE
Add commit hash text, hidden on the bottom of the tabs

### DIFF
--- a/frontend/config-overrides.js
+++ b/frontend/config-overrides.js
@@ -1,3 +1,4 @@
+/* eslint-disable fp/no-mutation */
 const {
   override,
   disableChunk,
@@ -8,6 +9,11 @@ const path = require('path');
 const RemovePlugin = require('remove-files-webpack-plugin');
 
 const country = process.env.REACT_APP_COUNTRY;
+
+// In case GIT_HASH is not set we are in github actions environment
+process.env.REACT_APP_GIT_HASH = process.env.GITHUB_SHA
+  ? process.env.GITHUB_SHA
+  : process.env.GIT_HASH;
 
 module.exports = override(
   useEslintRc(path.resolve(__dirname, '.eslintrc')),

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,9 +16,9 @@
   },
   "scripts": {
     "clean": "rimraf ./node_modules && pushd ../common && rimraf ./node_modules && popd",
-    "start": "cross-env EXTEND_ESLINT=true react-scripts start",
+    "start": "export GIT_HASH=$(git rev-parse --short HEAD) && cross-env EXTEND_ESLINT=true react-app-rewired start",
     "analyze": "yarn build && npx source-map-explorer 'build/static/js/*.js'",
-    "build": "cross-env EXTEND_ESLINT=true react-app-rewired build",
+    "build": "export GIT_HASH=$(git rev-parse --short HEAD) && cross-env EXTEND_ESLINT=true react-app-rewired build",
     "test": "cross-env REACT_APP_TESTING=true && react-scripts test",
     "prettier:json-fix": "prettier --write */**.json",
     "prettier:json-check": "prettier --check */**.json",

--- a/frontend/src/components/Common/HashText/index.tsx
+++ b/frontend/src/components/Common/HashText/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const HashText = () => (
+  <p
+    style={{
+      position: 'absolute',
+      bottom: '0',
+      left: '1rem',
+    }}
+  >
+    web hash: {JSON.stringify(process.env.REACT_APP_GIT_HASH)}
+  </p>
+);
+
+export default HashText;

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
@@ -107,6 +107,7 @@ import {
   setTabValue,
 } from 'context/leftPanelStateSlice';
 import LoadingBlinkingDots from 'components/Common/LoadingBlinkingDots';
+import HashText from 'components/Common/HashText';
 import AnalysisTable from './AnalysisTable';
 import ExposureAnalysisTable from './AnalysisTable/ExposureAnalysisTable';
 import ExposureAnalysisActions from './ExposureAnalysisActions';
@@ -1036,6 +1037,7 @@ const AnalysisPanel = memo(
           </div>
           {renderedPolygonHazardType}
           {renderedRasterType}
+          <HashText />
         </div>
       );
     }, [

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -46,6 +46,7 @@ import { useSafeTranslation } from 'i18n';
 import DownloadCsvButton from 'components/MapView/DownloadCsvButton';
 import { buildCsvFileName } from 'components/MapView/utils';
 
+import HashText from 'components/Common/HashText';
 import ChartSection from './ChartSection';
 import LocationSelector from './LocationSelector';
 import TimePeriodSelector from './TimePeriodSelector';
@@ -100,6 +101,7 @@ const useStyles = makeStyles(() =>
       alignItems: 'center',
       width: PanelSize.medium,
       flexShrink: 0,
+      height: 'calc(100% - 30px)',
     },
     layerFormControl: {
       marginTop: 30,
@@ -826,6 +828,7 @@ const ChartsPanel = memo(
         >
           <Typography variant="body2">{t('Clear All')}</Typography>
         </Button>
+        <HashText />
       </Box>
     );
   },

--- a/frontend/src/components/MapView/LeftPanel/TablesPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/TablesPanel/index.tsx
@@ -30,6 +30,7 @@ import {
   loadTable,
 } from 'context/tableStateSlice';
 import { leftPanelTabValueSelector } from 'context/leftPanelStateSlice';
+import HashText from 'components/Common/HashText';
 import TablesActions from './TablesActions';
 import DataTable from './DataTable';
 
@@ -212,6 +213,7 @@ const TablesPanel = memo(
           >
             {renderedTextFieldBody}
           </TextField>
+          <HashText />
         </div>
         {renderedTablesActions}
       </div>

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/index.tsx
@@ -10,6 +10,7 @@ import {
   analysisResultSortOrderSelector,
 } from 'context/analysisResultStateSlice';
 import { useSafeTranslation } from 'i18n';
+import HashText from 'components/Common/HashText';
 import AnalysisLayerMenuItem from './AnalysisLayerMenuItem';
 import MenuItem from './MenuItem';
 
@@ -59,6 +60,7 @@ const LayersPanel = memo(({ extent, layersMenuItems }: LayersPanelProps) => {
     <Box>
       {renderedRootAccordionItems}
       {renderedRootAnalysisAccordionItems}
+      <HashText />
     </Box>
   );
 });

--- a/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
@@ -3477,6 +3477,11 @@ exports[`renders as expected 1`] = `
                   </div>
                 </div>
               </div>
+              <p
+                style="position: absolute; bottom: 0px; left: 1rem;"
+              >
+                web hash: 
+              </p>
             </div>
           </div>
           <div


### PR DESCRIPTION
### Description

This fixes #984 

Adds hidden text at the bottom of the tabs, showing the commit hash of the code deployed.

## How to test the feature:

- navigate to the bottom eg. layers tab
- highlight the hidden text to see the commit hash. 
- confirm it is the same as the hash of the code of this deployment

## Checklist - did you ...

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
![Screenshot from 2023-11-30 15-36-59](https://github.com/WFP-VAM/prism-app/assets/80451946/8e1bd916-06da-401f-a670-4d55b49a8c63)
