### PR TITLE
Fix comparison period chart date title

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -541,7 +541,7 @@ const ChartsPanel = memo(
           weekday: undefined,
           year: 'numeric',
           month: 'short',
-          dayPeriod: 'short',
+          day: 'numeric',
         };
         const formatDate = (d: number) => {
           const dd = new Date(d);


### PR DESCRIPTION
### Description

This fixes #1105.

<!-- what this does -->

## How to test the feature:

- [ ] display charts in compare period mode
- [ ] validate that the date string is showing up as expected

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:

<img width="1092" alt="Screenshot 2024-02-07 at 12 18 06 PM" src="https://github.com/WFP-VAM/prism-app/assets/16843267/dd046792-a39a-41e1-95da-7968dea4de5c">

