### PR TITLE
Fix map image would not show in report; COUNTRY=cambodia 

### DIFF
--- a/api/app/report.py
+++ b/api/app/report.py
@@ -67,9 +67,7 @@ async def download_report(
         await expect(flood_extent_checkbox).to_be_visible(timeout=20_000)
 
         # the switch status is flaky (sometimes checked, sometimes not)
-        await flood_extent_checkbox.is_checked()
-
-        await expect(flood_extent_checkbox).to_be_checked(timeout=10_000)
+        await expect(flood_extent_checkbox).to_be_checked(timeout=20_000)
         await expect(
             page.get_by_role("button", name="Exposure Analysis")
         ).not_to_be_disabled()

--- a/frontend/src/components/MapView/Map/index.tsx
+++ b/frontend/src/components/MapView/Map/index.tsx
@@ -217,6 +217,8 @@ const MapComponent = memo(
     return (
       <MapGL
         ref={mapRef}
+        // preserveDrawingBuffer is required for the map to be exported as an image. Used in reportDoc.tsx
+        preserveDrawingBuffer
         dragRotate={false}
         minZoom={minZoom}
         maxZoom={maxZoom}


### PR DESCRIPTION
Fixes an issue where the map image would not appear in the flood report

#### How to test
- Use country cambodia
- Activate layer Flood / Flood Monitoring / Flood extent and run analysis
- Click on "Preview Report (slow)" button and verify the report