### PR TITLE
Frontend bug fixes - hash position and layer opacity; COUNTRY=zimbabwe

### DIFF
--- a/frontend/src/components/Common/HashText/index.tsx
+++ b/frontend/src/components/Common/HashText/index.tsx
@@ -3,12 +3,16 @@ import React from 'react';
 
 const HashText = () => {
   const hash = process.env.REACT_APP_GIT_HASH;
+  if (hash) {
+    // eslint-disable-next-line no-console
+    console.info(`The application is running version #${hash}`);
+    // eslint-disable-next-line no-console
+    console.info(`https://github.com/WFP-VAM/prism-app/tree/${hash}`);
+  }
   return (
     <a
       style={{
         color: '#f5f7f8',
-        position: 'absolute',
-        bottom: '1rem',
         fontSize: '0.7rem',
         left: '1rem',
       }}

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/index.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@material-ui/core';
 import React, { memo } from 'react';
+import HashText from 'components/Common/HashText';
 import { Extent } from 'components/MapView/Layers/raster-utils';
 import RootAccordionItems from './RootAccordionItems';
 import RootAnalysisAccordionItems from './RootAnalysisAccordionItems';
@@ -9,9 +10,11 @@ interface LayersPanelProps {
 }
 
 const LayersPanel = ({ extent }: LayersPanelProps) => (
-  <Box>
+  <Box display="flex" flexDirection="column" height="100%">
     <RootAccordionItems extent={extent} />
     <RootAnalysisAccordionItems />
+    <Box flexGrow={1} />
+    <HashText />
   </Box>
 );
 

--- a/frontend/src/components/MapView/Map/index.tsx
+++ b/frontend/src/components/MapView/Map/index.tsx
@@ -210,10 +210,7 @@ const MapComponent = memo(
     }, []);
 
     const getBeforeId = useCallback(
-      (layer: LayerType, index: number) => {
-        if (layer.type === 'boundary') {
-          return firstSymbolId;
-        }
+      (index: number) => {
         if (index === 0) {
           return firstSymbolId;
         }
@@ -251,7 +248,7 @@ const MapComponent = memo(
             return createElement(component, {
               key: layer.id,
               layer,
-              before: getBeforeId(layer, index),
+              before: getBeforeId(index),
             });
           })}
           {/* These are custom layers which provide functionality and are not really controllable via JSON */}

--- a/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
@@ -3598,6 +3598,17 @@ exports[`renders as expected 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="MuiBox-root MuiBox-root-86"
+              />
+              <a
+                href="https://github.com/WFP-VAM/prism-app"
+                rel="noopener noreferrer"
+                style="color: rgb(245, 247, 248); font-size: 0.7rem; left: 1rem;"
+                target="_blank"
+              >
+                version hash: 
+              </a>
             </div>
           </div>
           <div
@@ -3616,10 +3627,10 @@ exports[`renders as expected 1`] = `
       </div>
     </mock-drawer>
     <div
-      class="MuiBox-root MuiBox-root-126 memo-container-2"
+      class="MuiBox-root MuiBox-root-127 memo-container-2"
     >
       <div
-        class="MuiBox-root MuiBox-root-127 memo-optionContainer-3"
+        class="MuiBox-root MuiBox-root-128 memo-optionContainer-3"
         style="margin-left: 500px;"
       >
         <mock-tooltip
@@ -3657,7 +3668,7 @@ exports[`renders as expected 1`] = `
                 class="MuiGrid-root MuiGrid-item"
               >
                 <div
-                  class="makeStyles-button-130"
+                  class="makeStyles-button-131"
                 >
                   <svg
                     aria-hidden="true"
@@ -3670,7 +3681,7 @@ exports[`renders as expected 1`] = `
                     />
                   </svg>
                   <div
-                    class="makeStyles-selectContainer-132"
+                    class="makeStyles-selectContainer-133"
                   >
                     <mock-circularprogress
                       color="inherit"


### PR DESCRIPTION
### Description

This fixes #1017 and #1021.

- Hash version now stays below the menu items. Hash version is now logged to the console as well.
- layer ordering should be fixed for raster data stacked in-between admin boundaries
 
<!-- what this does -->

## How to test the feature:

- [ ] make sure that the hash version number does not prevent you from clicking on the menu items and does not appear on top of it
- [ ] verify that the hash version is logged to the console
- [ ] verify that WMS layers switched to 100% opacity does not hide admin boundaries
- [ ] run a few layer ordering tests with other mixes of layers

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
