### PR TITLE
Pin and upgrade comlink version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,7 @@
     "babel-eslint": "10.0.3",
     "chart.js": "^2.9.3",
     "colormap": "^2.3.1",
-    "comlink": "^4.3.1",
+    "comlink": "^4.4.1",
     "customize-cra": "^1.0.0",
     "d3-fetch": "^1.1.2",
     "date-fns": "^2.28.0",

--- a/frontend/src/utils/zonal-utils.ts
+++ b/frontend/src/utils/zonal-utils.ts
@@ -2,8 +2,9 @@ import * as Comlink from 'comlink';
 import { ZonalOptions } from 'config/types';
 
 // instantiate worker to handle zonal statistics requests
+// comlink version here should match the one in package.json
 const text = `
-importScripts("https://unpkg.com/comlink/dist/umd/comlink.js");
+importScripts("https://unpkg.com/comlink@4.4.1/dist/umd/comlink.js");
 importScripts("https://unpkg.com/zonal@0.7.3/zonal.min.js");
 
 Comlink.expose(zonal);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4675,10 +4675,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comlink@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.1.tgz#0c6b9d69bcd293715c907c33fe8fc45aecad13c5"
-  integrity sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA==
+comlink@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.4.1.tgz#e568b8e86410b809e8600eb2cf40c189371ef981"
+  integrity sha512-+1dlx0aY5Jo1vHy/tSsIGpSkN4tS9rZSW8FIhG0JH/crs9wwweswIo/POr451r7bZww3hFbPAKnTpimzL/mm4Q==
 
 commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"


### PR DESCRIPTION
### Description

This pins the version of comlink used in workers (as it is fetched from unpkg, instead of being set in `package.json`.

It does not seem to cause any problems as such, but it's probably safer to use the same version both sides of a communication channel :)
Also, it removes one network call while loading the app, which never hurts (the call to resolve "latest" version of `comlink`), and allows "forever" caching of it.

## How to test the feature:

- no visible changes, loading the app should be marginally faster (on my machine, this actually saves over 1s waiting for network calls in dev mode).

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with
 (none of these apply here)

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:
