### PR TITLE
Use country names above charts and in csv filenames; COUNTRY=rbd

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -531,7 +531,7 @@ const ChartsPanel = memo(
           return [
             [
               locationString(
-                multiCountry ? admin0Key : country,
+                multiCountry ? adminProperties?.admin0Name : country,
                 selectedAdmin1Area,
                 selectedAdmin2Area,
                 adminLevel,
@@ -540,7 +540,7 @@ const ChartsPanel = memo(
             ],
             [
               locationString(
-                multiCountry ? secondAdmin0Key : country,
+                multiCountry ? secondAdminProperties?.admin0Name : country,
                 comparedAdmin1Area,
                 comparedAdmin2Area,
                 comparedAdminLevel,
@@ -584,7 +584,7 @@ const ChartsPanel = memo(
         >
           <Typography className={classes.textLabel}>
             {locationString(
-              multiCountry ? admin0Key : country,
+              multiCountry ? adminProperties?.admin0Name : country,
               selectedAdmin1Area,
               selectedAdmin2Area,
               adminLevel,
@@ -594,7 +594,6 @@ const ChartsPanel = memo(
       ) : null;
       return [locationBox, ...titles, ...zipped];
     }, [
-      admin0Key,
       adminLevel,
       adminProperties,
       chartMaxDateRange,
@@ -605,7 +604,6 @@ const ChartsPanel = memo(
       country,
       endDate1,
       endDate2,
-      secondAdmin0Key,
       secondAdminLevel,
       secondAdminProperties,
       secondSelectedAdmin1Area,

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -327,6 +327,13 @@ const ChartsPanel = memo(
       [compareLocations, comparePeriods],
     );
 
+    const getCountryName: (admProps: GeoJsonProperties) => string = useCallback(
+      admProps => {
+        return multiCountry ? admProps?.admin0Name : country;
+      },
+      [country],
+    );
+
     const locationString = (
       countryName: string,
       adm1Name: string,
@@ -527,11 +534,11 @@ const ChartsPanel = memo(
       };
 
       const titleStrings: () => string[][] = () => {
-        if (compareLocations) {
+        if (compareLocations && adminProperties && secondAdminProperties) {
           return [
             [
               locationString(
-                multiCountry ? adminProperties?.admin0Name : country,
+                getCountryName(adminProperties),
                 selectedAdmin1Area,
                 selectedAdmin2Area,
                 adminLevel,
@@ -540,7 +547,7 @@ const ChartsPanel = memo(
             ],
             [
               locationString(
-                multiCountry ? secondAdminProperties?.admin0Name : country,
+                getCountryName(secondAdminProperties),
                 comparedAdmin1Area,
                 comparedAdmin2Area,
                 comparedAdminLevel,
@@ -572,26 +579,27 @@ const ChartsPanel = memo(
         </Box>
       ));
       // add a location string above everything if comparing periods
-      const locationBox = comparePeriods ? (
-        <Box
-          key="locationBox"
-          style={{
-            height: '30px',
-            minWidth: '80%',
-            flex: 1,
-            position: 'relative',
-          }}
-        >
-          <Typography className={classes.textLabel}>
-            {locationString(
-              multiCountry ? adminProperties?.admin0Name : country,
-              selectedAdmin1Area,
-              selectedAdmin2Area,
-              adminLevel,
-            )}
-          </Typography>
-        </Box>
-      ) : null;
+      const locationBox =
+        comparePeriods && adminProperties ? (
+          <Box
+            key="locationBox"
+            style={{
+              height: '30px',
+              minWidth: '80%',
+              flex: 1,
+              position: 'relative',
+            }}
+          >
+            <Typography className={classes.textLabel}>
+              {locationString(
+                getCountryName(adminProperties),
+                selectedAdmin1Area,
+                selectedAdmin2Area,
+                adminLevel,
+              )}
+            </Typography>
+          </Box>
+        ) : null;
       return [locationBox, ...titles, ...zipped];
     }, [
       adminLevel,
@@ -601,9 +609,9 @@ const ChartsPanel = memo(
       classes.textLabel,
       compareLocations,
       comparePeriods,
-      country,
       endDate1,
       endDate2,
+      getCountryName,
       secondAdminLevel,
       secondAdminProperties,
       secondSelectedAdmin1Area,
@@ -734,21 +742,25 @@ const ChartsPanel = memo(
       [t],
     );
 
-    const firstCSVFilename = buildCsvFileName([
-      multiCountry ? admin0Key : country,
-      selectedAdmin1Area,
-      selectedAdmin2Area,
-      ...(selectedLayerTitles as string[]),
-      comparePeriods ? 'first_period' : '',
-    ]);
+    const firstCSVFilename = adminProperties
+      ? buildCsvFileName([
+          getCountryName(adminProperties),
+          selectedAdmin1Area,
+          selectedAdmin2Area,
+          ...(selectedLayerTitles as string[]),
+          comparePeriods ? 'first_period' : '',
+        ])
+      : '';
 
-    const secondCSVFilename = buildCsvFileName([
-      multiCountry ? secondAdmin0Key : country,
-      compareLocations ? secondSelectedAdmin1Area : selectedAdmin1Area,
-      compareLocations ? secondSelectedAdmin2Area : selectedAdmin2Area,
-      ...(selectedLayerTitles as string[]),
-      comparePeriods ? 'second_period' : '',
-    ]);
+    const secondCSVFilename = secondAdminProperties
+      ? buildCsvFileName([
+          getCountryName(secondAdminProperties),
+          compareLocations ? secondSelectedAdmin1Area : selectedAdmin1Area,
+          compareLocations ? secondSelectedAdmin2Area : selectedAdmin2Area,
+          ...(selectedLayerTitles as string[]),
+          comparePeriods ? 'second_period' : '',
+        ])
+      : '';
 
     if (tabPanelType !== tabValue) {
       return null;


### PR DESCRIPTION
### Description

This fixes #1026 and #992.

It shows the full country name instead of a country code above charts, and in the CSV filenames. 

## How to test the feature:

- [ ] follow the repro steps in #1026 for RBD
- [ ] download a CSV of results, verify that the name starts with country name and not a code.

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:
