### PR TITLE
Select correct boundary area to request data for

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-polygon": "^6.5.0",
     "@turf/boolean-point-in-polygon": "^6.5.0",
+    "@turf/centroid": "^6.5.0",
     "@turf/clone": "^6.5.0",
     "@turf/meta": "^6.5.0",
     "@turf/union": "^6.5.0",

--- a/frontend/src/components/MapView/Layers/BoundaryLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/BoundaryLayer/index.tsx
@@ -65,6 +65,8 @@ function BoundaryLayer({ layer, before }: ComponentProps) {
 
   const onClickShowPopup = (evt: any) => {
     const coordinates = evt.lngLat;
+    const locationSelectorKey = layer.adminCode;
+    const locationAdminCode = evt.features[0].properties[layer.adminCode];
     const locationName = getFullLocationName(
       layer.adminLevelNames,
       evt.features[0],
@@ -75,7 +77,15 @@ function BoundaryLayer({ layer, before }: ComponentProps) {
       evt.features[0],
     );
 
-    dispatch(showPopup({ coordinates, locationName, locationLocalName }));
+    dispatch(
+      showPopup({
+        coordinates,
+        locationSelectorKey,
+        locationAdminCode,
+        locationName,
+        locationLocalName,
+      }),
+    );
   };
 
   const onClickFunc = (evt: any) => {

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
@@ -22,6 +22,7 @@ import { useSafeTranslation } from 'i18n';
 
 import { Column } from 'utils/analysis-utils';
 import { showPopup } from 'context/tooltipStateSlice';
+import { AdminCodeString } from 'config/types';
 
 const ExposureAnalysisTable = memo(
   ({
@@ -140,6 +141,8 @@ const ExposureAnalysisTable = memo(
           dispatch(
             showPopup({
               coordinates: row.coordinates,
+              locationSelectorKey: '',
+              locationAdminCode: row.key as AdminCodeString,
               locationName: row.name,
               locationLocalName: row.localName,
             }),

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
@@ -22,6 +22,7 @@ import { useSafeTranslation } from 'i18n';
 
 import { Column } from 'utils/analysis-utils';
 import { mapSelector } from 'context/mapStateSlice/selectors';
+import { setPopupCoordinates } from 'context/tooltipStateSlice';
 
 const ExposureAnalysisTable = memo(
   ({
@@ -145,6 +146,7 @@ const ExposureAnalysisTable = memo(
           dispatch(() =>
             map.fire('click', { lngLat: coords, point: map.project(coords) }),
           );
+          dispatch(setPopupCoordinates(row.coordinates));
         };
       },
       [map, dispatch],

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
@@ -138,12 +138,11 @@ const ExposureAnalysisTable = memo(
           if (!row.coordinates || !map) {
             return;
           }
-          const coords = {
-            lng: row.coordinates[0],
-            lat: row.coordinates[1],
-          };
           dispatch(() =>
-            map.fire('click', { lngLat: coords, point: map.project(coords) }),
+            map.fire('click', {
+              lngLat: row.coordinates,
+              point: map.project(row.coordinates),
+            }),
           );
         };
       },

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
@@ -22,7 +22,6 @@ import { useSafeTranslation } from 'i18n';
 
 import { Column } from 'utils/analysis-utils';
 import { mapSelector } from 'context/mapStateSlice/selectors';
-import { hidePopup } from 'context/tooltipStateSlice';
 
 const ExposureAnalysisTable = memo(
   ({
@@ -143,7 +142,6 @@ const ExposureAnalysisTable = memo(
             lng: row.coordinates[0],
             lat: row.coordinates[1],
           };
-          dispatch(hidePopup());
           dispatch(() =>
             map.fire('click', { lngLat: coords, point: map.project(coords) }),
           );

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
@@ -22,7 +22,6 @@ import { useSafeTranslation } from 'i18n';
 
 import { Column } from 'utils/analysis-utils';
 import { mapSelector } from 'context/mapStateSlice/selectors';
-import { setPopupCoordinates } from 'context/tooltipStateSlice';
 
 const ExposureAnalysisTable = memo(
   ({
@@ -146,10 +145,9 @@ const ExposureAnalysisTable = memo(
           dispatch(() =>
             map.fire('click', { lngLat: coords, point: map.project(coords) }),
           );
-          dispatch(setPopupCoordinates(row.coordinates));
         };
       },
-      [map, dispatch],
+      [dispatch, map],
     );
 
     // The rendered table body rows

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
@@ -15,14 +15,14 @@ import {
   WithStyles,
 } from '@material-ui/core';
 
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { TableRow as AnalysisTableRow } from 'context/analysisResultStateSlice';
 
 import { useSafeTranslation } from 'i18n';
 
 import { Column } from 'utils/analysis-utils';
-import { showPopup } from 'context/tooltipStateSlice';
-import { AdminCodeString } from 'config/types';
+import { mapSelector } from 'context/mapStateSlice/selectors';
+import { hidePopup } from 'context/tooltipStateSlice';
 
 const ExposureAnalysisTable = memo(
   ({
@@ -38,6 +38,7 @@ const ExposureAnalysisTable = memo(
 
     const [page, setPage] = useState(0);
     const [rowsPerPage, setRowsPerPage] = useState(10);
+    const map = useSelector(mapSelector);
 
     const dispatch = useDispatch();
 
@@ -135,21 +136,20 @@ const ExposureAnalysisTable = memo(
     const handleClickTableBodyRow = useCallback(
       row => {
         return () => {
-          if (!row.coordinates) {
+          if (!row.coordinates || !map) {
             return;
           }
-          dispatch(
-            showPopup({
-              coordinates: row.coordinates,
-              locationSelectorKey: '',
-              locationAdminCode: row.key as AdminCodeString,
-              locationName: row.name,
-              locationLocalName: row.localName,
-            }),
+          const coords = {
+            lng: row.coordinates[0],
+            lat: row.coordinates[1],
+          };
+          dispatch(hidePopup());
+          dispatch(() =>
+            map.fire('click', { lngLat: coords, point: map.project(coords) }),
           );
         };
       },
-      [dispatch],
+      [map, dispatch],
     );
 
     // The rendered table body rows

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
@@ -107,12 +107,11 @@ const AnalysisTable = memo(
           if (!row.coordinates || !map) {
             return;
           }
-          const coords = {
-            lng: row.coordinates[0],
-            lat: row.coordinates[1],
-          };
           dispatch(() =>
-            map.fire('click', { lngLat: coords, point: map.project(coords) }),
+            map.fire('click', {
+              lngLat: row.coordinates,
+              point: map.project(row.coordinates),
+            }),
           );
         };
       },

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
@@ -19,7 +19,6 @@ import { TableRow as AnalysisTableRow } from 'context/analysisResultStateSlice';
 import { Column } from 'utils/analysis-utils';
 import { useSafeTranslation } from 'i18n';
 import { mapSelector } from 'context/mapStateSlice/selectors';
-import { setPopupCoordinates } from 'context/tooltipStateSlice';
 
 const AnalysisTable = memo(
   ({
@@ -115,10 +114,9 @@ const AnalysisTable = memo(
           dispatch(() =>
             map.fire('click', { lngLat: coords, point: map.project(coords) }),
           );
-          dispatch(setPopupCoordinates(row.coordinates));
         };
       },
-      [map, dispatch],
+      [dispatch, map],
     );
 
     const renderedTableRowStyles = useCallback(

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
@@ -19,6 +19,7 @@ import { TableRow as AnalysisTableRow } from 'context/analysisResultStateSlice';
 import { Column } from 'utils/analysis-utils';
 import { useSafeTranslation } from 'i18n';
 import { mapSelector } from 'context/mapStateSlice/selectors';
+import { setPopupCoordinates } from 'context/tooltipStateSlice';
 
 const AnalysisTable = memo(
   ({
@@ -114,6 +115,7 @@ const AnalysisTable = memo(
           dispatch(() =>
             map.fire('click', { lngLat: coords, point: map.project(coords) }),
           );
+          dispatch(setPopupCoordinates(row.coordinates));
         };
       },
       [map, dispatch],

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
@@ -19,6 +19,7 @@ import { TableRow as AnalysisTableRow } from 'context/analysisResultStateSlice';
 import { showPopup } from 'context/tooltipStateSlice';
 import { Column } from 'utils/analysis-utils';
 import { useSafeTranslation } from 'i18n';
+import { AdminCodeString } from 'config/types';
 
 const AnalysisTable = memo(
   ({
@@ -109,6 +110,8 @@ const AnalysisTable = memo(
           dispatch(
             showPopup({
               coordinates: row.coordinates,
+              locationSelectorKey: '',
+              locationAdminCode: row.key as AdminCodeString,
               locationName: row.name,
               locationLocalName: row.localName,
             }),

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
@@ -14,12 +14,12 @@ import {
   withStyles,
   WithStyles,
 } from '@material-ui/core';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { TableRow as AnalysisTableRow } from 'context/analysisResultStateSlice';
-import { showPopup } from 'context/tooltipStateSlice';
 import { Column } from 'utils/analysis-utils';
 import { useSafeTranslation } from 'i18n';
-import { AdminCodeString } from 'config/types';
+import { mapSelector } from 'context/mapStateSlice/selectors';
+import { hidePopup } from 'context/tooltipStateSlice';
 
 const AnalysisTable = memo(
   ({
@@ -34,7 +34,7 @@ const AnalysisTable = memo(
     const { t } = useSafeTranslation();
     const [page, setPage] = useState(0);
     const [rowsPerPage, setRowsPerPage] = useState(10);
-
+    const map = useSelector(mapSelector);
     const dispatch = useDispatch();
 
     const handleChangePage = useCallback((event: unknown, newPage: number) => {
@@ -104,21 +104,20 @@ const AnalysisTable = memo(
     const handleClickTableBodyRow = useCallback(
       row => {
         return () => {
-          if (!row.coordinates) {
+          if (!row.coordinates || !map) {
             return;
           }
-          dispatch(
-            showPopup({
-              coordinates: row.coordinates,
-              locationSelectorKey: '',
-              locationAdminCode: row.key as AdminCodeString,
-              locationName: row.name,
-              locationLocalName: row.localName,
-            }),
+          const coords = {
+            lng: row.coordinates[0],
+            lat: row.coordinates[1],
+          };
+          dispatch(hidePopup());
+          dispatch(() =>
+            map.fire('click', { lngLat: coords, point: map.project(coords) }),
           );
         };
       },
-      [dispatch],
+      [map, dispatch],
     );
 
     const renderedTableRowStyles = useCallback(

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
@@ -19,7 +19,6 @@ import { TableRow as AnalysisTableRow } from 'context/analysisResultStateSlice';
 import { Column } from 'utils/analysis-utils';
 import { useSafeTranslation } from 'i18n';
 import { mapSelector } from 'context/mapStateSlice/selectors';
-import { hidePopup } from 'context/tooltipStateSlice';
 
 const AnalysisTable = memo(
   ({
@@ -35,6 +34,7 @@ const AnalysisTable = memo(
     const [page, setPage] = useState(0);
     const [rowsPerPage, setRowsPerPage] = useState(10);
     const map = useSelector(mapSelector);
+
     const dispatch = useDispatch();
 
     const handleChangePage = useCallback((event: unknown, newPage: number) => {
@@ -111,7 +111,6 @@ const AnalysisTable = memo(
             lng: row.coordinates[0],
             lat: row.coordinates[1],
           };
-          dispatch(hidePopup());
           dispatch(() =>
             map.fire('click', { lngLat: coords, point: map.project(coords) }),
           );

--- a/frontend/src/components/MapView/MapTooltip/PopupCharts/PopupAnalysisCharts.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PopupCharts/PopupAnalysisCharts.tsx
@@ -8,6 +8,7 @@ import {
   AdminLevelType,
   BoundaryLayerProps,
   WMSLayerProps,
+  AdminCodeString,
 } from 'config/types';
 import { getBoundaryLayersByAdminLevel } from 'config/utils';
 import { BoundaryLayerData } from 'context/layers/boundary';
@@ -40,10 +41,15 @@ const boundaryLayer = getBoundaryLayersByAdminLevel();
 
 const getProperties = (
   layerData: LayerData<BoundaryLayerProps>['data'],
+  adminCode: AdminCodeString,
+  adminSelectorKey: string,
   name: string,
 ) => {
   const features = layerData.features.filter(
-    elem => elem.properties && elem.properties[name],
+    elem =>
+      elem.properties &&
+      elem.properties[adminSelectorKey] &&
+      elem.properties[adminSelectorKey] === adminCode,
   );
 
   if (!features) {
@@ -54,12 +60,16 @@ const getProperties = (
 
 interface PopupChartProps extends WithStyles<typeof styles> {
   filteredChartLayers: WMSLayerProps[];
+  adminCode: AdminCodeString;
+  adminSelectorKey: string;
   adminLevel: AdminLevelType;
   onClose: React.Dispatch<React.SetStateAction<AdminLevelType | undefined>>;
   adminLevelsNames: () => string[];
 }
 const PopupAnalysisCharts = ({
   filteredChartLayers,
+  adminCode,
+  adminSelectorKey,
   adminLevel,
   onClose,
   adminLevelsNames,
@@ -89,6 +99,8 @@ const PopupAnalysisCharts = ({
               chartLayer={filteredChartLayer}
               adminProperties={getProperties(
                 data as BoundaryLayerData,
+                adminCode,
+                adminSelectorKey,
                 levelsConfiguration
                   .find(
                     levelConfiguration =>

--- a/frontend/src/components/MapView/MapTooltip/PopupCharts/PopupAnalysisCharts.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PopupCharts/PopupAnalysisCharts.tsx
@@ -43,9 +43,8 @@ const getProperties = (
   layerData: LayerData<BoundaryLayerProps>['data'],
   adminCode: AdminCodeString,
   adminSelectorKey: string,
-  name: string,
 ) => {
-  const features = layerData.features.filter(
+  const features = layerData.features.find(
     elem =>
       elem.properties &&
       elem.properties[adminSelectorKey] &&
@@ -55,7 +54,7 @@ const getProperties = (
   if (!features) {
     return null;
   }
-  return features[0].properties;
+  return features.properties;
 };
 
 interface PopupChartProps extends WithStyles<typeof styles> {
@@ -81,11 +80,6 @@ const PopupAnalysisCharts = ({
     | undefined;
   const { data } = boundaryLayerData || {};
 
-  const levelsConfiguration = filteredChartLayers.map(item => ({
-    name: item.id,
-    levels: item.chartData?.levels,
-  }));
-
   const { startDate: selectedDate } = useSelector(dateRangeSelector);
   const chartEndDate = selectedDate || new Date().getTime();
   const chartStartDate = chartEndDate - oneYearInMs;
@@ -101,13 +95,6 @@ const PopupAnalysisCharts = ({
                 data as BoundaryLayerData,
                 adminCode,
                 adminSelectorKey,
-                levelsConfiguration
-                  .find(
-                    levelConfiguration =>
-                      levelConfiguration.name === filteredChartLayer.id,
-                  )
-                  ?.levels?.find(level => level.level === adminLevel.toString())
-                  ?.name ?? '',
               )}
               adminLevel={adminLevel}
               startDate={chartStartDate}

--- a/frontend/src/components/MapView/MapTooltip/PopupCharts/index.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PopupCharts/index.tsx
@@ -1,4 +1,4 @@
-import { AdminLevelType } from 'config/types';
+import { AdminLevelType, AdminCodeString } from 'config/types';
 import { getWMSLayersWithChart } from 'config/utils';
 import { layersSelector } from 'context/mapStateSlice/selectors';
 import React, { memo, useEffect } from 'react';
@@ -10,6 +10,8 @@ const chartLayers = getWMSLayersWithChart();
 
 interface PopupChartsProps {
   setPopupTitle: React.Dispatch<React.SetStateAction<string>>;
+  adminCode: AdminCodeString;
+  adminSelectorKey: string;
   adminLevel: AdminLevelType | undefined;
   setAdminLevel: React.Dispatch<
     React.SetStateAction<AdminLevelType | undefined>
@@ -20,6 +22,8 @@ interface PopupChartsProps {
 
 const PopupCharts = ({
   setPopupTitle,
+  adminCode,
+  adminSelectorKey,
   adminLevel,
   setAdminLevel,
   adminLevelsNames,
@@ -52,6 +56,8 @@ const PopupCharts = ({
       )}
       {adminLevel !== undefined && (
         <PopupAnalysisCharts
+          adminCode={adminCode}
+          adminSelectorKey={adminSelectorKey}
           adminLevel={adminLevel}
           onClose={setAdminLevel}
           adminLevelsNames={adminLevelsNames}

--- a/frontend/src/components/MapView/MapTooltip/PopupContent.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PopupContent.tsx
@@ -136,6 +136,7 @@ const PopupContent = ({
         .filter(([, value]) => {
           // TODO - this seems like a hacky way to filter data and likely to break
           // Temporarily add logging to determine if this is actually filtering out any data
+          // Note - introduced  by Harry in https://github.com/WFP-VAM/prism-app/pull/834/
           console.warn('Coordinates are not equal ans some data is omitted.');
           console.warn('Data Coordinates:', value.coordinates);
           console.warn('Popup coordinates:', coordinates);

--- a/frontend/src/components/MapView/MapTooltip/PopupContent.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PopupContent.tsx
@@ -134,6 +134,7 @@ const PopupContent = ({
     <>
       {Object.entries(popupDataWithoutPhasePopulations)
         .filter(([, value]) => {
+          // TODO - this seems like a hacky way to filter data and likely to break
           return isEqual(value.coordinates, coordinates);
         })
         .map(([key, value]) => {

--- a/frontend/src/components/MapView/MapTooltip/PopupContent.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PopupContent.tsx
@@ -139,12 +139,15 @@ const PopupContent = ({
           // Note - introduced  by Harry in https://github.com/WFP-VAM/prism-app/pull/834/
           if (!isEqual(value.coordinates, coordinates)) {
             /* eslint-disable no-console */
-            console.log('Coordinates are not equal and some data is omitted.');
+            console.log(
+              'Coordinates are not equal and some data should be omitted!',
+            );
             console.log('Data Coordinates:', value.coordinates);
             console.log('Popup coordinates:', coordinates);
             /* eslint-enable no-console */
           }
-          return isEqual(value.coordinates, coordinates);
+          // return isEqual(value.coordinates, coordinates);
+          return true;
         })
         .map(([key, value]) => {
           return (

--- a/frontend/src/components/MapView/MapTooltip/PopupContent.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PopupContent.tsx
@@ -137,9 +137,13 @@ const PopupContent = ({
           // TODO - this seems like a hacky way to filter data and likely to break
           // Temporarily add logging to determine if this is actually filtering out any data
           // Note - introduced  by Harry in https://github.com/WFP-VAM/prism-app/pull/834/
-          console.warn('Coordinates are not equal ans some data is omitted.');
-          console.warn('Data Coordinates:', value.coordinates);
-          console.warn('Popup coordinates:', coordinates);
+          if (!isEqual(value.coordinates, coordinates)) {
+            /* eslint-disable no-console */
+            console.log('Coordinates are not equal and some data is omitted.');
+            console.log('Data Coordinates:', value.coordinates);
+            console.log('Popup coordinates:', coordinates);
+            /* eslint-enable no-console */
+          }
           return isEqual(value.coordinates, coordinates);
         })
         .map(([key, value]) => {

--- a/frontend/src/components/MapView/MapTooltip/PopupContent.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PopupContent.tsx
@@ -135,6 +135,10 @@ const PopupContent = ({
       {Object.entries(popupDataWithoutPhasePopulations)
         .filter(([, value]) => {
           // TODO - this seems like a hacky way to filter data and likely to break
+          // Temporarily add logging to determine if this is actually filtering out any data
+          console.warn('Coordinates are not equal ans some data is omitted.');
+          console.warn('Data Coordinates:', value.coordinates);
+          console.warn('Popup coordinates:', coordinates);
           return isEqual(value.coordinates, coordinates);
         })
         .map(([key, value]) => {

--- a/frontend/src/components/MapView/MapTooltip/index.tsx
+++ b/frontend/src/components/MapView/MapTooltip/index.tsx
@@ -95,7 +95,7 @@ const MapTooltip = ({ classes }: TooltipProps) => {
     // If adminLevel is undefined, return the whole array
     // eslint-disable-next-line fp/no-mutating-methods
     return splitNames.splice(0, adminLevelLimit);
-  }, [adminLevel, i18n, popup.locationLocalName, popup.locationName]);
+  }, [adminLevel, i18n, popup]);
 
   if (isLoading || !popup.showing || !popup.coordinates) {
     return null;
@@ -133,6 +133,8 @@ const MapTooltip = ({ classes }: TooltipProps) => {
       )}
       <PopupCharts
         setPopupTitle={setPopupTitle}
+        adminCode={popup.locationAdminCode}
+        adminSelectorKey={popup.locationSelectorKey}
         adminLevel={adminLevel}
         setAdminLevel={setAdminLevel}
         adminLevelsNames={adminLevelsNames}

--- a/frontend/src/context/analysisResultStateSlice.ts
+++ b/frontend/src/context/analysisResultStateSlice.ts
@@ -4,6 +4,7 @@ import {
   Dispatch,
   PayloadAction,
 } from '@reduxjs/toolkit';
+import centroid from '@turf/centroid';
 import { convertArea } from '@turf/helpers';
 import {
   Feature,
@@ -309,6 +310,14 @@ const generateTableFromApiData = (
       key,
     );
 
+    // Get the centroid coordinates of the feature. NOTE - this might be slow for large features.
+    const centroidCoordinates = featureBoundary?.geometry
+      ? (centroid(featureBoundary.geometry as any).geometry.coordinates as [
+          number,
+          number,
+        ])
+      : undefined;
+
     const tableRow: TableRow = {
       key: i.toString(), // primary key, identifying a unique row in the table
       name,
@@ -321,7 +330,7 @@ const generateTableFromApiData = (
         rawBaselineValue === 'No Data'
           ? 'No Data'
           : parseFloat(`${rawBaselineValue}`),
-      coordinates: (featureBoundary?.geometry as any)?.coordinates[0][0][0], // TODO likely will not keep
+      coordinates: centroidCoordinates as any,
       ...Object.fromEntries(
         extraColumns.map(extraColumn => [extraColumn, get(row, extraColumn)]),
       ),

--- a/frontend/src/context/tooltipStateSlice.ts
+++ b/frontend/src/context/tooltipStateSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { merge } from 'lodash';
+import { AdminCodeString } from 'config/types';
 import type { RootState } from './store';
 
 export interface PopupData {
@@ -17,6 +18,9 @@ export interface PopupMetaData {
 
 export interface MapTooltipState {
   coordinates?: GeoJSON.Position;
+  locationAdminCode: AdminCodeString;
+  // the key under which we find locationAdminCode
+  locationSelectorKey: string;
   locationName: string;
   locationLocalName: string;
   data: PopupData & PopupMetaData;
@@ -26,11 +30,16 @@ export interface MapTooltipState {
 
 type ShowPopupType = {
   coordinates: GeoJSON.Position;
+  // the key of the dict under which locationAdminCode is to be found
+  locationSelectorKey: string;
+  locationAdminCode: AdminCodeString;
   locationName: string;
   locationLocalName: string;
 };
 
 const initialState: MapTooltipState = {
+  locationAdminCode: '' as AdminCodeString,
+  locationSelectorKey: '',
   locationName: '',
   locationLocalName: '',
   data: {},
@@ -69,6 +78,8 @@ export const tooltipStateSlice = createSlice({
     showPopup: (state, { payload }: PayloadAction<ShowPopupType>) => ({
       ...state,
       showing: true,
+      locationSelectorKey: payload.locationSelectorKey,
+      locationAdminCode: payload.locationAdminCode,
       locationName: payload.locationName,
       locationLocalName: payload.locationLocalName,
       coordinates: payload.coordinates,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2151,6 +2151,14 @@
     "@turf/helpers" "^6.5.0"
     "@turf/invariant" "^6.5.0"
 
+"@turf/centroid@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/centroid/-/centroid-6.5.0.tgz#ecaa365412e5a4d595bb448e7dcdacfb49eb0009"
+  integrity sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
 "@turf/clone@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-6.5.0.tgz#895860573881ae10a02dfff95f274388b1cda51a"


### PR DESCRIPTION
### Description

This is a hotfix for a small bug in popup chart whereby the data sent to the chart was never the correct one.

To reproduce the bug:
- country=cambodia (but any other will show the bug)
- activate a data layer, for instance "rainfall amount"
- click any are of the map to bring up the popup, and load a chart
- save CSV data for easier comparison (or just a good look at the shape of the chart will do)
- click some other part of the map. the chart reloads the same data

(this can be confirmed by looking at the network requests which all relate to the same boundary code)

This PR fixes this, so that data is fetched for the area that was indeed clicked.

## How to test the feature:

Same as above, but the network requests are now different for each click, and admin codes can be confirmed with the json data.

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:
