### PR TITLE
Fix date shift issue; COUNTRY=rbd

### DIFF
--- a/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineItem/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/TimelineItem/index.tsx
@@ -101,6 +101,7 @@ const styles = () =>
       height: '0px',
       zIndex: 1,
       left: 0,
+      pointerEvents: 'none',
     },
 
     layerDirectionBackwardBase: {


### PR DESCRIPTION
### Description

This fixes #1065 and a few other issues with the date picker.
The date selector and the date arrows where blocking clicks on the date picker.

@laurentS let me know if you think my changes make sense.
The logic in this file is way too complicated imho and might need a revamp...

<!-- what this does -->

## How to test the feature:

- [ ] select a cadre harmonise layer and a rainfall layer, set your location to San Francisco, check that clicking on a new date does not shift the date backward an extra day
- [ ] repeat with other timezones (EU, Asia)

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
