### PR TITLE
Fix tooltip would show close icon when no chart

### DIFF
--- a/frontend/src/components/MapView/MapTooltip/PopupCharts/PopupAnalysisCharts.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PopupCharts/PopupAnalysisCharts.tsx
@@ -84,6 +84,10 @@ const PopupAnalysisCharts = ({
   const chartEndDate = selectedDate || new Date().getTime();
   const chartStartDate = chartEndDate - oneYearInMs;
 
+  if (filteredChartLayers.length < 1) {
+    return null;
+  }
+
   return (
     <PopupChartWrapper onClose={onClose}>
       {filteredChartLayers.map(filteredChartLayer => (


### PR DESCRIPTION
### Description

This fixes #1044, where the tooltip would **always** show the scrollbar with the closing icon.

<!-- what this does -->

## How to test the feature:

- Load a layer, which is not associated with charts on the tooltip (eg. COUNTRY=zimbabwe, Rainfall > Forecasts > Rolling daily rainfall forecast) 
- Verify that the tooltip has no scrollbar and close icon, if there is no chart showing

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
