### PR TITLE
fix(frontend): apply styles to drawer's paper

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/index.tsx
@@ -1,4 +1,4 @@
-import { createStyles, Drawer, makeStyles, Theme } from '@material-ui/core';
+import { Drawer } from '@material-ui/core';
 import React, { memo, useMemo } from 'react';
 import { LayersCategoryType, MenuItemType, PanelSize } from 'config/types';
 import AnalysisPanel from './AnalysisPanel';
@@ -7,26 +7,8 @@ import LeftPanelTabs from './LeftPanelTabs';
 import TablesPanel from './TablesPanel';
 import { menuList } from './utils';
 
-interface StyleProps {
-  panelSize: PanelSize;
-}
-
-const useStyles = makeStyles<Theme, StyleProps>(() =>
-  createStyles({
-    paper: {
-      marginTop: '7vh',
-      height: '93%',
-      width: ({ panelSize }) => panelSize,
-      backgroundColor: '#F5F7F8',
-      maxWidth: '100%',
-    },
-  }),
-);
-
 const LeftPanel = memo(
   ({ panelSize, setPanelSize, isPanelHidden }: LeftPanelProps) => {
-    const classes = useStyles({ panelSize });
-
     const [
       resultsPage,
       setResultsPage,
@@ -48,10 +30,18 @@ const LeftPanel = memo(
 
     return (
       <Drawer
+        PaperProps={{
+          style: {
+            width: panelSize,
+            marginTop: '7vh',
+            height: '93%',
+            backgroundColor: '#F5F7F8',
+            maxWidth: '100%',
+          },
+        }}
         variant="persistent"
         anchor="left"
         open={!isPanelHidden}
-        classes={{ paper: classes.paper }}
       >
         <LeftPanelTabs
           panelSize={panelSize}

--- a/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
@@ -7,18 +7,18 @@ exports[`renders as expected 1`] = `
   >
     <mock-drawer
       anchor="left"
-      classes="[object Object]"
       open="true"
+      paperprops="[object Object]"
       variant="persistent"
     >
       <div
-        class="makeStyles-root-6 makeStyles-root-12"
+        class="makeStyles-root-4 makeStyles-root-10"
       >
         <div
-          class="makeStyles-tabsWrapper-7"
+          class="makeStyles-tabsWrapper-5"
         >
           <div
-            class="makeStyles-tabsContainer-8 makeStyles-tabsContainer-13"
+            class="makeStyles-tabsContainer-6 makeStyles-tabsContainer-11"
           >
             <mock-tabs
               aria-label="left panel tabs"
@@ -58,22 +58,22 @@ exports[`renders as expected 1`] = `
             style="display: block; flex-grow: 1; order: -1; overflow-x: hidden;"
           >
             <div
-              class="MuiBox-root MuiBox-root-14"
+              class="MuiBox-root MuiBox-root-12"
             >
               <div
-                class="MuiPaper-root MuiAccordion-root makeStyles-root-15 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                class="MuiPaper-root MuiAccordion-root makeStyles-root-13 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
               >
                 <div
                   aria-controls="Rainfall"
                   aria-disabled="false"
                   aria-expanded="false"
-                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-16"
+                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-14"
                   id="Rainfall"
                   role="button"
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content makeStyles-summaryContent-19"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-17"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -84,7 +84,7 @@ exports[`renders as expected 1`] = `
                   <div
                     aria-disabled="false"
                     aria-hidden="true"
-                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-18 MuiIconButton-edgeEnd"
+                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-16 MuiIconButton-edgeEnd"
                   >
                     <span
                       class="MuiIconButton-label"
@@ -107,19 +107,19 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAccordion-root makeStyles-root-15 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                class="MuiPaper-root MuiAccordion-root makeStyles-root-13 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
               >
                 <div
                   aria-controls="Vegetation"
                   aria-disabled="false"
                   aria-expanded="false"
-                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-16"
+                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-14"
                   id="Vegetation"
                   role="button"
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content makeStyles-summaryContent-19"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-17"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -130,7 +130,7 @@ exports[`renders as expected 1`] = `
                   <div
                     aria-disabled="false"
                     aria-hidden="true"
-                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-18 MuiIconButton-edgeEnd"
+                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-16 MuiIconButton-edgeEnd"
                   >
                     <span
                       class="MuiIconButton-label"
@@ -153,19 +153,19 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAccordion-root makeStyles-root-15 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                class="MuiPaper-root MuiAccordion-root makeStyles-root-13 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
               >
                 <div
                   aria-controls="Temperature"
                   aria-disabled="false"
                   aria-expanded="false"
-                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-16"
+                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-14"
                   id="Temperature"
                   role="button"
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content makeStyles-summaryContent-19"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-17"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -176,7 +176,7 @@ exports[`renders as expected 1`] = `
                   <div
                     aria-disabled="false"
                     aria-hidden="true"
-                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-18 MuiIconButton-edgeEnd"
+                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-16 MuiIconButton-edgeEnd"
                   >
                     <span
                       class="MuiIconButton-label"
@@ -199,19 +199,19 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAccordion-root makeStyles-root-15 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                class="MuiPaper-root MuiAccordion-root makeStyles-root-13 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
               >
                 <div
                   aria-controls="Tropical Storms"
                   aria-disabled="false"
                   aria-expanded="false"
-                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-16"
+                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-14"
                   id="Tropical Storms"
                   role="button"
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content makeStyles-summaryContent-19"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-17"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -222,7 +222,7 @@ exports[`renders as expected 1`] = `
                   <div
                     aria-disabled="false"
                     aria-hidden="true"
-                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-18 MuiIconButton-edgeEnd"
+                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-16 MuiIconButton-edgeEnd"
                   >
                     <span
                       class="MuiIconButton-label"
@@ -245,19 +245,19 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAccordion-root makeStyles-root-15 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                class="MuiPaper-root MuiAccordion-root makeStyles-root-13 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
               >
                 <div
                   aria-controls="Vulnerability"
                   aria-disabled="false"
                   aria-expanded="false"
-                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-16"
+                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-14"
                   id="Vulnerability"
                   role="button"
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content makeStyles-summaryContent-19"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-17"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -268,7 +268,7 @@ exports[`renders as expected 1`] = `
                   <div
                     aria-disabled="false"
                     aria-hidden="true"
-                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-18 MuiIconButton-edgeEnd"
+                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-16 MuiIconButton-edgeEnd"
                   >
                     <span
                       class="MuiIconButton-label"
@@ -291,19 +291,19 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="MuiPaper-root MuiAccordion-root makeStyles-root-15 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+                class="MuiPaper-root MuiAccordion-root makeStyles-root-13 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
               >
                 <div
                   aria-controls="Exposure"
                   aria-disabled="false"
                   aria-expanded="false"
-                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-16"
+                  class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-14"
                   id="Exposure"
                   role="button"
                   tabindex="0"
                 >
                   <div
-                    class="MuiAccordionSummary-content makeStyles-summaryContent-19"
+                    class="MuiAccordionSummary-content makeStyles-summaryContent-17"
                   >
                     <mock-typography
                       classes="[object Object]"
@@ -314,7 +314,7 @@ exports[`renders as expected 1`] = `
                   <div
                     aria-disabled="false"
                     aria-hidden="true"
-                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-18 MuiIconButton-edgeEnd"
+                    class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-16 MuiIconButton-edgeEnd"
                   >
                     <span
                       class="MuiIconButton-label"
@@ -337,7 +337,7 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="MuiBox-root MuiBox-root-22"
+                class="MuiBox-root MuiBox-root-20"
               />
               <a
                 href="https://github.com/WFP-VAM/prism-app"
@@ -365,10 +365,10 @@ exports[`renders as expected 1`] = `
       </div>
     </mock-drawer>
     <div
-      class="MuiBox-root MuiBox-root-25 OtherFeatures-container-23"
+      class="MuiBox-root MuiBox-root-23 OtherFeatures-container-21"
     >
       <div
-        class="MuiBox-root MuiBox-root-26 OtherFeatures-optionContainer-24"
+        class="MuiBox-root MuiBox-root-24 OtherFeatures-optionContainer-22"
         style="margin-left: 500px;"
       >
         <mock-tooltip
@@ -394,7 +394,7 @@ exports[`renders as expected 1`] = `
           </mock-button>
         </mock-tooltip>
         <div
-          class="MuiGrid-root ExtraFeature-buttonContainer-29 MuiGrid-container MuiGrid-justify-content-xs-space-between"
+          class="MuiGrid-root ExtraFeature-buttonContainer-27 MuiGrid-container MuiGrid-justify-content-xs-space-between"
         >
           <div
             class="MuiGrid-root MuiGrid-item"
@@ -406,7 +406,7 @@ exports[`renders as expected 1`] = `
                 class="MuiGrid-root MuiGrid-item"
               >
                 <div
-                  class="makeStyles-button-30"
+                  class="makeStyles-button-28"
                 >
                   <svg
                     aria-hidden="true"
@@ -419,7 +419,7 @@ exports[`renders as expected 1`] = `
                     />
                   </svg>
                   <div
-                    class="makeStyles-selectContainer-32"
+                    class="makeStyles-selectContainer-30"
                   >
                     <mock-circularprogress
                       color="inherit"


### PR DESCRIPTION
/claim #1012 
### Description

This fixes #1012 

Source of the bug comes from using makeStyles to style MUI drawer's paper.  Looks like by MUI version 4.12 Drawer was already taking PaperProps as a prop, which accepts all props drilled down to the paper component.

See [stackoverflow](https://stackoverflow.com/a/70039483), [stackoverflow MUI 5](https://stackoverflow.com/questions/69494901/how-to-style-the-paper-of-a-drawer-in-mui) and [MUI documentation](https://mui.com/material-ui/api/drawer/)

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests? N/A
- [x] Add / update outdated documentation? N/A

## Screenshot/video of feature:

[Loom video ](https://www.loom.com/share/b77da639009d4eb3aefbe849b9c97152?sid=9572c1f4-03a9-4588-89cd-62d62c4904ee)