### PR TITLE
Add dropdown to select map style

### DIFF
--- a/frontend/src/components/MapView/Map/index.tsx
+++ b/frontend/src/components/MapView/Map/index.tsx
@@ -23,7 +23,7 @@ import {
   getLayerMapId,
   isLayerOnView,
 } from 'utils/map-utils';
-import { mapSelector } from 'context/mapStateSlice/selectors';
+import { mapSelector, mapStyleSelector } from 'context/mapStateSlice/selectors';
 import {
   AdminLevelDataLayer,
   BoundaryLayer,
@@ -50,7 +50,7 @@ type LayerComponentsMap<U extends LayerType> = {
   };
 };
 
-export const mapStyle = new URL(
+export const fallbackMapStyle = new URL(
   process.env.REACT_APP_DEFAULT_STYLE ||
     'https://api.maptiler.com/maps/0ad52f6b-ccf2-4a36-a9b8-7ebd8365e56f/style.json?key=y2DTSu9yWiu755WByJr3',
 );
@@ -78,6 +78,7 @@ const MapComponent = memo(({ setIsAlertFormOpen }: MapComponentProps) => {
 
   const selectedMap = useSelector(mapSelector);
   const tabValue = useSelector(leftPanelTabValueSelector);
+  const mapStyle = useSelector(mapStyleSelector);
 
   const panelHidden = tabValue === Panel.None;
 
@@ -228,7 +229,7 @@ const MapComponent = memo(({ setIsAlertFormOpen }: MapComponentProps) => {
         bounds: boundingBox,
         fitBoundsOptions: { padding: fitBoundsOptions.padding },
       }}
-      mapStyle={mapStyle.toString()}
+      mapStyle={mapStyle?.url || fallbackMapStyle.toString()}
       onLoad={onMapLoad}
       onClick={mapOnClick()}
       maxBounds={maxBounds}

--- a/frontend/src/components/NavBar/MapStyleSelector/index.tsx
+++ b/frontend/src/components/NavBar/MapStyleSelector/index.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  Button,
+  createStyles,
+  makeStyles,
+  Menu,
+  MenuItem,
+  Typography,
+} from '@material-ui/core';
+import { useSafeTranslation } from 'i18n';
+import { appConfig } from 'config';
+import { get } from 'lodash';
+import { ArrowDropDown, Public } from '@material-ui/icons';
+import { useDispatch, useSelector } from 'react-redux';
+import { mapStyleSelector } from 'context/mapStateSlice/selectors';
+import { MapStyle, setMapStyle } from 'context/mapStateSlice';
+
+const mapStyles: MapStyle[] = get(appConfig, 'mapStyles', []);
+
+function MapStyleSelector() {
+  const classes = useStyles();
+  const dispatch = useDispatch();
+  const { t } = useSafeTranslation();
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const mapStyle = useSelector(mapStyleSelector);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleChange = (style: MapStyle): void => {
+    dispatch(setMapStyle(style));
+    handleClose();
+  };
+
+  if (mapStyles.length <= 1) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        aria-label="map-style-select-dropdown-button"
+        style={{ paddingLeft: 0 }}
+        onClick={handleClick}
+        endIcon={<ArrowDropDown fontSize="small" />}
+      >
+        <Public style={{ paddingRight: '0.5rem' }} />
+        <Typography color="secondary" style={{ textTransform: 'none' }}>
+          {t(mapStyle?.label || '')}
+        </Typography>
+      </Button>
+      <Menu
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        className={classes.block}
+        anchorEl={anchorEl}
+      >
+        {mapStyles?.map(x => (
+          <MenuItem key={x.id} onClick={() => handleChange(x)}>
+            <Typography>{t(x.label)}</Typography>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    block: {
+      paddingLeft: '10px',
+      paddingTop: '4px',
+    },
+  }),
+);
+
+export default MapStyleSelector;

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -26,7 +26,6 @@ import maplibregl from 'maplibre-gl';
 import React, { useRef, useState } from 'react';
 import MapGL, { Layer, MapRef, Source } from 'react-map-gl/maplibre';
 import { useSelector } from 'react-redux';
-import { mapStyle } from 'components/MapView/Map';
 import { addFillPatternImagesInMap } from 'components/MapView/Layers/AdminLevelDataLayer';
 import { getFormattedDate } from 'utils/date-utils';
 import useLayers from 'utils/layers-utils';
@@ -541,7 +540,7 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
                         }}
                         onLoad={() => refreshImage()}
                         onMove={() => debounceCallback(refreshImage)}
-                        mapStyle={selectedMapStyle || mapStyle.toString()}
+                        mapStyle={selectedMapStyle}
                         maxBounds={selectedMap.getMaxBounds() ?? undefined}
                       >
                         {toggles.countryMask && (

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -42,6 +42,7 @@ import { PanelSize } from 'config/types';
 import About from './About';
 import LanguageSelector from './LanguageSelector';
 import PrintImage from './PrintImage';
+import MapStyleSelector from './MapStyleSelector';
 
 const panels = [
   { panel: Panel.Layers, label: 'Layers', icon: <LayersOutlined /> },
@@ -208,6 +209,7 @@ function NavBar({ classes, isAlertFormOpen, setIsAlertFormOpen }: NavBarProps) {
             {buttons}
             <About />
             <LanguageSelector />
+            <MapStyleSelector />
           </div>
         </div>
       </Toolbar>

--- a/frontend/src/config/shared/prism.json
+++ b/frontend/src/config/shared/prism.json
@@ -2,6 +2,29 @@
     "country": "Global",
     "alertFormActive": false,
     "hidePanel": false,
+    "mapStyles": [
+      {
+        "id": "basic",
+        "label": "Basic",
+        "url": "https://api.maptiler.com/maps/0ad52f6b-ccf2-4a36-a9b8-7ebd8365e56f/style.json?key=y2DTSu9yWiu755WByJr3",
+        "default": true
+      },
+      {
+        "id": "noLabels",
+        "label": "No labels",
+        "url": "https://api.maptiler.com/maps/a97e9d31-055d-48f2-bfa9-ea6b369b9535/style.json?key=y2DTSu9yWiu755WByJr3"
+      },
+      {
+        "id": "satellite",
+        "label": "Satellite",
+        "url": "https://api.maptiler.com/maps/a97e9d31-055d-48f2-bfa9-ea6b369b9535/style.json?key=y2DTSu9yWiu755WByJr3"
+      },
+      {
+        "id": "street",
+        "label": "Street",
+        "url": "https://api.maptiler.com/maps/streets/style.json?key=y2DTSu9yWiu755WByJr3"
+      }
+    ],
     "icons": {
         "capacity": "icon_capacity.png",
         "tables": "icon_table.png",

--- a/frontend/src/context/mapStateSlice/index.ts
+++ b/frontend/src/context/mapStateSlice/index.ts
@@ -9,6 +9,17 @@ import {
 import { BoundaryRelationsDict } from 'components/Common/BoundaryDropdown/utils';
 import { keepLayer } from 'utils/keep-layer-utils';
 import { Map as MaplibreMap } from 'maplibre-gl';
+import { appConfig } from 'config';
+import { get } from 'lodash';
+
+export interface MapStyle {
+  id: string;
+  label: string;
+  url: string;
+  default?: boolean;
+}
+
+const mapStyles: MapStyle[] = get(appConfig, 'mapStyles', []);
 
 interface DateRange {
   startDate?: number;
@@ -18,6 +29,7 @@ interface DateRange {
 
 export type MapState = {
   layers: LayerType[];
+  mapStyle: MapStyle | undefined;
   dateRange: DateRange;
   maplibreMap: MapGetter;
   errors: string[];
@@ -37,6 +49,7 @@ type MapGetter = () => MaplibreMap | undefined;
 
 const initialState: MapState = {
   layers: [],
+  mapStyle: mapStyles?.find(x => x.default),
   dateRange: {} as DateRange,
   maplibreMap: (() => {}) as MapGetter,
   errors: [],
@@ -160,6 +173,11 @@ export const mapStateSlice = createSlice({
       ...rest,
       errors: errors.filter(msg => msg !== payload),
     }),
+
+    setMapStyle: (state, { payload }: PayloadAction<MapStyle>) => ({
+      ...state,
+      mapStyle: payload,
+    }),
   },
   extraReducers: builder => {
     builder.addCase(
@@ -205,6 +223,7 @@ export const {
   setMap,
   removeLayerData,
   setBoundaryRelationData,
+  setMapStyle,
 } = mapStateSlice.actions;
 
 export default mapStateSlice.reducer;

--- a/frontend/src/context/mapStateSlice/selectors.ts
+++ b/frontend/src/context/mapStateSlice/selectors.ts
@@ -36,3 +36,6 @@ export const loadingLayerIdsSelector = (state: RootState): LayerKey[] =>
 export const boundaryRelationSelector = (
   state: RootState,
 ): BoundaryRelationsDict => state.mapState.boundaryRelationData;
+
+export const mapStyleSelector = (state: RootState): MapState['mapStyle'] =>
+  state.mapState.mapStyle;


### PR DESCRIPTION
### Description

This PR adds a drop-down on the navbar to select the map style.

Implement this suggestion: https://github.com/WFP-VAM/prism-app/issues/1199#issuecomment-2077806107

TODO: remove the "street" styles, they are just for test the feature is working. Find working satellite styles.

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
![image](https://github.com/WFP-VAM/prism-app/assets/80451946/5def1fce-edc7-4065-b9c1-7cc0a4bf388c)
