### PR TITLE
Analysis - hide extended validity dates and only show actual query dates; COUNTRY=rbd

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
@@ -232,7 +232,6 @@ const AnalysisPanel = memo(
     const hazardDataType: HazardDataType | null = selectedHazardLayer
       ? selectedHazardLayer.geometry || RasterType.Raster
       : null;
-
     const availableHazardDates = selectedHazardLayer
       ? Array.from(
           new Set(

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/index.tsx
@@ -232,11 +232,16 @@ const AnalysisPanel = memo(
     const hazardDataType: HazardDataType | null = selectedHazardLayer
       ? selectedHazardLayer.geometry || RasterType.Raster
       : null;
+
     const availableHazardDates = selectedHazardLayer
-      ? getPossibleDatesForLayer(selectedHazardLayer, availableDates)?.map(
-          d => new Date(d.displayDate),
-        ) || []
-      : undefined;
+      ? Array.from(
+          new Set(
+            getPossibleDatesForLayer(selectedHazardLayer, availableDates)?.map(
+              d => d.queryDate,
+            ),
+          ),
+        ).map(d => new Date(d)) || []
+      : [];
 
     const BASELINE_URL_LAYER_KEY = 'baselineLayerId';
     const preSelectedBaselineLayer = selectedLayers.find(


### PR DESCRIPTION
### Description

This fixes #1027 

<!-- what this does -->

## How to test the feature:

- [ ] go to anslysis, select a layer which has validity periods
- [ ] confirm that only actual query dates are available in the date picker

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:
