### PR TITLE
Speed up various date processing functions; COUNTRY=rbd

### DIFF
--- a/common/src/utils/time.ts
+++ b/common/src/utils/time.ts
@@ -1,5 +1,5 @@
 export function setNoon(date: string): string {
-  return date.split("T")[0] + "T12:00:00Z";
+  return `${date.split("T")[0]}T12:00:00Z`;
 }
 
 export const DEFAULT_DATE_FORMAT = "YYYY-MM-DD";

--- a/common/src/utils/time.ts
+++ b/common/src/utils/time.ts
@@ -1,7 +1,5 @@
-import * as moment from "moment";
-
 export function setNoon(date: string): string {
-  return moment.utc(date.split("T")[0]).set({ hour: 12, minute: 0 }).format();
+  return date.split("T")[0] + "T12:00:00Z";
 }
 
 export const DEFAULT_DATE_FORMAT = "YYYY-MM-DD";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "start": "cross-env EXTEND_ESLINT=true react-scripts start",
     "analyze": "yarn build && npx source-map-explorer 'build/static/js/*.js'",
     "build": "export GIT_HASH=$(git rev-parse --short HEAD) || true && cross-env EXTEND_ESLINT=true react-app-rewired build",
+    "profile:serve": "yarn build --profile && npx serve -s build",
     "test": "cross-env REACT_APP_TESTING=true && react-scripts test",
     "prettier:json-fix": "prettier --write */**.json",
     "prettier:json-check": "prettier --check */**.json",

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineItem/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineItem/index.tsx
@@ -2,7 +2,7 @@ import { WithStyles, createStyles, withStyles } from '@material-ui/core';
 import React, { memo } from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
 import { DateItem, DateRangeType } from 'config/types';
-import { datesAreEqualWithoutTime } from 'utils/date-utils';
+import { binaryFind } from 'utils/date-utils';
 
 const TimelineItem = memo(
   ({
@@ -39,12 +39,13 @@ const TimelineItem = memo(
       <>
         {concatenatedLayers.map(
           (layerDates: DateItem[], layerIndex: number) => {
-            // TODO: fix not really efficient algorithm
-            const matchingDateItemInLayer:
-              | DateItem
-              | undefined = layerDates.find(f =>
-              datesAreEqualWithoutTime(f.displayDate, currentDate.value),
+            const idx = binaryFind<DateItem>(
+              layerDates,
+              new Date(currentDate.value).setHours(0, 0, 0, 0),
+              (i: DateItem) => new Date(i.displayDate).setHours(0, 0, 0, 0),
             );
+            const matchingDateItemInLayer: DateItem | undefined =
+              idx > -1 ? layerDates[idx] : undefined;
 
             if (!matchingDateItemInLayer) {
               return null;

--- a/frontend/src/context/store.ts
+++ b/frontend/src/context/store.ts
@@ -38,7 +38,15 @@ export const store = configureStore({
     // serialize the state
     serializableCheck: false,
     immutableCheck: {
-      ignoredPaths: ['mapState.layersData', 'analysisResultState.result'],
+      // do not check the following state branches for accidental
+      // mutations. This saves a lot of time in dev mode (but has no
+      // impact on production builds).
+      ignoredPaths: [
+        'mapState.boundaryRelations',
+        'mapState.layersData',
+        'analysisResultState.result',
+        'serverState.availableDates',
+      ],
     },
   }).concat(errorToNotificationMiddleware),
 });

--- a/frontend/src/utils/date-utils.test.ts
+++ b/frontend/src/utils/date-utils.test.ts
@@ -1,4 +1,4 @@
-import { generateDateItemsRange, StartEndDate } from './date-utils';
+import { binaryFind, generateDateItemsRange, StartEndDate } from './date-utils';
 
 describe('Test buildDateItemsFromStartEndDates', () => {
   test('should return empty', () => {
@@ -42,5 +42,28 @@ describe('Test buildDateItemsFromStartEndDates', () => {
         isEndDate: true,
       },
     ]);
+  });
+});
+
+describe('Binary search in ordered arrays of timestamps', () => {
+  test('should return the index of found element', () => {
+    const arr = [
+      1701160000000,
+      1702160000000,
+      1703160000000,
+      1703460000000,
+      1705160000000,
+      1705395000000,
+      1706160000000,
+      1715160000000,
+      1725160000000,
+      1735160000000,
+    ];
+    arr.forEach((elem, i) => {
+      const idx = binaryFind<number>(arr, elem, x => x);
+      expect(idx).toEqual(i);
+    });
+    // look for missing value
+    expect(binaryFind<number>(arr, 42, x => x)).toEqual(-1);
   });
 });

--- a/frontend/src/utils/date-utils.ts
+++ b/frontend/src/utils/date-utils.ts
@@ -10,7 +10,13 @@ export const datesAreEqualWithoutTime = (
   date1: number | Date,
   date2: number | Date,
 ): boolean => {
-  return new Date(date1).toDateString() === new Date(date2).toDateString();
+  const d1 = new Date(date1);
+  const d2 = new Date(date2);
+  return (
+    d1.getDate() === d2.getDate() &&
+    d1.getMonth() === d2.getMonth() &&
+    d1.getFullYear() === d2.getFullYear()
+  );
 };
 
 export const generateDatesRange = (

--- a/frontend/src/utils/date-utils.ts
+++ b/frontend/src/utils/date-utils.ts
@@ -10,13 +10,9 @@ export const datesAreEqualWithoutTime = (
   date1: number | Date,
   date2: number | Date,
 ): boolean => {
-  const d1 = new Date(date1);
-  const d2 = new Date(date2);
-  return (
-    d1.getDate() === d2.getDate() &&
-    d1.getMonth() === d2.getMonth() &&
-    d1.getFullYear() === d2.getFullYear()
-  );
+  const d1 = new Date(date1).setHours(0, 0, 0, 0);
+  const d2 = new Date(date2).setHours(0, 0, 0, 0);
+  return d1 === d2;
 };
 
 export const generateDatesRange = (

--- a/frontend/src/utils/date-utils.ts
+++ b/frontend/src/utils/date-utils.ts
@@ -51,3 +51,42 @@ export const generateDateItemsRange = (
     return dateItems;
   });
 };
+
+// search array of timestamps for a given timestamp, using
+// the binary search algorithm.
+// The array MUST be sorted in ascending order.
+// Use callback to extract timestamp values from array items.
+export function binaryFind<T extends any>(
+  arr: T[],
+  ts: number,
+  cb: (x: T) => number,
+): number {
+  let left = 0;
+  let right = arr.length - 1;
+  while (left <= right) {
+    const testIdx = Math.floor((left + right) / 2);
+    const val = cb(arr[testIdx]);
+    if (val < ts) {
+      // eslint-disable-next-line fp/no-mutation
+      left = testIdx + 1;
+    } else if (val > ts) {
+      // eslint-disable-next-line fp/no-mutation
+      right = testIdx - 1;
+    } else {
+      return testIdx;
+    }
+  }
+  return -1;
+}
+
+// check if an array includes the given value using
+// the binary search algorithm.
+// The array MUST be sorted in ascending order.
+// Use callback to extract timestamp values from array items.
+export function binaryIncludes<T extends any>(
+  arry: T[],
+  timestamp: number,
+  callback: (x: T) => number,
+): boolean {
+  return binaryFind(arry, timestamp, callback) > -1;
+}

--- a/frontend/src/utils/layers-utils.tsx
+++ b/frontend/src/utils/layers-utils.tsx
@@ -8,6 +8,7 @@ import {
   LayerKey,
   LayerType,
   isMainLayer,
+  DateItem,
 } from 'config/types';
 import { LayerDefinitions, getBoundaryLayerSingleton } from 'config/utils';
 import { LayerData } from 'context/layers/layer-data';
@@ -35,7 +36,7 @@ import {
   getPossibleDatesForLayer,
 } from 'utils/server-utils';
 import { UrlLayerKey, getUrlKey, useUrlHistory } from 'utils/url-utils';
-import { datesAreEqualWithoutTime } from './date-utils';
+import { datesAreEqualWithoutTime, binaryIncludes } from './date-utils';
 
 const dateSupportLayerTypes: Array<LayerType['type']> = [
   'impact',
@@ -376,12 +377,11 @@ const useLayers = () => {
 
   const possibleDatesForLayerIncludeMomentSelectedDate = useCallback(
     (layer: DateCompatibleLayer, momentSelectedDate: moment.Moment) => {
-      // we convert to date strings, so hh:ss is irrelevant
-      return getPossibleDatesForLayer(layer, serverAvailableDates)
-        .map(dateItem =>
-          new Date(dateItem.displayDate).toISOString().slice(0, 10),
-        )
-        .includes(momentSelectedDate.format(DEFAULT_DATE_FORMAT));
+      return binaryIncludes<DateItem>(
+        getPossibleDatesForLayer(layer, serverAvailableDates),
+        momentSelectedDate.set({ hour: 12, minute: 0 }).valueOf(),
+        x => new Date(x.displayDate).setHours(12, 0, 0, 0),
+      );
     },
     [serverAvailableDates],
   );

--- a/frontend/src/utils/layers-utils.tsx
+++ b/frontend/src/utils/layers-utils.tsx
@@ -419,7 +419,6 @@ const useLayers = () => {
         console.warn(
           'closest dates is the same as selected date, not updating url',
         );
-        // updateHistory('date', closestDate.format(DEFAULT_DATE_FORMAT));
       } else {
         updateHistory('date', closestDate.format(DEFAULT_DATE_FORMAT));
       }

--- a/frontend/src/utils/layers-utils.tsx
+++ b/frontend/src/utils/layers-utils.tsx
@@ -129,7 +129,7 @@ const useLayers = () => {
         .map(layer => getPossibleDatesForLayer(layer, serverAvailableDates))
         .filter(value => value) // null check
         .flat()
-        .map(value => moment(value.displayDate).format(DEFAULT_DATE_FORMAT)),
+        .map(value => new Date(value.displayDate).toISOString().slice(0, 10)),
     );
   }, [selectedLayersWithDateSupport, serverAvailableDates]);
 
@@ -379,7 +379,7 @@ const useLayers = () => {
       // we convert to date strings, so hh:ss is irrelevant
       return getPossibleDatesForLayer(layer, serverAvailableDates)
         .map(dateItem =>
-          moment(dateItem.displayDate).format(DEFAULT_DATE_FORMAT),
+          new Date(dateItem.displayDate).toISOString().slice(0, 10),
         )
         .includes(momentSelectedDate.format(DEFAULT_DATE_FORMAT));
     },

--- a/frontend/src/utils/layers-utils.tsx
+++ b/frontend/src/utils/layers-utils.tsx
@@ -35,6 +35,7 @@ import {
   getPossibleDatesForLayer,
 } from 'utils/server-utils';
 import { UrlLayerKey, getUrlKey, useUrlHistory } from 'utils/url-utils';
+import { datesAreEqualWithoutTime } from './date-utils';
 
 const dateSupportLayerTypes: Array<LayerType['type']> = [
   'impact',
@@ -408,7 +409,20 @@ const useLayers = () => {
 
       const closestDate = findClosestDate(selectedDate, selectedLayerDates);
 
-      updateHistory('date', closestDate.format(DEFAULT_DATE_FORMAT));
+      if (
+        datesAreEqualWithoutTime(
+          momentSelectedDate.valueOf(),
+          closestDate.valueOf(),
+        )
+      ) {
+        console.warn({ closestDate });
+        console.warn(
+          'closest dates is the same as selected date, not updating url',
+        );
+        // updateHistory('date', closestDate.format(DEFAULT_DATE_FORMAT));
+      } else {
+        updateHistory('date', closestDate.format(DEFAULT_DATE_FORMAT));
+      }
 
       dispatch(
         addNotification({

--- a/frontend/src/utils/server-utils.test.ts
+++ b/frontend/src/utils/server-utils.test.ts
@@ -1,0 +1,110 @@
+import { DatesPropagation } from 'config/types';
+import { generateIntermediateDateItemFromValidity } from './server-utils';
+
+describe('Test generateIntermediateDateItemFromValidity', () => {
+  test('should return correct dates with forward propagation', () => {
+    const layer = {
+      name: 'myd11a2_taa_dekad',
+      dates: [1701432000000, 1702296000000, 1703160000000],
+      validity: {
+        days: 10,
+        mode: DatesPropagation.FORWARD,
+      },
+    };
+
+    const output = generateIntermediateDateItemFromValidity(layer);
+    expect(output).toEqual([
+      {
+        displayDate: 1701428400000,
+        queryDate: 1701428400000,
+        isStartDate: true,
+        isEndDate: false,
+      },
+      { displayDate: 1701514800000, queryDate: 1701428400000 },
+      { displayDate: 1701601200000, queryDate: 1701428400000 },
+      { displayDate: 1701687600000, queryDate: 1701428400000 },
+      { displayDate: 1701774000000, queryDate: 1701428400000 },
+      { displayDate: 1701860400000, queryDate: 1701428400000 },
+      { displayDate: 1701946800000, queryDate: 1701428400000 },
+      { displayDate: 1702033200000, queryDate: 1701428400000 },
+      { displayDate: 1702119600000, queryDate: 1701428400000 },
+      { displayDate: 1702206000000, queryDate: 1701428400000 },
+      {
+        displayDate: 1702292400000,
+        queryDate: 1702292400000,
+        isStartDate: true,
+        isEndDate: false,
+      },
+      { displayDate: 1702378800000, queryDate: 1702292400000 },
+      { displayDate: 1702465200000, queryDate: 1702292400000 },
+      { displayDate: 1702551600000, queryDate: 1702292400000 },
+      { displayDate: 1702638000000, queryDate: 1702292400000 },
+      { displayDate: 1702724400000, queryDate: 1702292400000 },
+      { displayDate: 1702810800000, queryDate: 1702292400000 },
+      { displayDate: 1702897200000, queryDate: 1702292400000 },
+      { displayDate: 1702983600000, queryDate: 1702292400000 },
+      { displayDate: 1703070000000, queryDate: 1702292400000 },
+      {
+        displayDate: 1703156400000,
+        queryDate: 1703156400000,
+        isStartDate: true,
+        isEndDate: false,
+      },
+      { displayDate: 1703242800000, queryDate: 1703156400000 },
+      { displayDate: 1703329200000, queryDate: 1703156400000 },
+      { displayDate: 1703415600000, queryDate: 1703156400000 },
+      { displayDate: 1703502000000, queryDate: 1703156400000 },
+      { displayDate: 1703588400000, queryDate: 1703156400000 },
+      { displayDate: 1703674800000, queryDate: 1703156400000 },
+      { displayDate: 1703761200000, queryDate: 1703156400000 },
+      { displayDate: 1703847600000, queryDate: 1703156400000 },
+      { displayDate: 1703934000000, queryDate: 1703156400000 },
+      { displayDate: 1704020400000, queryDate: 1703156400000 },
+    ]);
+  });
+
+  test('should return correct dates with backwards propagation', () => {
+    const layer = {
+      name: 'myd11a2_taa_dekad',
+      dates: [1701432000000, 1702296000000],
+      validity: {
+        days: 10,
+        mode: DatesPropagation.BACKWARD,
+      },
+    };
+    const output = generateIntermediateDateItemFromValidity(layer);
+    expect(output).toEqual([
+      { displayDate: 1700564400000, queryDate: 1701428400000 },
+      { displayDate: 1700650800000, queryDate: 1701428400000 },
+      { displayDate: 1700737200000, queryDate: 1701428400000 },
+      { displayDate: 1700823600000, queryDate: 1701428400000 },
+      { displayDate: 1700910000000, queryDate: 1701428400000 },
+      { displayDate: 1700996400000, queryDate: 1701428400000 },
+      { displayDate: 1701082800000, queryDate: 1701428400000 },
+      { displayDate: 1701169200000, queryDate: 1701428400000 },
+      { displayDate: 1701255600000, queryDate: 1701428400000 },
+      { displayDate: 1701342000000, queryDate: 1701428400000 },
+      {
+        displayDate: 1701428400000,
+        queryDate: 1701428400000,
+        isStartDate: false,
+        isEndDate: true,
+      },
+      { displayDate: 1701514800000, queryDate: 1702292400000 },
+      { displayDate: 1701601200000, queryDate: 1702292400000 },
+      { displayDate: 1701687600000, queryDate: 1702292400000 },
+      { displayDate: 1701774000000, queryDate: 1702292400000 },
+      { displayDate: 1701860400000, queryDate: 1702292400000 },
+      { displayDate: 1701946800000, queryDate: 1702292400000 },
+      { displayDate: 1702033200000, queryDate: 1702292400000 },
+      { displayDate: 1702119600000, queryDate: 1702292400000 },
+      { displayDate: 1702206000000, queryDate: 1702292400000 },
+      {
+        displayDate: 1702292400000,
+        queryDate: 1702292400000,
+        isStartDate: false,
+        isEndDate: true,
+      },
+    ]);
+  });
+});

--- a/frontend/src/utils/server-utils.test.ts
+++ b/frontend/src/utils/server-utils.test.ts
@@ -1,11 +1,18 @@
 import { DatesPropagation } from 'config/types';
 import { generateIntermediateDateItemFromValidity } from './server-utils';
 
+// NOTE: all timestamps are created in the LOCAL timezone (as per js docs), so that
+// these tests should pass for any TZ.
+
 describe('Test generateIntermediateDateItemFromValidity', () => {
   test('should return correct dates with forward propagation', () => {
     const layer = {
       name: 'myd11a2_taa_dekad',
-      dates: [1701432000000, 1702296000000, 1703160000000],
+      dates: [
+        new Date('2023-12-01').setHours(12, 0),
+        new Date('2023-12-11').setHours(12, 0),
+        new Date('2023-12-21').setHours(12, 0),
+      ],
       validity: {
         days: 10,
         mode: DatesPropagation.FORWARD,
@@ -15,58 +22,145 @@ describe('Test generateIntermediateDateItemFromValidity', () => {
     const output = generateIntermediateDateItemFromValidity(layer);
     expect(output).toEqual([
       {
-        displayDate: 1701428400000,
-        queryDate: 1701428400000,
+        displayDate: new Date('2023-12-01').setHours(12, 0),
+        queryDate: layer.dates[0],
         isStartDate: true,
         isEndDate: false,
       },
-      { displayDate: 1701514800000, queryDate: 1701428400000 },
-      { displayDate: 1701601200000, queryDate: 1701428400000 },
-      { displayDate: 1701687600000, queryDate: 1701428400000 },
-      { displayDate: 1701774000000, queryDate: 1701428400000 },
-      { displayDate: 1701860400000, queryDate: 1701428400000 },
-      { displayDate: 1701946800000, queryDate: 1701428400000 },
-      { displayDate: 1702033200000, queryDate: 1701428400000 },
-      { displayDate: 1702119600000, queryDate: 1701428400000 },
-      { displayDate: 1702206000000, queryDate: 1701428400000 },
       {
-        displayDate: 1702292400000,
-        queryDate: 1702292400000,
-        isStartDate: true,
-        isEndDate: false,
+        displayDate: new Date('2023-12-02').setHours(12, 0),
+        queryDate: layer.dates[0],
       },
-      { displayDate: 1702378800000, queryDate: 1702292400000 },
-      { displayDate: 1702465200000, queryDate: 1702292400000 },
-      { displayDate: 1702551600000, queryDate: 1702292400000 },
-      { displayDate: 1702638000000, queryDate: 1702292400000 },
-      { displayDate: 1702724400000, queryDate: 1702292400000 },
-      { displayDate: 1702810800000, queryDate: 1702292400000 },
-      { displayDate: 1702897200000, queryDate: 1702292400000 },
-      { displayDate: 1702983600000, queryDate: 1702292400000 },
-      { displayDate: 1703070000000, queryDate: 1702292400000 },
       {
-        displayDate: 1703156400000,
-        queryDate: 1703156400000,
+        displayDate: new Date('2023-12-03').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-12-04').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-12-05').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-12-06').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-12-07').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-12-08').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-12-09').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-12-10').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-12-11').setHours(12, 0),
+        queryDate: layer.dates[1],
         isStartDate: true,
         isEndDate: false,
       },
-      { displayDate: 1703242800000, queryDate: 1703156400000 },
-      { displayDate: 1703329200000, queryDate: 1703156400000 },
-      { displayDate: 1703415600000, queryDate: 1703156400000 },
-      { displayDate: 1703502000000, queryDate: 1703156400000 },
-      { displayDate: 1703588400000, queryDate: 1703156400000 },
-      { displayDate: 1703674800000, queryDate: 1703156400000 },
-      { displayDate: 1703761200000, queryDate: 1703156400000 },
-      { displayDate: 1703847600000, queryDate: 1703156400000 },
-      { displayDate: 1703934000000, queryDate: 1703156400000 },
-      { displayDate: 1704020400000, queryDate: 1703156400000 },
+      {
+        displayDate: new Date('2023-12-12').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-13').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-14').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-15').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-16').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-17').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-18').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-19').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-20').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-21').setHours(12, 0),
+        queryDate: layer.dates[2],
+        isStartDate: true,
+        isEndDate: false,
+      },
+      {
+        displayDate: new Date('2023-12-22').setHours(12, 0),
+        queryDate: layer.dates[2],
+      },
+      {
+        displayDate: new Date('2023-12-23').setHours(12, 0),
+        queryDate: layer.dates[2],
+      },
+      {
+        displayDate: new Date('2023-12-24').setHours(12, 0),
+        queryDate: layer.dates[2],
+      },
+      {
+        displayDate: new Date('2023-12-25').setHours(12, 0),
+        queryDate: layer.dates[2],
+      },
+      {
+        displayDate: new Date('2023-12-26').setHours(12, 0),
+        queryDate: layer.dates[2],
+      },
+      {
+        displayDate: new Date('2023-12-27').setHours(12, 0),
+        queryDate: layer.dates[2],
+      },
+      {
+        displayDate: new Date('2023-12-28').setHours(12, 0),
+        queryDate: layer.dates[2],
+      },
+      {
+        displayDate: new Date('2023-12-29').setHours(12, 0),
+        queryDate: layer.dates[2],
+      },
+      {
+        displayDate: new Date('2023-12-30').setHours(12, 0),
+        queryDate: layer.dates[2],
+      },
+      {
+        displayDate: new Date('2023-12-31').setHours(12, 0),
+        queryDate: layer.dates[2],
+      },
     ]);
   });
 
   test('should return correct dates with backwards propagation', () => {
     const layer = {
       name: 'myd11a2_taa_dekad',
-      dates: [1701432000000, 1702296000000],
+      dates: [
+        new Date('2023-12-01').setHours(12, 0),
+        new Date('2023-12-11').setHours(12, 0),
+      ],
       validity: {
         days: 10,
         mode: DatesPropagation.BACKWARD,
@@ -74,34 +168,91 @@ describe('Test generateIntermediateDateItemFromValidity', () => {
     };
     const output = generateIntermediateDateItemFromValidity(layer);
     expect(output).toEqual([
-      { displayDate: 1700564400000, queryDate: 1701428400000 },
-      { displayDate: 1700650800000, queryDate: 1701428400000 },
-      { displayDate: 1700737200000, queryDate: 1701428400000 },
-      { displayDate: 1700823600000, queryDate: 1701428400000 },
-      { displayDate: 1700910000000, queryDate: 1701428400000 },
-      { displayDate: 1700996400000, queryDate: 1701428400000 },
-      { displayDate: 1701082800000, queryDate: 1701428400000 },
-      { displayDate: 1701169200000, queryDate: 1701428400000 },
-      { displayDate: 1701255600000, queryDate: 1701428400000 },
-      { displayDate: 1701342000000, queryDate: 1701428400000 },
       {
-        displayDate: 1701428400000,
-        queryDate: 1701428400000,
+        displayDate: new Date('2023-11-21').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-11-22').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-11-23').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-11-24').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-11-25').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-11-26').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-11-27').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-11-28').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-11-29').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-11-30').setHours(12, 0),
+        queryDate: layer.dates[0],
+      },
+      {
+        displayDate: new Date('2023-12-01').setHours(12, 0),
+        queryDate: layer.dates[0],
         isStartDate: false,
         isEndDate: true,
       },
-      { displayDate: 1701514800000, queryDate: 1702292400000 },
-      { displayDate: 1701601200000, queryDate: 1702292400000 },
-      { displayDate: 1701687600000, queryDate: 1702292400000 },
-      { displayDate: 1701774000000, queryDate: 1702292400000 },
-      { displayDate: 1701860400000, queryDate: 1702292400000 },
-      { displayDate: 1701946800000, queryDate: 1702292400000 },
-      { displayDate: 1702033200000, queryDate: 1702292400000 },
-      { displayDate: 1702119600000, queryDate: 1702292400000 },
-      { displayDate: 1702206000000, queryDate: 1702292400000 },
       {
-        displayDate: 1702292400000,
-        queryDate: 1702292400000,
+        displayDate: new Date('2023-12-02').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-03').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-04').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-05').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-06').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-07').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-08').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-09').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-10').setHours(12, 0),
+        queryDate: layer.dates[1],
+      },
+      {
+        displayDate: new Date('2023-12-11').setHours(12, 0),
+        queryDate: layer.dates[1],
         isStartDate: false,
         isEndDate: true,
       },

--- a/frontend/src/utils/server-utils.ts
+++ b/frontend/src/utils/server-utils.ts
@@ -274,7 +274,7 @@ async function generateIntermediateDateItemFromDataFile(
   return generateDateItemsRange(rangesWithoutMissing);
 }
 
-function generateIntermediateDateItemFromValidity(layer: ValidityLayer) {
+export function generateIntermediateDateItemFromValidity(layer: ValidityLayer) {
   const { dates } = layer;
   const { days, mode } = layer.validity;
 

--- a/frontend/src/utils/server-utils.ts
+++ b/frontend/src/utils/server-utils.ts
@@ -215,9 +215,10 @@ const getStaticRasterDataCoverage = (layer: StaticRasterLayerProps) => {
  * @return DateItem
  */
 const generateDefaultDateItem = (date: number, baseItem?: Object): DateItem => {
+  const newDate = moment(date).set({ hour: 12, minute: 0 }).valueOf()
   const r = {
-    displayDate: date,
-    queryDate: date,
+    displayDate: newDate,
+    queryDate: newDate,
   };
   if (baseItem) {
     return {

--- a/frontend/src/utils/server-utils.ts
+++ b/frontend/src/utils/server-utils.ts
@@ -298,8 +298,11 @@ function generateIntermediateDateItemFromValidity(layer: ValidityLayer) {
   );
 
   // only calculate validity for dates that are less than 5 years old
+  const fiveYearsInMs = 5 * 365 * 24 * 60 * 60 * 1000;
+  const earliestDate = Date.now() - fiveYearsInMs;
+
   const dateItemsWithValidity = momentDates
-    .filter(date => moment().diff(date, 'years') < 5)
+    .filter(date => date.valueOf() > earliestDate)
     .reduce((acc: DateItem[], momentDate) => {
       // We create the start and the end date for every moment date
       let startDate = momentDate.clone();

--- a/frontend/src/utils/server-utils.ts
+++ b/frontend/src/utils/server-utils.ts
@@ -274,15 +274,10 @@ async function generateIntermediateDateItemFromDataFile(
 }
 
 function generateIntermediateDateItemFromValidity(layer: ValidityLayer) {
-  console.log('generateIntermediateDateItemFromValidity', layer);
-
-  const { dates } = layer; // number[] about 700-1550 items long, epoch
+  const { dates } = layer;
   const { days, mode } = layer.validity;
 
-  // Convert the dates to moment dates
-  const momentDates = Array.prototype.sort
-    .call(dates)
-    .map(d => moment(d).set({ hour: 12, minute: 0 }));
+  const sortedDates = Array.prototype.sort.call(dates);
 
   // Generate first DateItem[] from dates array.
   const baseItem = layer.validity
@@ -293,16 +288,17 @@ function generateIntermediateDateItemFromValidity(layer: ValidityLayer) {
           mode === DatesPropagation.BACKWARD || mode === DatesPropagation.BOTH,
       }
     : {};
-  const dateItemsDefault = momentDates.map(momentDate =>
-    generateDefaultDateItem(momentDate.valueOf(), baseItem),
+  const dateItemsDefault = sortedDates.map(sortedDate =>
+    generateDefaultDateItem(sortedDate, baseItem),
   );
 
   // only calculate validity for dates that are less than 5 years old
   const fiveYearsInMs = 5 * 365 * 24 * 60 * 60 * 1000;
   const earliestDate = Date.now() - fiveYearsInMs;
 
-  const dateItemsWithValidity = momentDates
-    .filter(date => date.valueOf() > earliestDate)
+  const dateItemsWithValidity = sortedDates
+    .filter(date => date > earliestDate)
+    .map(d => moment(d).set({ hour: 12, minute: 0 }))
     .reduce((acc: DateItem[], momentDate) => {
       // We create the start and the end date for every moment date
       let startDate = momentDate.clone();

--- a/frontend/src/utils/server-utils.ts
+++ b/frontend/src/utils/server-utils.ts
@@ -215,7 +215,7 @@ const getStaticRasterDataCoverage = (layer: StaticRasterLayerProps) => {
  * @return DateItem
  */
 const generateDefaultDateItem = (date: number, baseItem?: Object): DateItem => {
-  const newDate = moment(date).set({ hour: 12, minute: 0 }).valueOf();
+  const newDate = new Date(date).setHours(12, 0, 0);
   const r = {
     displayDate: newDate,
     queryDate: newDate,

--- a/frontend/src/utils/server-utils.ts
+++ b/frontend/src/utils/server-utils.ts
@@ -30,6 +30,7 @@ import {
   datesAreEqualWithoutTime,
   generateDateItemsRange,
   generateDatesRange,
+  binaryIncludes,
 } from './date-utils';
 import { LocalError } from './error-utils';
 import { createEWSDatesArray } from './ews-utils';
@@ -331,7 +332,7 @@ export function generateIntermediateDateItemFromValidity(layer: ValidityLayer) {
 
       // We filter the dates that don't include the displayDate of the previous item array
       const filteredDateItems = acc.filter(
-        dateItem => !daysToAdd.includes(dateItem.displayDate),
+        dateItem => !binaryIncludes(daysToAdd, dateItem.displayDate, x => x),
       );
 
       return [...filteredDateItems, ...dateItemsToAdd];

--- a/frontend/src/utils/server-utils.ts
+++ b/frontend/src/utils/server-utils.ts
@@ -215,7 +215,7 @@ const getStaticRasterDataCoverage = (layer: StaticRasterLayerProps) => {
  * @return DateItem
  */
 const generateDefaultDateItem = (date: number, baseItem?: Object): DateItem => {
-  const newDate = moment(date).set({ hour: 12, minute: 0 }).valueOf()
+  const newDate = moment(date).set({ hour: 12, minute: 0 }).valueOf();
   const r = {
     displayDate: newDate,
     queryDate: newDate,


### PR DESCRIPTION
### Description

This fixes (partially) #467 .

I used firefox profiler to identify CPU heavy functions in the code when loading the app for RBD, and tried to speed up the most time consuming ones. Speedups range from 25% up to 10-20x.

## How to test the feature:

- [ ] Build the app with `REACT_APP_COUNTRY=rbd yarn build --profile` (to prevent webpack from  mangling function names, so that the profiler output is usable)
- [ ] Serve it locally with `npx serve -s build`
- [ ] Load the page with the profiler active (for firefox: https://profiler.firefox.com/docs/)
- [ ] explore the flame graph or stack chart tabs for major time consumers (wider blocks) to see time differences before/after

I suggest reviewing the PR commit by commit, as each of them does one thing, it will make more sense than trying to look at everything together.

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?
