### PR TITLE
Add an Anticipatory Action module

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/HomeTable/AAIcon.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/HomeTable/AAIcon.tsx
@@ -1,0 +1,62 @@
+import { makeStyles, createStyles } from '@material-ui/core';
+import React from 'react';
+
+export interface AAIconProps {
+  background: string;
+  topText: string;
+  bottomText: string;
+  color: string;
+}
+
+function AAIcon({ background, topText, bottomText, color }: AAIconProps) {
+  const classes = useAAIconStyles();
+
+  return (
+    <div style={{ background }} className={classes.iconWrapper}>
+      <div
+        style={{ border: `1px solid ${color}`, color }}
+        className={classes.centerContainer}
+      >
+        <div
+          style={{ borderBottom: `1px solid ${color}` }}
+          className={classes.topTextContainer}
+        >
+          {topText}
+        </div>
+        <div className={classes.bottomTextContainer}>{bottomText}</div>
+      </div>
+    </div>
+  );
+}
+
+const useAAIconStyles = makeStyles(() =>
+  createStyles({
+    iconWrapper: {
+      minHeight: '4rem',
+      height: '100%',
+      borderRadius: '2px 0 0 2px',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    centerContainer: {
+      width: '2.1em',
+      borderRadius: '2px',
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    topTextContainer: {
+      textAlign: 'center',
+      fontWeight: 'bold',
+      fontSize: '13px',
+      lineHeight: '21px',
+    },
+    bottomTextContainer: {
+      textAlign: 'center',
+      fontSize: '9px',
+      lineHeight: '21px',
+    },
+  }),
+);
+
+export default AAIcon;

--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/HomeTable/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/HomeTable/index.tsx
@@ -1,0 +1,162 @@
+import { Typography, createStyles, makeStyles } from '@material-ui/core';
+import { useSafeTranslation } from 'i18n';
+import { borderGray, gray } from 'muiTheme';
+import React from 'react';
+import { Phase } from '../utils';
+
+interface AreaTagProps {
+  name: string;
+  isNew: boolean;
+}
+
+function AreaTag({ name, isNew }: AreaTagProps) {
+  return (
+    <div
+      style={{
+        border: `1px solid ${borderGray}`,
+        height: '2rem',
+        borderRadius: '4px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.25em',
+        padding: '0 0.25em',
+      }}
+    >
+      <Typography>{name}</Typography>
+      {isNew && (
+        <div
+          style={{
+            height: '2em',
+            padding: '0 0.5em',
+            color: 'white',
+            background: '#A4A4A4',
+            fontSize: '10px',
+            borderRadius: '32px',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          NEW
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface RowProps {
+  id: Phase | 'header';
+  iconContent: React.ReactNode;
+  windows: [AreaTagProps[], AreaTagProps[]];
+  header?: string[];
+}
+
+function Row({ iconContent, windows, header }: RowProps) {
+  const classes = useRowStyles();
+  const { t } = useSafeTranslation();
+
+  if (header) {
+    return (
+      <div className={classes.rowWrapper}>
+        <div className={classes.iconCol}>{iconContent}</div>
+        {header.map(name => (
+          <div key={name} className={classes.windowWrapper}>
+            <Typography variant="h3" className={classes.headerText}>
+              {name}
+            </Typography>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className={classes.rowWrapper}>
+      <div className={classes.iconCol}>{iconContent}</div>
+      {windows.map((col, index) => (
+        // we can actually use the index as key here, since we know each index is a window
+        // eslint-disable-next-line react/no-array-index-key
+        <div key={index} className={classes.windowWrapper}>
+          <div className={classes.windowBackground}>
+            <div className={classes.tagWrapper}>
+              {col.map(x => (
+                <AreaTag key={x.name} {...x} />
+              ))}
+              {col.length === 0 && (
+                <Typography className={classes.emptyText}>
+                  ({t('no district')})
+                </Typography>
+              )}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const useRowStyles = makeStyles(() =>
+  createStyles({
+    rowWrapper: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-around',
+      padding: '0.125rem 0.5rem',
+    },
+    iconCol: { width: '3rem' },
+    windowWrapper: { width: 'calc(50% - 1.75rem)' },
+    windowBackground: {
+      background: 'white',
+      height: '100%',
+      width: '100%',
+    },
+    tagWrapper: {
+      padding: '1rem 0.5rem',
+      display: 'flex',
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'flex-start',
+      gap: '0.5em',
+    },
+    headerText: {
+      fontWeight: 'bold',
+      textTransform: 'uppercase',
+      minHeight: '3rem',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    emptyText: {
+      color: borderGray,
+    },
+  }),
+);
+
+interface HomeTableProps {
+  rows: RowProps[];
+}
+
+function HomeTable({ rows }: HomeTableProps) {
+  const classes = useHomeTableStyles();
+
+  return (
+    <div className={classes.tableWrapper}>
+      {rows.map(r => (
+        <Row key={r.id} {...r} />
+      ))}
+    </div>
+  );
+}
+
+const useHomeTableStyles = makeStyles(() =>
+  createStyles({
+    tableWrapper: {
+      display: 'flex',
+      flexDirection: 'column',
+      width: '100%',
+      background: gray,
+      padding: '0.5rem 0',
+    },
+  }),
+);
+
+export default HomeTable;

--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/index.tsx
@@ -1,0 +1,228 @@
+import {
+  Button,
+  FormControl,
+  RadioGroup,
+  Typography,
+  createStyles,
+  makeStyles,
+} from '@material-ui/core';
+import { PanelSize } from 'config/types';
+import { black, cyanBlue } from 'muiTheme';
+import React from 'react';
+import { useSafeTranslation } from 'i18n';
+import { GetApp, EditOutlined, BarChartOutlined } from '@material-ui/icons';
+import HomeTable, { RowProps } from './HomeTable';
+import AAIcon from './HomeTable/AAIcon';
+import { StyledRadioLabel } from './utils';
+
+const dummyAreas = [
+  { name: 'Mapai', isNew: true },
+  { name: 'Kolomna', isNew: false },
+  { name: 'Saraf', isNew: true },
+  { name: 'Glarus', isNew: false },
+  { name: 'Brampton', isNew: true },
+  { name: 'Xanadu', isNew: false },
+  { name: 'Zephyr', isNew: true },
+  { name: 'Quetzaltenango', isNew: false },
+  { name: 'Wakanda', isNew: true },
+  { name: 'Atlantis', isNew: false },
+];
+
+const buttons = [
+  { icon: GetApp, text: 'Assets' },
+  { icon: EditOutlined, text: 'Report' },
+  { icon: BarChartOutlined, text: 'Forecast' },
+];
+
+const links = [
+  { text: 'Group assumptions', href: 'google.com' },
+  { text: 'How to read this screen', href: 'google.com' },
+];
+
+function AnticipatoryActionPanel() {
+  const classes = useStyles();
+  const { t } = useSafeTranslation();
+
+  const rows: RowProps[] = [
+    {
+      id: 'header',
+      iconContent: null,
+      windows: [[], []],
+      header: ['window 1', 'window 2'],
+    },
+    {
+      id: 'set_sev',
+      iconContent: (
+        <AAIcon
+          background="#831F00"
+          topText="S"
+          bottomText="SEV"
+          color="white"
+        />
+      ),
+      windows: [dummyAreas.slice(0, 2), dummyAreas.slice(0, 3)],
+    },
+    {
+      id: 'ready_sev',
+      iconContent: (
+        <AAIcon
+          background="#E63701"
+          topText="R"
+          bottomText="SEV"
+          color="white"
+        />
+      ),
+      windows: [dummyAreas.slice(3, 6), dummyAreas.slice(6, 7)],
+    },
+    {
+      id: 'set_mod',
+      iconContent: (
+        <AAIcon
+          background="#FF8934"
+          topText="S"
+          bottomText="MOD"
+          color="black"
+        />
+      ),
+      windows: [[], dummyAreas.slice(0, 1)],
+    },
+    {
+      id: 'ready_mod',
+      iconContent: (
+        <AAIcon
+          background="#FFD52D"
+          topText="R"
+          bottomText="MOD"
+          color="black"
+        />
+      ),
+      windows: [dummyAreas.slice(0, 1), []],
+    },
+    {
+      id: 'na',
+      iconContent: (
+        <AAIcon
+          background="#F1F1F1"
+          topText="na"
+          bottomText="-"
+          color="black"
+        />
+      ),
+      windows: [[], []],
+    },
+    {
+      id: 'ny',
+      iconContent: (
+        <AAIcon
+          background={`repeating-linear-gradient(
+        -45deg,
+        #F1F1F1,
+        #F1F1F1 10px,
+        white 10px,
+        white 20px
+      )`}
+          topText="ny"
+          bottomText="-"
+          color="black"
+        />
+      ),
+      windows: [[], []],
+    },
+  ];
+
+  return (
+    <div className={classes.anticipatoryActionPanel}>
+      {/* header */}
+      <div className={classes.headerWrapper}>
+        {/* Title area */}
+        <div>
+          <Typography variant="h2">Phases: global view</Typography>
+        </div>
+        {/* window select */}
+        <div>
+          <FormControl component="fieldset">
+            <RadioGroup defaultValue="all" className={classes.radioButtonGroup}>
+              <StyledRadioLabel value="all" label="All" />
+              <StyledRadioLabel value="window1" label="Window 1" />
+              <StyledRadioLabel value="window2" label="Window 2" />
+            </RadioGroup>
+          </FormControl>
+        </div>
+      </div>
+      {/* main view */}
+      <HomeTable rows={rows} />
+      {/* footer */}
+      <div className={classes.footerWrapper}>
+        {/* actions */}
+        <div className={classes.footerActionsWrapper}>
+          {buttons.map(x => (
+            <Button
+              key={x.text}
+              className={classes.footerButton}
+              variant="outlined"
+              fullWidth
+              startIcon={<x.icon />}
+            >
+              <Typography>{t(x.text)}</Typography>
+            </Button>
+          ))}
+        </div>
+        {/* links */}
+        <div className={classes.footerLinksWrapper}>
+          {links.map(link => (
+            <Typography
+              key={link.text}
+              className={classes.footerLink}
+              component="a"
+              target="_blank"
+              rel="noopener noreferrer"
+              href={link.href}
+            >
+              {link.text}
+            </Typography>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    anticipatoryActionPanel: {
+      width: PanelSize.medium,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '1rem',
+    },
+    headerWrapper: {
+      padding: '1rem',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '0.50rem',
+    },
+    radioButtonGroup: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+    },
+    footerWrapper: { display: 'flex', flexDirection: 'column' },
+    footerActionsWrapper: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      padding: '0.5rem',
+      gap: '1rem',
+    },
+    footerLinksWrapper: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      padding: '0.5rem',
+    },
+    footerButton: { borderColor: cyanBlue, color: black },
+    footerLink: { textDecoration: 'underline' },
+  }),
+);
+
+export default AnticipatoryActionPanel;

--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/utils.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/utils.tsx
@@ -1,0 +1,49 @@
+import {
+  FormControlLabel,
+  FormControlLabelProps,
+  Radio,
+  RadioProps,
+  useRadioGroup,
+  withStyles,
+} from '@material-ui/core';
+import { black, borderGray, gray } from 'muiTheme';
+import React from 'react';
+
+const StyledRadio = withStyles({
+  root: {
+    '&$checked': {
+      color: black,
+    },
+  },
+  checked: {},
+})((props: RadioProps) => <Radio color="default" {...props} />);
+
+export const StyledRadioLabel = withStyles({
+  root: {
+    border: `1px solid ${borderGray}`,
+    borderRadius: '32px',
+    height: '1.75rem',
+    marginLeft: 0,
+  },
+  checked: {},
+})(({ label, ...props }: Omit<FormControlLabelProps, 'control'>) => {
+  const radioGroup = useRadioGroup();
+  const checked = radioGroup?.value === props.value;
+
+  return (
+    <FormControlLabel
+      style={{ background: checked ? gray : undefined }}
+      label={<span style={{ marginRight: '1rem' }}>{label}</span>}
+      control={<StyledRadio />}
+      {...props}
+    />
+  );
+});
+
+export type Phase =
+  | 'set_sev'
+  | 'ready_sev'
+  | 'set_mod'
+  | 'ready_mod'
+  | 'na'
+  | 'ny';

--- a/frontend/src/components/MapView/LeftPanel/LeftPanelTabs/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/LeftPanelTabs/index.tsx
@@ -44,11 +44,18 @@ interface TabsProps {
   chartsPanel: React.ReactNode;
   analysisPanel: React.ReactNode;
   tablesPanel: React.ReactNode;
+  anticipatoryActionPanel: React.ReactNode;
   resultsPage: React.JSX.Element | null;
 }
 
 const LeftPanelTabs = memo(
-  ({ chartsPanel, analysisPanel, tablesPanel, resultsPage }: TabsProps) => {
+  ({
+    chartsPanel,
+    analysisPanel,
+    tablesPanel,
+    anticipatoryActionPanel,
+    resultsPage,
+  }: TabsProps) => {
     const tabValue = useSelector(leftPanelTabValueSelector);
     const panelSize = useSelector(leftPanelSizeSelector);
     const classes = useStyles({ panelSize, tabValue });
@@ -75,6 +82,18 @@ const LeftPanelTabs = memo(
       );
     }, [tabValue, tablesPanel]);
 
+    const renderedAnticipatoryActionPanel = useMemo(() => {
+      // TODO: update condition
+      if (0) {
+        return null;
+      }
+      return (
+        <TabPanel value={tabValue} index={Panel.AnticipatoryAction}>
+          {anticipatoryActionPanel}
+        </TabPanel>
+      );
+    }, [anticipatoryActionPanel, tabValue]);
+
     return (
       <div className={classes.root}>
         <div className={classes.tabsWrapper}>
@@ -86,6 +105,7 @@ const LeftPanelTabs = memo(
             {analysisPanel}
           </TabPanel>
           {renderedTablesPanel}
+          {renderedAnticipatoryActionPanel}
           {/* Empty panel to remove warnings */}
           <TabPanel value={tabValue} index={Panel.None} />
         </div>

--- a/frontend/src/components/MapView/LeftPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/index.tsx
@@ -10,6 +10,7 @@ import AnalysisPanel from './AnalysisPanel';
 import ChartsPanel from './ChartsPanel';
 import LeftPanelTabs from './LeftPanelTabs';
 import TablesPanel from './TablesPanel';
+import AnticipatoryActionPanel from './AnticipatoryActionPanel';
 
 const LeftPanel = memo(() => {
   const tabValue = useSelector(leftPanelTabValueSelector);
@@ -44,6 +45,7 @@ const LeftPanel = memo(() => {
         chartsPanel={<ChartsPanel setResultsPage={setResultsPage} />}
         analysisPanel={<AnalysisPanel setResultsPage={setResultsPage} />}
         tablesPanel={<TablesPanel setResultsPage={setResultsPage} />}
+        anticipatoryActionPanel={<AnticipatoryActionPanel />}
       />
     </Drawer>
   );

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -22,6 +22,7 @@ import {
   ImageAspectRatioOutlined,
   LayersOutlined,
   TableChartOutlined,
+  TimerOutlined,
 } from '@material-ui/icons';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -55,6 +56,15 @@ const panels = [
   },
   ...(areTablesAvailable
     ? [{ panel: Panel.Tables, label: 'Tables', icon: <TableChartOutlined /> }]
+    : []),
+  ...(1
+    ? [
+        {
+          panel: Panel.AnticipatoryAction,
+          label: 'Anticipatory Action',
+          icon: <TimerOutlined />,
+        },
+      ]
     : []),
 ];
 

--- a/frontend/src/context/leftPanelStateSlice.ts
+++ b/frontend/src/context/leftPanelStateSlice.ts
@@ -11,6 +11,7 @@ export enum Panel {
   Charts = 'charts',
   Analysis = 'analysis',
   Tables = 'tables',
+  AnticipatoryAction = 'anticipatory_action',
 }
 
 type LeftPanelState = {
@@ -19,7 +20,7 @@ type LeftPanelState = {
 };
 
 const initialState: LeftPanelState = {
-  tabValue: hidePanel ? Panel.None : Panel.Layers,
+  tabValue: hidePanel ? Panel.None : Panel.AnticipatoryAction,
   panelSize: PanelSize.medium,
 };
 

--- a/frontend/src/muiTheme.tsx
+++ b/frontend/src/muiTheme.tsx
@@ -7,6 +7,8 @@ const darkGreyBlue: string = '#2D3436';
 const white: string = '#FFFFFF';
 const lightGray = '#CCCCCC';
 const midnightSlate = '#323638';
+export const gray = '#F1F1F1';
+export const borderGray = '#A4A4A4';
 export const paleSkyBlue = '#D8E9EC';
 export const black = '#101010';
 export const cyanBlue = '#63B2BD';
@@ -112,6 +114,10 @@ const theme: any = createTheme({
       },
     },
     MuiTypography: {
+      h2: {
+        fontSize: 20,
+        fontWeight: 'bold',
+      },
       h3: {
         fontSize: 16,
         fontWeight: 400,


### PR DESCRIPTION
### Description

This fixes #1098 .

WIP:
So far only the main page layout is implemented.
Next steps can be:
- [ ] adapt CSV and fetch date from there
- [ ] create anticipatory action layer 
- [ ] create AA legend
- [ ] make left panel AA page interactive 

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:

![Screenshot from 2024-03-01 17-26-35](https://github.com/WFP-VAM/prism-app/assets/80451946/324be63e-0451-40c8-aeb1-3ef2232577de)

