### PR TITLE
999 remove hidePopup dispatch

### DIFF
--- a/frontend/src/components/Common/Loader/index.tsx
+++ b/frontend/src/components/Common/Loader/index.tsx
@@ -1,0 +1,14 @@
+import { LinearProgress } from '@material-ui/core';
+import React from 'react';
+
+interface LoaderProps {
+  showLoader: boolean;
+}
+const Loader = ({ showLoader }: LoaderProps) => {
+  if (!showLoader) {
+    return null;
+  }
+  return <LinearProgress />;
+};
+
+export default Loader;

--- a/frontend/src/components/MapView/Layers/BoundaryLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/BoundaryLayer/index.tsx
@@ -4,7 +4,7 @@ import { GeoJSONLayer } from 'react-mapbox-gl';
 import { useDispatch, useSelector } from 'react-redux';
 import { BoundaryLayerProps } from 'config/types';
 import { LayerData } from 'context/layers/layer-data';
-import { hidePopup, showPopup } from 'context/tooltipStateSlice';
+import { showPopup } from 'context/tooltipStateSlice';
 
 import { setBoundaryRelationData } from 'context/mapStateSlice';
 import {
@@ -64,7 +64,6 @@ function BoundaryLayer({ layer, before }: ComponentProps) {
   }
 
   const onClickShowPopup = (evt: any) => {
-    dispatch(hidePopup());
     const coordinates = evt.lngLat;
     const locationName = getFullLocationName(
       layer.adminLevelNames,

--- a/frontend/src/components/MapView/Map/index.tsx
+++ b/frontend/src/components/MapView/Map/index.tsx
@@ -239,21 +239,23 @@ const MapComponent = memo(
         center={mapTempCenter}
         maxBounds={maxBounds}
       >
-        {/* We cannot memoize the above behavior because tooltip becomes sluggish and does not render at all, when we enable a layer */}
-        {selectedLayers.map((layer, index) => {
-          const component: ComponentType<{
-            layer: any;
-            before?: string;
-          }> = componentTypes[layer.type];
-          return createElement(component, {
-            key: layer.id,
-            layer,
-            before: getBeforeId(layer, index),
-          });
-        })}
-        {/* These are custom layers which provide functionality and are not really controllable via JSON */}
-        <AnalysisLayer before={firstBoundaryId} />
-        <SelectionLayer before={firstSymbolId} />
+        <>
+          {/* We cannot memoize the above behavior because tooltip becomes sluggish and does not render at all, when we enable a layer */}
+          {selectedLayers.map((layer, index) => {
+            const component: ComponentType<{
+              layer: any;
+              before?: string;
+            }> = componentTypes[layer.type];
+            return createElement(component, {
+              key: layer.id,
+              layer,
+              before: getBeforeId(layer, index),
+            });
+          })}
+          {/* These are custom layers which provide functionality and are not really controllable via JSON */}
+          <AnalysisLayer before={firstBoundaryId} />
+          <SelectionLayer before={firstSymbolId} />
+        </>
         <MapTooltip />
       </MapboxMap>
     );

--- a/frontend/src/components/MapView/MapTooltip/index.tsx
+++ b/frontend/src/components/MapView/MapTooltip/index.tsx
@@ -5,13 +5,13 @@ import {
   createStyles,
   withStyles,
   WithStyles,
-  LinearProgress,
   Typography,
 } from '@material-ui/core';
 import { tooltipSelector } from 'context/tooltipStateSlice';
 import { isEnglishLanguageSelected, useSafeTranslation } from 'i18n';
 import { AdminLevelType } from 'config/types';
 import { appConfig } from 'config';
+import Loader from 'components/Common/Loader';
 import PopupCharts from './PopupCharts';
 import RedirectToDMP from './RedirectToDMP';
 import PopupContent from './PopupContent';
@@ -79,13 +79,6 @@ const MapTooltip = ({ classes }: TooltipProps) => {
     return popup.locationLocalName;
   }, [i18n, popup.locationLocalName, popup.locationName]);
 
-  const renderedPopupLoader = useMemo(() => {
-    if (!popup.wmsGetFeatureInfoLoading) {
-      return null;
-    }
-    return <LinearProgress />;
-  }, [popup.wmsGetFeatureInfoLoading]);
-
   const popupData = popup.data;
 
   // TODO - simplify logic once we revamp admin levels ojbect
@@ -145,7 +138,7 @@ const MapTooltip = ({ classes }: TooltipProps) => {
         adminLevelsNames={adminLevelsNames}
         availableAdminLevels={availableAdminLevels}
       />
-      {renderedPopupLoader}
+      <Loader showLoader={popup.wmsGetFeatureInfoLoading} />
     </Popup>
   );
 };


### PR DESCRIPTION
### Description

This fixes #999 .

It fixes this issue :
[Capture vidéo du 24-11-2023 10:49:50.webm](https://github.com/WFP-VAM/prism-app/assets/100352902/b27835bd-98c2-4bec-8750-85c4f4cff1a0)
In the video we see that when flood report is selected Tooltip contents several information.
When we add rainfall layer, Tooltip loss flood report content. We want to keep flood report content (and any selected layer data) as long as the layer is selected.

## How to test 
[Capture vidéo du 05-12-2023 16:22:52.webm](https://github.com/WFP-VAM/prism-app/assets/100352902/9d46fc5e-72e1-4d96-b68c-8b27c6a247f4)

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
