### PR TITLE
Use download icons for EWS charts; COUNTRY=cambodia

### DIFF
--- a/frontend/src/components/MapView/MapTooltip/PointDataChart/PopupPointDataChart.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PointDataChart/PopupPointDataChart.tsx
@@ -1,16 +1,14 @@
 import Chart from 'components/Common/Chart';
-import { buildCsvFileName, isAdminBoundary } from 'components/MapView/utils';
+import { isAdminBoundary } from 'components/MapView/utils';
 import { ChartConfig } from 'config/types';
 import {
   CHART_DATA_PREFIXES,
   datasetSelector,
 } from 'context/datasetStateSlice';
 import { t } from 'i18next';
-import React, { memo, useRef } from 'react';
+import React, { memo } from 'react';
 import { useSelector } from 'react-redux';
 import { WithStyles, createStyles, withStyles } from '@material-ui/core';
-import DownloadCsvButton from 'components/MapView/DownloadCsvButton';
-import { appConfig } from 'config';
 
 const styles = () =>
   createStyles({
@@ -20,21 +18,15 @@ const styles = () =>
       gap: '8px',
     },
     chartSection: {
-      height: '240px',
+      paddingTop: '16px', // leave room for the download icons
+      height: '200px',
       width: '400px',
     },
   });
 
-const { countryAdmin0Id, country, multiCountry } = appConfig;
+interface PopupDatasetChartProps extends WithStyles<typeof styles> {}
 
-interface PopupDatasetChartProps extends WithStyles<typeof styles> {
-  adminLevelsNames: () => string[];
-}
-const PopupPointDataChart = ({
-  adminLevelsNames,
-  classes,
-}: PopupDatasetChartProps) => {
-  const dataForCsv = useRef<{ [key: string]: any[] }>({});
+const PopupPointDataChart = ({ classes }: PopupDatasetChartProps) => {
   const { data: dataset, datasetParams, title, chartType } = useSelector(
     datasetSelector,
   );
@@ -51,11 +43,6 @@ const PopupPointDataChart = ({
     return null;
   }
 
-  dataForCsv.current = {
-    ...dataForCsv.current,
-    [title]: dataset.rows,
-  };
-
   return (
     <div className={classes.chartContainer}>
       <div className={classes.chartSection}>
@@ -68,20 +55,10 @@ const PopupPointDataChart = ({
               ? undefined
               : t('Timestamps reflect local time in Cambodia')
           }
+          showDownloadIcons
+          iconStyles={{ color: 'white' }}
         />
       </div>
-      <DownloadCsvButton
-        filesData={[
-          {
-            fileName: buildCsvFileName([
-              multiCountry ? countryAdmin0Id : country,
-              ...adminLevelsNames(),
-              title,
-            ]),
-            data: dataForCsv,
-          },
-        ]}
-      />
     </div>
   );
 };

--- a/frontend/src/components/MapView/MapTooltip/PointDataChart/PopupPointDataChart.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PointDataChart/PopupPointDataChart.tsx
@@ -16,10 +16,11 @@ const styles = () =>
       display: 'flex',
       flexDirection: 'column',
       gap: '8px',
+      paddingTop: '20px', // leave room for the close icon
     },
     chartSection: {
       paddingTop: '16px', // leave room for the download icons
-      height: '200px',
+      height: '220px',
       width: '400px',
     },
   });
@@ -56,7 +57,7 @@ const PopupPointDataChart = ({ classes }: PopupDatasetChartProps) => {
               : t('Timestamps reflect local time in Cambodia')
           }
           showDownloadIcons
-          iconStyles={{ color: 'white' }}
+          iconStyles={{ color: 'white', marginTop: '20px' }}
         />
       </div>
     </div>

--- a/frontend/src/components/MapView/MapTooltip/PointDataChart/PopupPointDataChart.tsx
+++ b/frontend/src/components/MapView/MapTooltip/PointDataChart/PopupPointDataChart.tsx
@@ -20,7 +20,7 @@ const styles = () =>
     },
     chartSection: {
       paddingTop: '16px', // leave room for the download icons
-      height: '220px',
+      height: '200px',
       width: '400px',
     },
   });

--- a/frontend/src/components/MapView/MapTooltip/index.tsx
+++ b/frontend/src/components/MapView/MapTooltip/index.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useMemo, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Popup } from 'react-mapbox-gl';
 import {
   createStyles,
@@ -8,7 +8,7 @@ import {
   Typography,
   IconButton,
 } from '@material-ui/core';
-import { tooltipSelector } from 'context/tooltipStateSlice';
+import { hidePopup, tooltipSelector } from 'context/tooltipStateSlice';
 import { isEnglishLanguageSelected, useSafeTranslation } from 'i18n';
 import { AdminLevelType } from 'config/types';
 import { appConfig } from 'config';
@@ -72,6 +72,7 @@ const availableAdminLevels: AdminLevelType[] = multiCountry
 interface TooltipProps extends WithStyles<typeof styles> {}
 
 const MapTooltip = ({ classes }: TooltipProps) => {
+  const dispatch = useDispatch();
   const popup = useSelector(tooltipSelector);
   const { i18n } = useSafeTranslation();
   const [popupTitle, setPopupTitle] = useState<string>('');
@@ -117,6 +118,14 @@ const MapTooltip = ({ classes }: TooltipProps) => {
         className={classes.popup}
         style={{ zIndex: 5 }}
       >
+        <IconButton
+          aria-label="close"
+          className={classes.closeButton}
+          onClick={() => dispatch(hidePopup())}
+          size="small"
+        >
+          <FontAwesomeIcon icon={faTimes} />
+        </IconButton>
         <PopupPointDataChart />
       </Popup>
     );

--- a/frontend/src/components/MapView/MapTooltip/index.tsx
+++ b/frontend/src/components/MapView/MapTooltip/index.tsx
@@ -117,7 +117,7 @@ const MapTooltip = ({ classes }: TooltipProps) => {
         className={classes.popup}
         style={{ zIndex: 5 }}
       >
-        <PopupPointDataChart adminLevelsNames={() => [...adminLevelsNames()]} />
+        <PopupPointDataChart />
       </Popup>
     );
   }


### PR DESCRIPTION
### Description

This fixes #1055

Use download icons for EWS charts.
This makes the experience across charts more consistent.
There is more data in the CSV now (it includes the alert thresholds) but the date field only show the time. In addition, the CSV filename is a bit different and only includes the title. I don't think it's an issue but let us know if you would like any of this to change @wadhwamatic 

<img width="582" alt="Screenshot 2024-01-10 at 6 53 57 PM" src="https://github.com/WFP-VAM/prism-app/assets/16843267/406aae1d-faa9-4eff-9585-68f468b552e3">


## How to test the feature:

- [ ] Activate EWS layer
- [ ] Use the download icons on the top right and check the output

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
