### PR TITLE
change geoserver config for tropical storms; COUNTRY=mozambique

### DIFF
--- a/frontend/src/config/mozambique/layers.json
+++ b/frontend/src/config/mozambique/layers.json
@@ -1949,7 +1949,7 @@
     "opacity": 0.9,
     "legend": [],
     "legend_text": "Wind buffers (radii) estimate potential wind speeds along the path of a storm with a buffer estimating the area exposed to each wind speed category. Source: GDACS",
-    "base_url": "https://sparc.wfp.org/geoserver",
+    "base_url": "https://ogcserver.gis.wfp.org/geoserver",
     "feature_info_props": {
       "event_name": {
         "type": "text",
@@ -1988,7 +1988,7 @@
     "opacity": 0.9,
     "legend": [],
     "legend_text": "Nodes visualize estimated maximum wind speed along a storm's path at various points in time. Source: GDACS",
-    "base_url": "https://sparc.wfp.org/geoserver",
+    "base_url": "https://ogcserver.gis.wfp.org/geoserver",
     "geometry": "point"
   },
   "adamts_tracks": {
@@ -1998,7 +1998,7 @@
     "opacity": 0.9,
     "legend": [],
     "legend_text": "Tracks visualize the projected path of a storm based on the forecasted position of it's center at various points in time. Source: GDACS",
-    "base_url": "https://sparc.wfp.org/geoserver",
+    "base_url": "https://ogcserver.gis.wfp.org/geoserver",
     "geometry": "linestring"
   },
   "ipc_pop_ph3_current": {

--- a/frontend/src/config/mozambique/prism.json
+++ b/frontend/src/config/mozambique/prism.json
@@ -18,7 +18,7 @@
   "serversUrls": {
     "wms": [
       "https://api.earthobservation.vam.wfp.org/ows/wms",
-      "https://sparc.wfp.org/geoserver/prism/wms"
+      "https://ogcserver.gis.wfp.org/geoserver/prism/wms"
     ]
   },
   "map": {


### PR DESCRIPTION
### Description

This updates configuration of tropical storm layers using a new WFP GeoServer instance

## How to test the feature:

- Activate tropical storm layer
- Run exposure analysis

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
<img width="1512" alt="Screenshot 2023-11-30 at 09 28 32" src="https://github.com/WFP-VAM/prism-app/assets/3343536/bf2307ff-0b29-4e43-b0fa-e1eb1acbba04">

