### PR TITLE
Optionally pass band info for STAC download; COUNTRY=zimbabwe

### DIFF
--- a/api/app/geotiff_from_stac_api.py
+++ b/api/app/geotiff_from_stac_api.py
@@ -43,7 +43,9 @@ def generate_geotiff_from_stac_api(
     if not items:
         raise HTTPException(status_code=500, detail="Collection not found in stac API")
 
-    print(items[0].assets)
+    # TODO - confirm that input band exists
+    available_bands = items[0].assets.keys()
+    print(available_bands)
 
     bands = [band] if band else None
     try:

--- a/api/app/geotiff_from_stac_api.py
+++ b/api/app/geotiff_from_stac_api.py
@@ -40,10 +40,10 @@ def generate_geotiff_from_stac_api(
     query_answer = catalog.search(bbox=bbox, collections=[collection], datetime=[date])
     items = list(query_answer.items())
 
-    print(items)
-
     if not items:
         raise HTTPException(status_code=500, detail="Collection not found in stac API")
+    
+    print(items[0].assets)
 
     bands = [band] if band else None
     try:

--- a/api/app/geotiff_from_stac_api.py
+++ b/api/app/geotiff_from_stac_api.py
@@ -74,10 +74,7 @@ def upload_to_s3(file_path: str) -> str:
     s3_client = boto3.client("s3")
     s3_filename = os.path.basename(file_path)
 
-    try:
-        s3_client.upload_file(file_path, GEOTIFF_BUCKET_NAME, s3_filename)
-    except:
-        pass
+    s3_client.upload_file(file_path, GEOTIFF_BUCKET_NAME, s3_filename)
     return s3_filename
 
 

--- a/api/app/geotiff_from_stac_api.py
+++ b/api/app/geotiff_from_stac_api.py
@@ -42,7 +42,7 @@ def generate_geotiff_from_stac_api(
 
     if not items:
         raise HTTPException(status_code=500, detail="Collection not found in stac API")
-    
+
     print(items[0].assets)
 
     bands = [band] if band else None
@@ -66,7 +66,7 @@ def upload_to_s3(file_path: str) -> str:
     """Upload to s3"""
     s3_client = boto3.client("s3")
     s3_filename = os.path.basename(file_path)
-    
+
     print(s3_filename)
 
     try:
@@ -91,7 +91,9 @@ def generate_geotiff_and_upload_to_s3(
     return s3_filename
 
 
-def get_geotiff(collection: str, bbox: [float, float, float, float], date: str, band: str):
+def get_geotiff(
+    collection: str, bbox: [float, float, float, float], date: str, band: str
+):
     """Generate a geotiff and return presigned download url"""
     s3_filename = generate_geotiff_and_upload_to_s3(collection, bbox, date, band)
 

--- a/api/app/geotiff_from_stac_api.py
+++ b/api/app/geotiff_from_stac_api.py
@@ -42,6 +42,10 @@ def generate_geotiff_from_stac_api(
     if not items:
         raise HTTPException(status_code=500, detail="Collection not found in stac API")
 
+    # TODO - what should happen if the STAC API returns multiple dataset
+    # or if the selected band is not available?
+
+    # Filter data to the correct band if it is set.
     available_bands = items[0].assets.keys()
     logger.debug("available bands: %s", available_bands)
     bands = [band] if band and band in available_bands else None
@@ -69,8 +73,6 @@ def upload_to_s3(file_path: str) -> str:
     """Upload to s3"""
     s3_client = boto3.client("s3")
     s3_filename = os.path.basename(file_path)
-
-    print(s3_filename)
 
     try:
         s3_client.upload_file(file_path, GEOTIFF_BUCKET_NAME, s3_filename)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -397,7 +397,8 @@ def post_raster_geotiff(raster_geotiff: RasterGeotiffModel):
         raster_geotiff.lat_max,
     )
     date = raster_geotiff.date
-    presigned_download_url = get_geotiff(collection, bbox, date)
+    band = raster_geotiff.band
+    presigned_download_url = get_geotiff(collection, bbox, date, band)
 
     return JSONResponse(
         content={"download_url": presigned_download_url}, status_code=200

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -71,6 +71,7 @@ class RasterGeotiffModel(BaseModel):
 
     collection: str
     date: str
+    band: Optional[str] = None
     lat_min: float
     long_min: float
     lat_max: float

--- a/frontend/src/components/MapView/Layers/raster-utils.ts
+++ b/frontend/src/components/MapView/Layers/raster-utils.ts
@@ -199,6 +199,7 @@ export function getExtent(map?: MapBoxMap): Extent {
 
 export async function downloadGeotiff(
   collection: string,
+  band: string | undefined,
   boundingBox: Extent | undefined,
   date: string,
   dispatch: Dispatch,
@@ -217,6 +218,7 @@ export async function downloadGeotiff(
       long_max: boundingBox[2],
       lat_max: boundingBox[3],
       date,
+      band,
     };
     const response = await fetchWithTimeout(
       RASTER_API_URL,

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -126,10 +126,16 @@ function LayerDownloadOptions({
   };
 
   const handleDownloadGeoTiff = (): void => {
-    const band = (layer as WMSLayerProps).additionalQueryParams?.band;
+    const { serverLayerName, additionalQueryParams } = layer as WMSLayerProps;
+    // TODO - figure out a way to leverage style to guess band?
+    const { band } = additionalQueryParams as {
+      styles?: string;
+      band?: string;
+    };
+
     setIsGeotiffLoading(true);
     downloadGeotiff(
-      (layer as WMSLayerProps).serverLayerName,
+      serverLayerName,
       band,
       extent,
       moment(selectedDate).format(DEFAULT_DATE_FORMAT),

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -126,9 +126,11 @@ function LayerDownloadOptions({
   };
 
   const handleDownloadGeoTiff = (): void => {
+    const band = (layer as WMSLayerProps).additionalQueryParams?.band;
     setIsGeotiffLoading(true);
     downloadGeotiff(
       (layer as WMSLayerProps).serverLayerName,
+      band,
       extent,
       moment(selectedDate).format(DEFAULT_DATE_FORMAT),
       dispatch,

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -128,10 +128,11 @@ function LayerDownloadOptions({
   const handleDownloadGeoTiff = (): void => {
     const { serverLayerName, additionalQueryParams } = layer as WMSLayerProps;
     // TODO - figure out a way to leverage style to guess band?
-    const { band } = additionalQueryParams as {
-      styles?: string;
-      band?: string;
-    };
+    const { band } =
+      (additionalQueryParams as {
+        styles?: string;
+        band?: string;
+      }) || {};
 
     setIsGeotiffLoading(true);
     downloadGeotiff(

--- a/frontend/src/config/zimbabwe/layers.json
+++ b/frontend/src/config/zimbabwe/layers.json
@@ -505,7 +505,8 @@
     "type": "wms",
     "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "rfb_blended"
+      "styles": "rfb_blended",
+      "band": "rfb"
     },
     "chart_data": {
       "url": "https://api.earthobservation.vam.wfp.org/stats/admin/fetch",
@@ -559,7 +560,8 @@
     "type": "wms",
     "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "rfq_blended"
+      "styles": "rfq_blended",
+      "band": "rfq"
     },
     "chart_data": {
       "url": "https://api.earthobservation.vam.wfp.org/stats/admin/fetch",
@@ -668,8 +670,7 @@
     "type": "wms",
     "server_layer_name": "r1q_dekad",
     "additional_query_params": {
-      "styles": "rfq_14_20_400",
-      "band": "r1q"
+      "styles": "rfq_14_20_400"
     },
     "chart_data": {
       "fields": [
@@ -1317,7 +1318,8 @@
     "type": "wms",
     "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r1b_blended"
+      "styles": "r1b_blended",
+      "band": "r1b"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1348,7 +1350,8 @@
     "type": "wms",
     "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r2b_blended"
+      "styles": "r2b_blended",
+      "band": "r2b"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1379,7 +1382,8 @@
     "type": "wms",
     "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r3b_blended"
+      "styles": "r3b_blended",
+      "band": "r3b"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1410,7 +1414,8 @@
     "type": "wms",
     "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r4b_blended"
+      "styles": "r4b_blended",
+      "band": "r4b"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1441,7 +1446,8 @@
     "type": "wms",
     "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r5b_blended"
+      "styles": "r5b_blended",
+      "band": "r5b"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1472,7 +1478,8 @@
     "type": "wms",
     "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r6b_blended"
+      "styles": "r6b_blended",
+      "band": "r6b"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1503,7 +1510,8 @@
     "type": "wms",
     "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r9b_blended"
+      "styles": "r9b_blended",
+      "band": "r9b"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1534,7 +1542,8 @@
     "type": "wms",
     "server_layer_name": "rfb_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "ryb_blended"
+      "styles": "ryb_blended",
+      "band": "ryb"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1595,7 +1604,9 @@
     "type": "wms",
     "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r2q_blended"
+      "styles": "r2q_blended",
+      "band": "r2q"
+
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1624,7 +1635,8 @@
     "type": "wms",
     "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r3q_blended"
+      "styles": "r3q_blended",
+      "band": "r3q"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1653,7 +1665,8 @@
     "type": "wms",
     "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r4q_blended"
+      "styles": "r4q_blended",
+      "band": "r4q"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1682,7 +1695,8 @@
     "type": "wms",
     "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r5q_blended"
+      "styles": "r5q_blended",
+      "band": "r5q"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1711,7 +1725,8 @@
     "type": "wms",
     "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r6q_blended"
+      "styles": "r6q_blended",
+      "band": "r6q"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1740,7 +1755,8 @@
     "type": "wms",
     "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r9q_blended"
+      "styles": "r9q_blended",
+      "band": "r9q"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
@@ -1769,7 +1785,8 @@
     "type": "wms",
     "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "ryq_blended"
+      "styles": "ryq_blended",
+      "band": "ryq"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",

--- a/frontend/src/config/zimbabwe/layers.json
+++ b/frontend/src/config/zimbabwe/layers.json
@@ -668,7 +668,8 @@
     "type": "wms",
     "server_layer_name": "r1q_dekad",
     "additional_query_params": {
-      "styles": "rfq_14_20_400"
+      "styles": "rfq_14_20_400",
+      "band": "r1q"
     },
     "chart_data": {
       "fields": [
@@ -1564,7 +1565,8 @@
     "type": "wms",
     "server_layer_name": "rfq_blended_zwe_dekad",
     "additional_query_params": {
-      "styles": "r1q_blended"
+      "styles": "r1q_blended",
+      "band": "r1q"
     },
     "disableAnalysis": true,
     "base_url": "https://api.earthobservation.vam.wfp.org/ows/",


### PR DESCRIPTION
### Description

This tentatively fixes #1005. By adding a "band" additional_query_parameter.

Unfortunately it doesn't seem super easy to infer the band name from the style name so I added an additional parameter for now. This won't work as is since it's not deployed to the API but you can give it a try locally.

The band info is now added to the filename if it is not simply "band".

<!-- what this does -->

## How to test the feature:

- [ ] check that you can download a geotiff for this layer using a band - https://prism-1006.surge.sh/?hazardLayerIds=precip_blended_3m&date=2023-11-11
- [ ] check that you can download a geotiff for this layer that does not use a band - https://prism-1006.surge.sh/?hazardLayerIds=rain_anomaly_2month&date=2023-11-11

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
