### PR TITLE
Point to active layer for geotiff downloads in group layers

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -47,7 +47,8 @@ function LayerDownloadOptions({
   const { t } = useSafeTranslation();
   const dispatch = useDispatch();
   const layer = useMemo(() => {
-    return LayerDefinitions[layerId];
+    // default to first layer if layerId is not found
+    return LayerDefinitions[layerId] || Object.values(LayerDefinitions)[0];
   }, [layerId]);
 
   const [

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -6,14 +6,14 @@ import {
   MenuItem,
   Tooltip,
 } from '@material-ui/core';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import moment from 'moment';
 import { mapValues } from 'lodash';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import {
   AdminLevelDataLayerProps,
-  LayerType,
+  LayerKey,
   WMSLayerProps,
 } from 'config/types';
 import {
@@ -35,16 +35,22 @@ import { useSafeTranslation } from 'i18n';
 import { isExposureAnalysisLoadingSelector } from 'context/analysisResultStateSlice';
 import { availableDatesSelector } from 'context/serverStateSlice';
 import { getRequestDate } from 'utils/server-utils';
+import { LayerDefinitions } from 'config/utils';
 
 // TODO - return early when the layer is not selected.
 function LayerDownloadOptions({
-  layer,
+  layerId,
   extent,
   selected,
   size,
 }: LayerDownloadOptionsProps) {
   const { t } = useSafeTranslation();
   const dispatch = useDispatch();
+  const layer = useMemo(() => {
+    return LayerDefinitions[layerId];
+  }, [layerId]);
+
+  console.log({ layer });
 
   const [
     downloadMenuAnchorEl,
@@ -186,7 +192,7 @@ function LayerDownloadOptions({
 }
 
 interface LayerDownloadOptionsProps {
-  layer: LayerType;
+  layerId: LayerKey;
   extent: Extent | undefined;
   selected: boolean;
   size?: 'small' | undefined;

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -50,8 +50,6 @@ function LayerDownloadOptions({
     return LayerDefinitions[layerId];
   }, [layerId]);
 
-  console.log({ layer });
-
   const [
     downloadMenuAnchorEl,
     setDownloadMenuAnchorEl,

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -6,7 +6,7 @@ import {
   MenuItem,
   Tooltip,
 } from '@material-ui/core';
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import moment from 'moment';
 import { mapValues } from 'lodash';
@@ -46,10 +46,7 @@ function LayerDownloadOptions({
 }: LayerDownloadOptionsProps) {
   const { t } = useSafeTranslation();
   const dispatch = useDispatch();
-  const layer = useMemo(() => {
-    // default to first layer if layerId is not found
-    return LayerDefinitions[layerId] || Object.values(LayerDefinitions)[0];
-  }, [layerId]);
+  const layer = LayerDefinitions[layerId] || Object.values(LayerDefinitions)[0];
 
   const [
     downloadMenuAnchorEl,

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/index.tsx
@@ -84,19 +84,19 @@ const SwitchItem = memo(({ classes, layer, extent }: SwitchItemProps) => {
       : [];
   }, [group, selected, selectedLayers]);
 
-  const initialActiveLayer = useMemo(() => {
+  const initialActiveLayerId = useMemo(() => {
     return selectedActiveLayer.length > 0 ? selectedActiveLayer[0].id : null;
   }, [selectedActiveLayer]);
 
-  const [activeLayer, setActiveLayer] = useState(
-    initialActiveLayer || (group?.layers?.find(l => l.main)?.id as string),
+  const [activeLayerId, setActiveLayerId] = useState(
+    initialActiveLayerId || (group?.layers?.find(l => l.main)?.id as string),
   );
 
   useEffect(() => {
-    setActiveLayer(
-      initialActiveLayer || (group?.layers?.find(l => l.main)?.id as string),
+    setActiveLayerId(
+      initialActiveLayerId || (group?.layers?.find(l => l.main)?.id as string),
     );
-  }, [group, initialActiveLayer]);
+  }, [group, initialActiveLayerId]);
 
   const exposure = useMemo(() => {
     return (layer.type === 'wms' && layer.exposure) || undefined;
@@ -174,7 +174,7 @@ const SwitchItem = memo(({ classes, layer, extent }: SwitchItemProps) => {
   const handleSelect = useCallback(
     (event: React.ChangeEvent<{ value: string | unknown }>) => {
       const selectedId = event.target.value;
-      setActiveLayer(selectedId as string);
+      setActiveLayerId(selectedId as string);
       toggleLayerValue(selectedId as string, true);
     },
     [toggleLayerValue],
@@ -200,14 +200,14 @@ const SwitchItem = memo(({ classes, layer, extent }: SwitchItemProps) => {
         classes={{
           root: selected ? classes.selectItem : classes.selectItemUnchecked,
         }}
-        value={activeLayer}
+        value={activeLayerId}
         onChange={e => handleSelect(e)}
       >
         {renderedGroupLayersMenuItems}
       </Select>
     );
   }, [
-    activeLayer,
+    activeLayerId,
     classes.select,
     classes.selectItem,
     classes.selectItemUnchecked,
@@ -270,12 +270,12 @@ const SwitchItem = memo(({ classes, layer, extent }: SwitchItemProps) => {
         event,
         newValue as number,
         map,
-        activeLayer || layerId,
+        activeLayerId || layerId,
         layerType,
         val => setOpacityValue(val),
       );
     },
-    [activeLayer, layerId, layerType, map],
+    [activeLayerId, layerId, layerType, map],
   );
 
   const renderedOpacitySlider = useMemo(() => {
@@ -317,9 +317,9 @@ const SwitchItem = memo(({ classes, layer, extent }: SwitchItemProps) => {
 
   const handleOnChangeSwitch = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      toggleLayerValue(activeLayer, event.target.checked);
+      toggleLayerValue(activeLayerId, event.target.checked);
     },
-    [activeLayer, toggleLayerValue],
+    [activeLayerId, toggleLayerValue],
   );
 
   return (
@@ -356,7 +356,7 @@ const SwitchItem = memo(({ classes, layer, extent }: SwitchItemProps) => {
         </Tooltip>
         {renderedExposureAnalysisOption}
         <LayerDownloadOptions
-          layer={layer}
+          layerId={activeLayerId || layerId}
           extent={extent}
           selected={selected}
         />

--- a/frontend/src/components/MapView/Legends/LegendItem/index.tsx
+++ b/frontend/src/components/MapView/Legends/LegendItem/index.tsx
@@ -131,7 +131,7 @@ const LegendItem = memo(
     const layerDownloadOptions = useMemo(() => {
       return layer ? (
         <LayerDownloadOptions
-          layer={layer}
+          layerId={layer.id}
           extent={extent}
           selected
           size="small"

--- a/frontend/src/components/MapView/Legends/layerContentPreview.tsx
+++ b/frontend/src/components/MapView/Legends/layerContentPreview.tsx
@@ -19,9 +19,7 @@ const LayerContentPreview = memo(({ layerId, classes }: PreviewProps) => {
 
   const dispatch = useDispatch();
 
-  const layer = useMemo(() => {
-    return LayerDefinitions[layerId || 'admin_boundaries'];
-  }, [layerId]);
+  const layer = LayerDefinitions[layerId || 'admin_boundaries'];
 
   const handleIconButtonClick = useCallback(async () => {
     if (!layer.contentPath) {


### PR DESCRIPTION
### Description

This fixes #1003 by pointing to active layer in group layers.

## How to test the feature:

- [ ] change a group wms layer (eg. rainfall agg products and download from the menu
- [ ] download from the legend buttong
- [ ] check that the two resulting files are the same and have the same name
- [ ] check that geotiff downloads of a non-group layer still work as expected

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=zimbabwe yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
