### PR TITLE
Simplify opacity logic in print; COUNTRY=rbd

### DIFF
--- a/frontend/src/components/MapView/Layers/AdminLevelDataLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/AdminLevelDataLayer/index.tsx
@@ -61,8 +61,12 @@ export const addFillPatternImageInMap = (
     if (!image) {
       return;
     }
-    // Add the image to the map style.
-    map.addImage(`fill-pattern-${layer.id}-legend-${index}`, image);
+    // Add the image to the map style if it doesn't already exist
+    const imageId = `fill-pattern-${layer.id}-legend-${index}`;
+    if (!map.hasImage(imageId)) {
+      // Add the image since it doesn't exist
+      map.addImage(imageId, image);
+    }
   });
 };
 
@@ -111,9 +115,6 @@ const AdminLevelDataLayers = ({
   const { features } = data || {};
 
   useEffect(() => {
-    if (isLayerOnView(map, layer.id)) {
-      return;
-    }
     addFillPatternImagesInMap(layer, map);
   }, [layer, map]);
 

--- a/frontend/src/components/MapView/Legends/handleChangeOpacity.ts
+++ b/frontend/src/components/MapView/Legends/handleChangeOpacity.ts
@@ -41,6 +41,10 @@ export const handleChangeOpacity = (
     })(type);
 
     map.setPaintProperty(layerId, opacityType, newValue);
+    // force a update of the map style to ensure the change is reflected
+    // see https://github.com/maplibre/maplibre-gl-js/issues/3373
+    // eslint-disable-next-line no-underscore-dangle
+    map.style._updateLayer(layerId as any);
     callback(newValue);
   }
 };

--- a/frontend/src/components/MapView/Legends/handleChangeOpacity.ts
+++ b/frontend/src/components/MapView/Legends/handleChangeOpacity.ts
@@ -43,6 +43,7 @@ export const handleChangeOpacity = (
     map.setPaintProperty(layerId, opacityType, newValue);
     // force a update of the map style to ensure the change is reflected
     // see https://github.com/maplibre/maplibre-gl-js/issues/3373
+    // TODO - check if the above issue got resolved from time to time.
     // eslint-disable-next-line no-underscore-dangle
     map.style._updateLayer(layerId as any);
     callback(newValue);

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -34,7 +34,6 @@ import React, { ChangeEvent, useRef } from 'react';
 import MapGL, { MapRef } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
 
-import { isDataLayer } from 'components/MapView/Layers/layer-utils';
 import { mapStyle } from 'components/MapView/Map';
 import { addFillPatternImagesInMap } from 'components/MapView/Layers/AdminLevelDataLayer';
 
@@ -140,38 +139,6 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
 
   // Get the style and layers of the old map
   const selectedMapStyle = selectedMap?.getStyle();
-  const selectedMapLayers = selectedMap?.getStyle()?.layers;
-  // The map style already contains all the info we need to re-render the map
-  // however, there is a small bug with opacity and we need to ovrerride the paint
-  // properties of the data layers
-  // TODO - use opacity state when it has been revamped
-  const cleanSelectedMapStyle = {
-    ...selectedMapStyle,
-    layers: selectedMapLayers?.map(layer => {
-      if (isDataLayer(layer.id)) {
-        // eslint-disable-next-line
-        const paintProps = (selectedMap?.style?._layers as any)[layer.id].paint
-          ._values;
-        // only keep opacity info and handle weird behaviors
-        const opacityProps = Object.keys(paintProps)
-          .filter(key => key.includes('opacity'))
-          .reduce((obj, key) => {
-            return {
-              ...obj,
-              [key]:
-                typeof paintProps[key] === 'number'
-                  ? paintProps[key]
-                  : paintProps[key].value.value,
-            };
-          }, {});
-        return {
-          ...layer,
-          paint: { ...layer.paint, ...opacityProps },
-        };
-      }
-      return layer;
-    }),
-  };
 
   const { selectedLayers } = useLayers();
   const adminLevelLayersWithFillPattern = selectedLayers.filter(
@@ -539,9 +506,7 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
                         }}
                         minZoom={selectedMap.getMinZoom()}
                         maxZoom={selectedMap.getMaxZoom()}
-                        mapStyle={
-                          (cleanSelectedMapStyle as any) || mapStyle.toString()
-                        }
+                        mapStyle={selectedMapStyle || mapStyle.toString()}
                         maxBounds={selectedMap.getMaxBounds() ?? undefined}
                       />
                     )}


### PR DESCRIPTION
### Description

This PR simplifies the logic around the opacity setting uncovered in #1074 by following the tips from https://github.com/maplibre/maplibre-gl-js/issues/3373.

<!-- what this does -->

## How to test the feature:

- [ ] Make sure the opacity setting is conserved between the main map and the print version for all layer types.

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
