### PR TITLE
Fix loss of focus when editing text in print preview

### DIFF
--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -620,8 +620,7 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
             <div className={classes.optionWrap}>
               <Typography variant="h4">{t('Title')}</Typography>
               <TextField
-                key={titleText}
-                defaultValue={titleText}
+                defaultValue={country}
                 fullWidth
                 size="small"
                 inputProps={{ style: { color: 'black' } }}


### PR DESCRIPTION
### Description

This fixes #1196 

<!-- what this does -->

## How to test the feature:

- Go top print preview
- Try editing the title text, pause for 2-3 seconds and start typing again
- notice the focus is not lost

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
