### PR TITLE
Cache kobo dates results in the browser

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -223,12 +223,15 @@ def wrap_get_hdc_stats(
 
 @app.get("/kobo/dates")
 def get_kobo_form_dates(
+    response: Response,
     koboUrl: HttpUrl,
     formId: str,
     datetimeField: str,
     filters: Optional[str] = None,
 ):
     """Get all form response dates."""
+    # cache responses for 24h as they're unlikely to change
+    response.headers["Cache-Control"] = "max-age=86400"
     return get_form_dates(koboUrl, formId, datetimeField, filters)
 
 


### PR DESCRIPTION
### Description
This PR tells browsers to cache results of the `/kobo/dates` api call.

For Cambodia, there are 3 such calls when loading the app, 2 of which take 2-4s each. Caching improves overall load time for the page. I've set the caching period to 24h, under the assumption that the dates shouldn't change much over that period of time.


## How to test the feature:

- [ ] in `layers.json`, change the urls that point to `prism-app.ovio.org/kobo/dates` to point to localhost
- [ ] start the app for Cambodia
- [ ] the second loading of the page should be somewhat faster

## Checklist - did you ...

Test your changes with

Other countries don't seem to be affected by this change.

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:
