### PR TITLE
Fix datepicker would not update dates

### DIFF
--- a/frontend/src/components/MapView/DateSelector/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/index.tsx
@@ -37,7 +37,7 @@ import { format } from 'date-fns';
 import { ReactComponent as TickSvg } from './tick.svg';
 import DateSelectorInput from './DateSelectorInput';
 import TimelineItems from './TimelineItems';
-import { TIMELINE_ITEM_WIDTH, USER_DATE_OFFSET, findDateIndex } from './utils';
+import { TIMELINE_ITEM_WIDTH, findDateIndex } from './utils';
 import { oneDayInMs } from '../LeftPanel/utils';
 
 type Point = {
@@ -194,31 +194,21 @@ const DateSelector = memo(({ classes }: DateSelectorProps) => {
     [stateStartDate, updateHistory],
   );
 
-  const addUserOffset = useCallback((dates: number[]) => {
-    return dates.map(d => {
-      return d + USER_DATE_OFFSET;
-    });
-  }, []);
-
-  const dates = useMemo(() => {
-    return addUserOffset(availableDates);
-  }, [addUserOffset, availableDates]);
-
   const setDatePosition = useCallback(
     (
       date: number | undefined,
       increment: number,
       isUpdatingHistory: boolean,
     ) => {
-      const selectedIndex = findDateIndex(dates, date);
-      if (dates[selectedIndex + increment]) {
+      const selectedIndex = findDateIndex(availableDates, date);
+      if (availableDates[selectedIndex + increment]) {
         updateStartDate(
-          new Date(dates[selectedIndex + increment]),
+          new Date(availableDates[selectedIndex + increment]),
           isUpdatingHistory,
         );
       }
     },
-    [dates, updateStartDate],
+    [availableDates, updateStartDate],
   );
 
   // move pointer to closest date when change map layer
@@ -239,8 +229,8 @@ const DateSelector = memo(({ classes }: DateSelectorProps) => {
   }, [setDatePosition, stateStartDate]);
 
   const includedDates = useMemo(() => {
-    return dates?.map(d => new Date(d)) ?? [];
-  }, [dates]);
+    return availableDates?.map(d => new Date(d)) ?? [];
+  }, [availableDates]);
 
   const checkIntersectingDateAndShowPopup = useCallback(
     (selectedDate: Date, positionY: number) => {
@@ -269,16 +259,16 @@ const DateSelector = memo(({ classes }: DateSelectorProps) => {
 
   // Click on available date to move the pointer
   const clickDate = (index: number) => {
-    const selectedIndex = findDateIndex(dates, dateRange[index].value);
+    const selectedIndex = findDateIndex(availableDates, dateRange[index].value);
     if (
       selectedIndex < 0 ||
       (stateStartDate &&
-        datesAreEqualWithoutTime(dates[selectedIndex], stateStartDate))
+        datesAreEqualWithoutTime(availableDates[selectedIndex], stateStartDate))
     ) {
       return;
     }
     setPointerPosition({ x: index * TIMELINE_ITEM_WIDTH, y: 0 });
-    const updatedDate = new Date(dates[selectedIndex]);
+    const updatedDate = new Date(availableDates[selectedIndex]);
     checkIntersectingDateAndShowPopup(new Date(dateRange[index].value), 0);
     updateStartDate(updatedDate, true);
   };
@@ -299,15 +289,21 @@ const DateSelector = memo(({ classes }: DateSelectorProps) => {
       if (exactX >= dateRange.length) {
         return;
       }
-      const selectedIndex = findDateIndex(dates, dateRange[exactX].value);
-      if (selectedIndex < 0 || dates[selectedIndex] === stateStartDate) {
+      const selectedIndex = findDateIndex(
+        availableDates,
+        dateRange[exactX].value,
+      );
+      if (
+        selectedIndex < 0 ||
+        availableDates[selectedIndex] === stateStartDate
+      ) {
         return;
       }
       setPointerPosition({
         x: exactX * TIMELINE_ITEM_WIDTH,
         y: position.y,
       });
-      const updatedDate = new Date(dates[selectedIndex]);
+      const updatedDate = new Date(availableDates[selectedIndex]);
       checkIntersectingDateAndShowPopup(
         new Date(dateRange[exactX].value),
         position.y,
@@ -315,9 +311,9 @@ const DateSelector = memo(({ classes }: DateSelectorProps) => {
       updateStartDate(updatedDate, true);
     },
     [
+      availableDates,
       checkIntersectingDateAndShowPopup,
       dateRange,
-      dates,
       stateStartDate,
       updateStartDate,
     ],

--- a/frontend/src/components/MapView/DateSelector/utils.ts
+++ b/frontend/src/components/MapView/DateSelector/utils.ts
@@ -3,10 +3,6 @@ import { DateItem } from 'config/types';
 
 export const TIMELINE_ITEM_WIDTH = 10;
 
-// The DatePicker is timezone aware, so we trick it into
-// displaying UTC dates.
-export const USER_DATE_OFFSET = new Date().getTimezoneOffset() * 60000;
-
 export type DateCompatibleLayerWithDateItems = DateCompatibleLayer & {
   dateItems: DateItem[];
 };


### PR DESCRIPTION
### Description

This fixes a bug, where in some cases the date picker would not update the selected date, when clicking it

<!-- what this does -->

The bug was caused by the user timezone offset we would add, causing timestamps from the same date not to be equal for few hours and as a result the same date being picked from `findDateIndex`.
Since we now set UTC hours to 12, for every date, we should no longer need the users offset to correctly display the date.

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
