### PR TITLE
Register onclick with map.on

### DIFF
--- a/frontend/src/components/MapView/Layers/AdminLevelDataLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/AdminLevelDataLayer/index.tsx
@@ -20,6 +20,7 @@ import {
   firstBoundaryOnView,
   getLayerMapId,
   isLayerOnView,
+  useMapCallback,
 } from 'utils/map-utils';
 import { fillPaintData } from 'components/MapView/Layers/styles';
 import { availableDatesSelector } from 'context/serverStateSlice';
@@ -30,7 +31,6 @@ import {
 } from 'components/MapView/Layers/layer-utils';
 import { convertSvgToPngBase64Image, getSVGShape } from 'utils/image-utils';
 import { FillLayerSpecification } from 'maplibre-gl';
-import { useSafeTranslation } from 'i18n';
 
 const onClick = ({
   layer,
@@ -52,11 +52,11 @@ const AdminLevelDataLayers = ({
   const dispatch = useDispatch();
   const map = useSelector(mapSelector);
   const serverAvailableDates = useSelector(availableDatesSelector);
-  const { t } = useSafeTranslation();
 
   const boundaryId = layer.boundary || firstBoundaryOnView(map);
 
   const selectedDate = useDefaultDate(layer.id);
+  useMapCallback('click', getLayerMapId(layer.id), layer, onClick);
   const layerAvailableDates = serverAvailableDates[layer.id];
   const queryDate = getRequestDate(layerAvailableDates, selectedDate);
 
@@ -109,21 +109,6 @@ const AdminLevelDataLayers = ({
     }
     addFillPatternImagesInMap();
   }, [addFillPatternImagesInMap, layer.id, map]);
-
-  useEffect(() => {
-    if (!map) {
-      return () => {};
-    }
-
-    map.on('click', getLayerMapId(layer.id), onClick({ dispatch, layer, t }));
-    return () => {
-      map.off(
-        'click',
-        getLayerMapId(layer.id),
-        onClick({ dispatch, layer, t }),
-      );
-    };
-  }, [dispatch, layer, layer.id, map, t]);
 
   useEffect(() => {
     // before loading layer check if it has unique boundary?

--- a/frontend/src/components/MapView/Layers/AdminLevelDataLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/AdminLevelDataLayer/index.tsx
@@ -30,12 +30,9 @@ import {
 } from 'components/MapView/Layers/layer-utils';
 import { convertSvgToPngBase64Image, getSVGShape } from 'utils/image-utils';
 import { FillLayerSpecification } from 'maplibre-gl';
+import { useSafeTranslation } from 'i18n';
 
-export const getLayersIds = (layer: AdminLevelDataLayerProps) => [
-  getLayerMapId(layer.id),
-];
-
-export const onClick = ({
+const onClick = ({
   layer,
   dispatch,
   t,
@@ -55,6 +52,7 @@ const AdminLevelDataLayers = ({
   const dispatch = useDispatch();
   const map = useSelector(mapSelector);
   const serverAvailableDates = useSelector(availableDatesSelector);
+  const { t } = useSafeTranslation();
 
   const boundaryId = layer.boundary || firstBoundaryOnView(map);
 
@@ -111,6 +109,21 @@ const AdminLevelDataLayers = ({
     }
     addFillPatternImagesInMap();
   }, [addFillPatternImagesInMap, layer.id, map]);
+
+  useEffect(() => {
+    if (!map) {
+      return () => {};
+    }
+
+    map.on('click', getLayerMapId(layer.id), onClick({ dispatch, layer, t }));
+    return () => {
+      map.off(
+        'click',
+        getLayerMapId(layer.id),
+        onClick({ dispatch, layer, t }),
+      );
+    };
+  }, [dispatch, layer, layer.id, map, t]);
 
   useEffect(() => {
     // before loading layer check if it has unique boundary?

--- a/frontend/src/components/MapView/Layers/AnalysisLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/AnalysisLayer/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { get } from 'lodash';
 import { Layer, Source } from 'react-map-gl/maplibre';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { addPopupData } from 'context/tooltipStateSlice';
 import {
   analysisResultSelector,
@@ -21,11 +21,13 @@ import { formatIntersectPercentageAttribute } from 'components/MapView/utils';
 import { Dispatch } from 'redux';
 import { FillLayerSpecification, MapLayerMouseEvent } from 'maplibre-gl';
 import { TFunction } from 'i18next';
-import { getLayerMapId } from 'utils/map-utils';
+import { getEvtCoords, getLayerMapId } from 'utils/map-utils';
+import { mapSelector } from 'context/mapStateSlice/selectors';
+import { useSafeTranslation } from 'i18n';
 
 export const layerId = getLayerMapId('analysis');
 
-export const onClick = ({
+const onClick = ({
   analysisData,
   dispatch,
   t,
@@ -34,7 +36,7 @@ export const onClick = ({
   dispatch: Dispatch;
   t: TFunction;
 }) => (evt: MapLayerMouseEvent) => {
-  const coordinates = [evt.lngLat.lng, evt.lngLat.lat];
+  const coordinates = getEvtCoords(evt);
 
   if (!analysisData) {
     return;
@@ -147,7 +149,22 @@ function AnalysisLayer({ before }: { before?: string }) {
   // TODO maybe in the future we can try add this to LayerType so we don't need exclusive code in Legends and MapView to make this display correctly
   // Currently it is quite difficult due to how JSON focused the typing is. We would have to refactor it to also accept layers generated on-the-spot
   const analysisData = useSelector(analysisResultSelector);
+  const dispatch = useDispatch();
+  const map = useSelector(mapSelector);
+  const { t } = useSafeTranslation();
   const isAnalysisLayerActive = useSelector(isAnalysisLayerActiveSelector);
+
+  React.useEffect(() => {
+    if (!map) {
+      return () => {};
+    }
+
+    map.on('click', layerId, onClick({ dispatch, analysisData, t }));
+
+    return () => {
+      map.off('click', layerId, onClick({ dispatch, analysisData, t }));
+    };
+  }, [analysisData, dispatch, map, t]);
 
   if (!analysisData || !isAnalysisLayerActive) {
     return null;

--- a/frontend/src/components/MapView/Layers/ImpactLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/ImpactLayer/index.tsx
@@ -22,7 +22,7 @@ import {
   LineLayerSpecification,
   MapLayerMouseEvent,
 } from 'maplibre-gl';
-import { getEvtCoords, getLayerMapId } from 'utils/map-utils';
+import { getEvtCoords, getLayerMapId, useMapCallback } from 'utils/map-utils';
 
 const linePaint: LineLayerSpecification['paint'] = {
   'line-color': 'grey',
@@ -92,20 +92,7 @@ const ImpactLayer = ({ classes, layer, before }: ComponentProps) => {
   const dispatch = useDispatch();
   const { t } = useSafeTranslation();
 
-  useEffect(() => {
-    if (!map) {
-      return () => {};
-    }
-
-    map.on('click', getLayerMapId(layer.id), onClick({ dispatch, layer, t }));
-    return () => {
-      map.off(
-        'click',
-        getLayerMapId(layer.id),
-        onClick({ dispatch, layer, t }),
-      );
-    };
-  }, [dispatch, layer, layer.id, map, t]);
+  useMapCallback('click', getLayerMapId(layer.id), layer, onClick);
 
   const extent: Extent = getExtent(map);
   useEffect(() => {

--- a/frontend/src/components/MapView/Layers/PointDataLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/PointDataLayer/index.tsx
@@ -14,10 +14,7 @@ import {
   availableDatesSelector,
 } from 'context/serverStateSlice';
 import { LayerData, loadLayerData } from 'context/layers/layer-data';
-import {
-  layerDataSelector,
-  mapSelector,
-} from 'context/mapStateSlice/selectors';
+import { layerDataSelector } from 'context/mapStateSlice/selectors';
 import { removeLayerData } from 'context/mapStateSlice';
 import { addNotification } from 'context/notificationStateSlice';
 import { useDefaultDate } from 'utils/useDefaultDate';
@@ -36,8 +33,7 @@ import {
   FillLayerSpecification,
   MapLayerMouseEvent,
 } from 'maplibre-gl';
-import { getLayerMapId } from 'utils/map-utils';
-import { useSafeTranslation } from 'i18n';
+import { getLayerMapId, useMapCallback } from 'utils/map-utils';
 
 const onClick = ({
   layer,
@@ -67,12 +63,14 @@ const onClick = ({
 
 // Point Data, takes any GeoJSON of points and shows it.
 const PointDataLayer = ({ layer, before }: LayersProps) => {
+  const layerId = getLayerMapId(layer.id);
+
   const selectedDate = useDefaultDate(layer.id);
   const serverAvailableDates = useSelector(availableDatesSelector);
   const layerAvailableDates = serverAvailableDates[layer.id];
   const userAuth = useSelector(userAuthSelector);
-  const map = useSelector(mapSelector);
-  const { t } = useSafeTranslation();
+
+  useMapCallback('click', layerId, layer, onClick);
 
   const queryDate = getRequestDate(layerAvailableDates, selectedDate);
 
@@ -88,19 +86,6 @@ const PointDataLayer = ({ layer, before }: LayersProps) => {
 
   const { data } = layerData || {};
   const { features } = data || {};
-
-  const layerId = getLayerMapId(layer.id);
-
-  useEffect(() => {
-    if (!map) {
-      return () => {};
-    }
-
-    map.on('click', layerId, onClick({ dispatch, layer, t }));
-    return () => {
-      map.off('click', layerId, onClick({ dispatch, layer, t }));
-    };
-  }, [dispatch, layer, layer.id, layerId, map, t]);
 
   useEffect(() => {
     if (layer.authRequired && !userAuth) {

--- a/frontend/src/components/MapView/Layers/layer-utils.tsx
+++ b/frontend/src/components/MapView/Layers/layer-utils.tsx
@@ -13,7 +13,7 @@ import { getRoundedData } from 'utils/data-utils';
 import { i18nTranslator } from 'i18n';
 import { getFeatureInfoPropsData } from 'components/MapView/utils';
 import { MapLayerMouseEvent } from 'maplibre-gl';
-import { getLayerMapId } from 'utils/map-utils';
+import { getEvtCoords, getLayerMapId } from 'utils/map-utils';
 
 export function legendToStops(
   legend: LegendDefinition = [],
@@ -85,7 +85,7 @@ export const addPopupParams = (
     return;
   }
 
-  const coordinates = [evt.lngLat.lng, evt.lngLat.lat];
+  const coordinates = getEvtCoords(evt);
 
   const { dataField, featureInfoProps, title } = layer;
 

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/ExposureAnalysisTable/index.tsx
@@ -22,6 +22,7 @@ import { useSafeTranslation } from 'i18n';
 
 import { Column } from 'utils/analysis-utils';
 import { mapSelector } from 'context/mapStateSlice/selectors';
+import { hidePopup } from 'context/tooltipStateSlice';
 
 const ExposureAnalysisTable = memo(
   ({
@@ -134,16 +135,15 @@ const ExposureAnalysisTable = memo(
 
     const handleClickTableBodyRow = useCallback(
       row => {
-        return () => {
+        return async () => {
           if (!row.coordinates || !map) {
             return;
           }
-          dispatch(() =>
-            map.fire('click', {
-              lngLat: row.coordinates,
-              point: map.project(row.coordinates),
-            }),
-          );
+          await dispatch(hidePopup());
+          map.fire('click', {
+            lngLat: row.coordinates,
+            point: map.project(row.coordinates),
+          });
         };
       },
       [dispatch, map],

--- a/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnalysisPanel/AnalysisTable/index.tsx
@@ -19,6 +19,7 @@ import { TableRow as AnalysisTableRow } from 'context/analysisResultStateSlice';
 import { Column } from 'utils/analysis-utils';
 import { useSafeTranslation } from 'i18n';
 import { mapSelector } from 'context/mapStateSlice/selectors';
+import { hidePopup } from 'context/tooltipStateSlice';
 
 const AnalysisTable = memo(
   ({
@@ -103,16 +104,15 @@ const AnalysisTable = memo(
 
     const handleClickTableBodyRow = useCallback(
       row => {
-        return () => {
+        return async () => {
           if (!row.coordinates || !map) {
             return;
           }
-          dispatch(() =>
-            map.fire('click', {
-              lngLat: row.coordinates,
-              point: map.project(row.coordinates),
-            }),
-          );
+          await dispatch(hidePopup());
+          map.fire('click', {
+            lngLat: row.coordinates,
+            point: map.project(row.coordinates),
+          });
         };
       },
       [dispatch, map],

--- a/frontend/src/components/MapView/useMapOnClick.ts
+++ b/frontend/src/components/MapView/useMapOnClick.ts
@@ -25,7 +25,6 @@ const useMapOnClick = (
   setIsAlertFormOpen: (value: boolean) => void,
   boundaryLayerId: string,
   mapRef: MapRef | null,
-  ...callBacks: { layerId: string; fn: (e: MapLayerMouseEvent) => void }[]
 ) => {
   const dispatch = useDispatch();
   const { startDate: selectedDate } = useSelector(dateRangeSelector);
@@ -117,15 +116,6 @@ const useMapOnClick = (
     if (boundaryLayerData) {
       defaultFunction(e);
     }
-
-    // TODO: maplibre: fix features
-    // Call each registered callback
-    callBacks.forEach(c => {
-      if (!e.features?.find((x: any) => x.source !== c.layerId)) {
-        return;
-      }
-      c.fn(e);
-    });
   };
 };
 

--- a/frontend/src/utils/map-utils.ts
+++ b/frontend/src/utils/map-utils.ts
@@ -1,4 +1,4 @@
-import { Map as MaplibreMap } from 'maplibre-gl';
+import { MapLayerMouseEvent, Map as MaplibreMap } from 'maplibre-gl';
 import { LayerKey, BoundaryLayerProps, LayerType } from 'config/types';
 import { getDisplayBoundaryLayers } from 'config/utils';
 import { addLayer, removeLayer } from 'context/mapStateSlice';
@@ -85,3 +85,7 @@ export function refreshBoundaries(
 
 export const getLayerMapId = (layerId: string, type?: 'fill' | 'line') =>
   `layer-${layerId}${type ? `-${type}` : ''}`;
+
+// evt emitted by map.fire has array of coordinates, but other events have an object
+export const getEvtCoords = (evt: MapLayerMouseEvent) =>
+  Array.isArray(evt.lngLat) ? evt.lngLat : [evt.lngLat.lng, evt.lngLat.lat];

--- a/frontend/src/utils/map-utils.ts
+++ b/frontend/src/utils/map-utils.ts
@@ -1,8 +1,21 @@
-import { MapLayerMouseEvent, Map as MaplibreMap } from 'maplibre-gl';
-import { LayerKey, BoundaryLayerProps, LayerType } from 'config/types';
+import {
+  MapLayerEventType,
+  MapLayerMouseEvent,
+  Map as MaplibreMap,
+} from 'maplibre-gl';
+import {
+  LayerKey,
+  BoundaryLayerProps,
+  LayerType,
+  MapEventWrapFunctionProps,
+} from 'config/types';
 import { getDisplayBoundaryLayers } from 'config/utils';
 import { addLayer, removeLayer } from 'context/mapStateSlice';
-import { Dispatch } from 'react';
+import React, { Dispatch } from 'react';
+
+import { useDispatch, useSelector } from 'react-redux';
+import { mapSelector } from 'context/mapStateSlice/selectors';
+import { useSafeTranslation } from 'i18n';
 
 /**
  * Checks weither given layer is on view
@@ -89,3 +102,27 @@ export const getLayerMapId = (layerId: string, type?: 'fill' | 'line') =>
 // evt emitted by map.fire has array of coordinates, but other events have an object
 export const getEvtCoords = (evt: MapLayerMouseEvent) =>
   Array.isArray(evt.lngLat) ? evt.lngLat : [evt.lngLat.lng, evt.lngLat.lat];
+
+export function useMapCallback<T extends keyof MapLayerEventType, U>(
+  type: T,
+  layerId: string,
+  layer: U,
+  listener: (
+    props: MapEventWrapFunctionProps<U>,
+  ) => (ev: MapLayerEventType[T] & Object) => void,
+) {
+  const dispatch = useDispatch();
+  const map = useSelector(mapSelector);
+  const { t } = useSafeTranslation();
+
+  React.useEffect(() => {
+    if (!map) {
+      return () => {};
+    }
+
+    map.on(type, layerId, listener({ dispatch, layer, t }));
+    return () => {
+      map.off(type, layerId, listener({ dispatch, layer, t }));
+    };
+  }, [dispatch, layer, layerId, listener, map, t, type]);
+}


### PR DESCRIPTION
### Description
changes the way we register layer to use `map.on`. This way `map.fire` triggers onclick events.
note that the event produced by `map.fire`, returns coordinates in an array instead of an object

This fixes #issueNumber.

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
