### PR TITLE
Charts - unify scale when comparing

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
@@ -27,6 +27,14 @@ import { useSafeTranslation } from 'i18n';
 import { getChartAdminBoundaryParams } from 'utils/admin-utils';
 import Chart from 'components/Common/Chart';
 
+/**
+ * This function removes the first occurrence of a specific number from an array.
+ * If the number is not found in the array, it returns the original array.
+ *
+ * @param arr - The array from which the number should be removed.
+ * @param numberToRemove - The number to remove from the array.
+ * @returns A new array with the first occurrence of the specified number removed.
+ */
 function removeFirstOccurrence(arr: number[], numberToRemove: number) {
   const indexToRemove = arr.indexOf(numberToRemove);
   if (indexToRemove !== -1) {
@@ -143,6 +151,8 @@ const ChartSection = memo(
       setExtendedChartDataset(extended);
     }, [chartDataset, chartMaxDateRange]);
 
+    // This effect is used to calculate the max and min values of the chart
+    // so that we can put charts on the same scale for comparison.
     React.useEffect(() => {
       if (!(extendedChartDataset && setMaxChartValue && setMinChartValue)) {
         return () => {};

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
@@ -27,6 +27,14 @@ import { useSafeTranslation } from 'i18n';
 import { getChartAdminBoundaryParams } from 'utils/admin-utils';
 import Chart from 'components/Common/Chart';
 
+function removeFirstOccurrence(arr: number[], numberToRemove: number) {
+  const indexToRemove = arr.indexOf(numberToRemove);
+  if (indexToRemove !== -1) {
+    return [...arr.slice(0, indexToRemove), ...arr.slice(indexToRemove + 1)];
+  }
+  return arr;
+}
+
 // returns startDate and endDate as part of result
 function generateDateStrings(startDate: Date, endDate: Date) {
   const result = [];
@@ -109,6 +117,10 @@ const ChartSection = memo(
     setMaxDataTicks,
     setChartSelectedDateRange,
     setChartMaxDateRange,
+    setMaxChartValue,
+    setMinChartValue,
+    maxChartValue,
+    minChartValue,
     classes,
   }: ChartSectionProps) => {
     const dispatch = useDispatch();
@@ -130,6 +142,41 @@ const ChartSection = memo(
 
       setExtendedChartDataset(extended);
     }, [chartDataset, chartMaxDateRange]);
+
+    React.useEffect(() => {
+      if (!(extendedChartDataset && setMaxChartValue && setMinChartValue)) {
+        return () => {};
+      }
+      const keys = Object.keys(extendedChartDataset.rows[0]).filter(
+        x => x !== CHART_DATA_PREFIXES.date,
+      );
+      const max = extendedChartDataset.rows.reduce(
+        (m, curr) =>
+          Math.max(
+            ...keys
+              .map(i => curr[i])
+              .filter((x): x is number => typeof x === 'number'),
+            m,
+          ),
+        Number.NEGATIVE_INFINITY,
+      );
+      const min = extendedChartDataset.rows.reduce(
+        (m, curr) =>
+          Math.min(
+            ...keys
+              .map(i => curr[i])
+              .filter((x): x is number => typeof x === 'number'),
+            m,
+          ),
+        Number.POSITIVE_INFINITY,
+      );
+      setMaxChartValue(prev => [...prev, max]);
+      setMinChartValue(prev => [...prev, min]);
+      return () => {
+        setMaxChartValue(prev => removeFirstOccurrence(prev, max));
+        setMinChartValue(prev => removeFirstOccurrence(prev, min));
+      };
+    }, [extendedChartDataset, setMaxChartValue, setMinChartValue]);
 
     React.useEffect(() => {
       if (!extendedChartDataset) {
@@ -369,11 +416,11 @@ const ChartSection = memo(
         data: CHART_DATA_PREFIXES.col,
         transpose: true,
         displayLegend: true,
-        minValue,
-        maxValue,
+        minValue: minChartValue || minValue,
+        maxValue: maxChartValue || maxValue,
         colors,
       };
-    }, [chartType, colors, maxValue, minValue]);
+    }, [chartType, colors, maxChartValue, maxValue, minChartValue, minValue]);
 
     const title = useMemo(() => {
       return chartLayer.title;
@@ -457,6 +504,10 @@ export interface ChartSectionProps extends WithStyles<typeof styles> {
     React.SetStateAction<[string, string]>
   >;
   setChartMaxDateRange?: React.Dispatch<React.SetStateAction<[string, string]>>;
+  setMaxChartValue?: React.Dispatch<React.SetStateAction<number[]>>;
+  setMinChartValue?: React.Dispatch<React.SetStateAction<number[]>>;
+  maxChartValue?: number;
+  minChartValue?: number;
 }
 
 export default withStyles(styles)(ChartSection);

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/ChartSection/index.tsx
@@ -125,8 +125,8 @@ const ChartSection = memo(
     setMaxDataTicks,
     setChartSelectedDateRange,
     setChartMaxDateRange,
-    setMaxChartValue,
-    setMinChartValue,
+    setMaxChartValues,
+    setMinChartValues,
     maxChartValue,
     minChartValue,
     classes,
@@ -154,7 +154,7 @@ const ChartSection = memo(
     // This effect is used to calculate the max and min values of the chart
     // so that we can put charts on the same scale for comparison.
     React.useEffect(() => {
-      if (!(extendedChartDataset && setMaxChartValue && setMinChartValue)) {
+      if (!(extendedChartDataset && setMaxChartValues && setMinChartValues)) {
         return () => {};
       }
       const keys = Object.keys(extendedChartDataset.rows[0]).filter(
@@ -180,13 +180,13 @@ const ChartSection = memo(
           ),
         Number.POSITIVE_INFINITY,
       );
-      setMaxChartValue(prev => [...prev, max]);
-      setMinChartValue(prev => [...prev, min]);
+      setMaxChartValues(prev => [...prev, max]);
+      setMinChartValues(prev => [...prev, min]);
       return () => {
-        setMaxChartValue(prev => removeFirstOccurrence(prev, max));
-        setMinChartValue(prev => removeFirstOccurrence(prev, min));
+        setMaxChartValues(prev => removeFirstOccurrence(prev, max));
+        setMinChartValues(prev => removeFirstOccurrence(prev, min));
       };
-    }, [extendedChartDataset, setMaxChartValue, setMinChartValue]);
+    }, [extendedChartDataset, setMaxChartValues, setMinChartValues]);
 
     React.useEffect(() => {
       if (!extendedChartDataset) {
@@ -514,8 +514,8 @@ export interface ChartSectionProps extends WithStyles<typeof styles> {
     React.SetStateAction<[string, string]>
   >;
   setChartMaxDateRange?: React.Dispatch<React.SetStateAction<[string, string]>>;
-  setMaxChartValue?: React.Dispatch<React.SetStateAction<number[]>>;
-  setMinChartValue?: React.Dispatch<React.SetStateAction<number[]>>;
+  setMaxChartValues?: React.Dispatch<React.SetStateAction<number[]>>;
+  setMinChartValues?: React.Dispatch<React.SetStateAction<number[]>>;
   maxChartValue?: number;
   minChartValue?: number;
 }

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -275,6 +275,8 @@ const ChartsPanel = memo(
       [string, string]
     >(['', '']);
     const [showSlider, setShowSlider] = useState(true);
+    const [maxChartValue, setMaxChartValue] = useState<number[]>([]);
+    const [minChartValue, setMinChartValue] = useState<number[]>([]);
 
     function resetSlider() {
       setMaxDataTicks(0);
@@ -452,6 +454,10 @@ const ChartsPanel = memo(
                     startDate={startDate1 as number}
                     endDate={endDate1 as number}
                     dataForCsv={dataForCsv}
+                    setMaxChartValue={setMaxChartValue}
+                    setMinChartValue={setMinChartValue}
+                    maxChartValue={Math.max(...maxChartValue)}
+                    minChartValue={Math.min(...minChartValue)}
                   />
                 </Box>
               ))
@@ -504,6 +510,10 @@ const ChartsPanel = memo(
                   startDate={comparedStartDate as number}
                   endDate={comparedEndDate as number}
                   dataForCsv={dataForSecondCsv}
+                  setMaxChartValue={setMaxChartValue}
+                  setMinChartValue={setMinChartValue}
+                  maxChartValue={Math.max(...maxChartValue)}
+                  minChartValue={Math.min(...minChartValue)}
                 />
               </Box>
             ))
@@ -612,6 +622,8 @@ const ChartsPanel = memo(
       endDate1,
       endDate2,
       getCountryName,
+      maxChartValue,
+      minChartValue,
       secondAdminLevel,
       secondAdminProperties,
       secondSelectedAdmin1Area,

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -275,8 +275,8 @@ const ChartsPanel = memo(
       [string, string]
     >(['', '']);
     const [showSlider, setShowSlider] = useState(true);
-    const [maxChartValue, setMaxChartValue] = useState<number[]>([]);
-    const [minChartValue, setMinChartValue] = useState<number[]>([]);
+    const [maxChartValues, setMaxChartValues] = useState<number[]>([]);
+    const [minChartValues, setMinChartValues] = useState<number[]>([]);
 
     function resetSlider() {
       setMaxDataTicks(0);
@@ -455,13 +455,13 @@ const ChartsPanel = memo(
                     startDate={startDate1 as number}
                     endDate={endDate1 as number}
                     dataForCsv={dataForCsv}
-                    setMaxChartValue={setMaxChartValue}
-                    setMinChartValue={setMinChartValue}
+                    setMaxChartValues={setMaxChartValues}
+                    setMinChartValues={setMinChartValues}
                     maxChartValue={
-                      comparing ? Math.max(...maxChartValue) : undefined
+                      comparing ? Math.max(...maxChartValues) : undefined
                     }
                     minChartValue={
-                      comparing ? Math.min(...minChartValue) : undefined
+                      comparing ? Math.min(...minChartValues) : undefined
                     }
                   />
                 </Box>
@@ -514,10 +514,10 @@ const ChartsPanel = memo(
                   startDate={comparedStartDate as number}
                   endDate={comparedEndDate as number}
                   dataForCsv={dataForSecondCsv}
-                  setMaxChartValue={setMaxChartValue}
-                  setMinChartValue={setMinChartValue}
-                  maxChartValue={Math.max(...maxChartValue)}
-                  minChartValue={Math.min(...minChartValue)}
+                  setMaxChartValues={setMaxChartValues}
+                  setMinChartValues={setMinChartValues}
+                  maxChartValue={Math.max(...maxChartValues)}
+                  minChartValue={Math.min(...minChartValues)}
                 />
               </Box>
             ))
@@ -626,8 +626,8 @@ const ChartsPanel = memo(
       endDate1,
       endDate2,
       getCountryName,
-      maxChartValue,
-      minChartValue,
+      maxChartValues,
+      minChartValues,
       secondAdminLevel,
       secondAdminProperties,
       secondSelectedAdmin1Area,

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -425,6 +425,7 @@ const ChartsPanel = memo(
         );
       }
       // show 2 or more charts (multi layer or comparisons)
+      const comparing = compareLocations || comparePeriods;
       const mainChartList =
         selectedLayerTitles.length >= 1
           ? chartLayers
@@ -456,14 +457,17 @@ const ChartsPanel = memo(
                     dataForCsv={dataForCsv}
                     setMaxChartValue={setMaxChartValue}
                     setMinChartValue={setMinChartValue}
-                    maxChartValue={Math.max(...maxChartValue)}
-                    minChartValue={Math.min(...minChartValue)}
+                    maxChartValue={
+                      comparing ? Math.max(...maxChartValue) : undefined
+                    }
+                    minChartValue={
+                      comparing ? Math.min(...minChartValue) : undefined
+                    }
                   />
                 </Box>
               ))
           : [];
       // now add comparison charts
-      const comparing = compareLocations || comparePeriods;
       const comparedAdminProperties = compareLocations
         ? secondAdminProperties
         : adminProperties;


### PR DESCRIPTION
### Description

This fixes #1015 .

Make charts have the same scale when comparing locations or periods.

## How to test the feature:

- navigate to chats panel
- select compare locations or periods
- verify that both charts have the same y scale

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
![Screenshot from 2023-12-22 15-28-27](https://github.com/WFP-VAM/prism-app/assets/80451946/fc3059ca-76f6-4ad2-9750-f0ae02e84f8e)
