### PR TITLE
Add publication and layer selection dates in print

### DIFF
--- a/frontend/src/components/NavBar/PrintImage/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/NavBar/PrintImage/__snapshots__/index.test.tsx.snap
@@ -42,10 +42,10 @@ exports[`renders as expected 1`] = `
     open="false"
   >
     <mock-dialogcontent
-      classname="DownloadImage-contentContainer-12"
+      classname="DownloadImage-contentContainer-13"
     >
       <div
-        class="DownloadImage-previewContainer-16"
+        class="DownloadImage-previewContainer-17"
       >
         <div>
           <mock-typography
@@ -82,10 +82,20 @@ exports[`renders as expected 1`] = `
               </div>
               
               <div
+                class="DownloadImage-dateFooterOverlay-10"
+                style="font-size: 12px;"
+              >
+                <div
+                  style="padding: 8px;"
+                >
+                  Publication date: 2024-05-03. Layer selection date: 2018-07-02.
+                </div>
+              </div>
+              <div
                 style="position: absolute; z-index: 2; top: 0px; left: 8px; width: 20px; transform: scale(1);"
               >
                 <mock-list
-                  classname="DownloadImage-legendListStyle-14"
+                  classname="DownloadImage-legendListStyle-15"
                 />
               </div>
               <div
@@ -96,11 +106,11 @@ exports[`renders as expected 1`] = `
         </div>
       </div>
       <div
-        class="DownloadImage-optionsContainer-13"
+        class="DownloadImage-optionsContainer-14"
       >
         <div>
           <div
-            class="MuiBox-root MuiBox-root-17 DownloadImage-title-1"
+            class="MuiBox-root MuiBox-root-18 DownloadImage-title-1"
           >
             Map Options
           </div>
@@ -144,10 +154,10 @@ exports[`renders as expected 1`] = `
           />
         </div>
         <div
-          class="DownloadImage-sameRowToggles-15"
+          class="DownloadImage-sameRowToggles-16"
         >
           <div
-            class="makeStyles-wrapper-18"
+            class="makeStyles-wrapper-19"
           >
             <mock-typography
               variant="h4"
@@ -155,12 +165,12 @@ exports[`renders as expected 1`] = `
               Admin area mask
             </mock-typography>
             <div
-              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
+              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
               role="group"
             >
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
                 tabindex="0"
                 type="button"
                 value="1"
@@ -176,7 +186,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="true"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
                 tabindex="0"
                 type="button"
                 value="0"
@@ -193,7 +203,7 @@ exports[`renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-wrapper-18"
+            class="makeStyles-wrapper-19"
           >
             <mock-typography
               style="text-align: end;"
@@ -202,13 +212,13 @@ exports[`renders as expected 1`] = `
               Map Labels
             </mock-typography>
             <div
-              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
+              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
               role="group"
               style="justify-content: end;"
             >
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
                 tabindex="0"
                 type="button"
                 value="0"
@@ -224,7 +234,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="true"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
                 tabindex="0"
                 type="button"
                 value="1"
@@ -242,10 +252,10 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="DownloadImage-sameRowToggles-15"
+          class="DownloadImage-sameRowToggles-16"
         >
           <div
-            class="makeStyles-wrapper-18"
+            class="makeStyles-wrapper-19"
           >
             <mock-typography
               variant="h4"
@@ -253,12 +263,12 @@ exports[`renders as expected 1`] = `
               Legend Position
             </mock-typography>
             <div
-              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
+              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
               role="group"
             >
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
                 tabindex="0"
                 type="button"
                 value="-1"
@@ -274,7 +284,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="true"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
                 tabindex="0"
                 type="button"
                 value="0"
@@ -295,7 +305,7 @@ exports[`renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-wrapper-18"
+            class="makeStyles-wrapper-19"
           >
             <mock-typography
               style="text-align: end;"
@@ -304,13 +314,13 @@ exports[`renders as expected 1`] = `
               Full Layer Description
             </mock-typography>
             <div
-              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
+              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
               role="group"
               style="justify-content: end;"
             >
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
                 tabindex="0"
                 type="button"
                 value="0"
@@ -326,7 +336,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="true"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
                 tabindex="0"
                 type="button"
                 value="1"
@@ -347,7 +357,7 @@ exports[`renders as expected 1`] = `
           style="opacity: 1; pointer-events: auto;"
         >
           <div
-            class="makeStyles-wrapper-18"
+            class="makeStyles-wrapper-19"
           >
             <mock-typography
               variant="h4"
@@ -355,12 +365,12 @@ exports[`renders as expected 1`] = `
               Legend Size
             </mock-typography>
             <div
-              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
+              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
               role="group"
             >
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
                 tabindex="0"
                 type="button"
                 value="0.5"
@@ -378,7 +388,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
                 tabindex="0"
                 type="button"
                 value="0.4"
@@ -396,7 +406,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
                 tabindex="0"
                 type="button"
                 value="0.3"
@@ -414,7 +424,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
                 tabindex="0"
                 type="button"
                 value="0.2"
@@ -432,7 +442,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
                 tabindex="0"
                 type="button"
                 value="0.1"
@@ -450,7 +460,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="true"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
                 tabindex="0"
                 type="button"
                 value="0"
@@ -470,7 +480,7 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-wrapper-18"
+          class="makeStyles-wrapper-19"
         >
           <mock-typography
             variant="h4"
@@ -478,12 +488,12 @@ exports[`renders as expected 1`] = `
             Map Width
           </mock-typography>
           <div
-            class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
+            class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
             role="group"
           >
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
               tabindex="0"
               type="button"
               value="50"
@@ -501,7 +511,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
               tabindex="0"
               type="button"
               value="60"
@@ -519,7 +529,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
               tabindex="0"
               type="button"
               value="70"
@@ -537,7 +547,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
               tabindex="0"
               type="button"
               value="80"
@@ -555,7 +565,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
               tabindex="0"
               type="button"
               value="90"
@@ -573,7 +583,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="true"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
               tabindex="0"
               type="button"
               value="100"
@@ -592,7 +602,7 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-wrapper-18"
+          class="makeStyles-wrapper-19"
         >
           <mock-typography
             variant="h4"
@@ -600,12 +610,12 @@ exports[`renders as expected 1`] = `
             Footer Text
           </mock-typography>
           <div
-            class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
+            class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
             role="group"
           >
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
               tabindex="0"
               type="button"
               value="0"
@@ -621,7 +631,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
               tabindex="0"
               type="button"
               value="8"
@@ -641,7 +651,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
               tabindex="0"
               type="button"
               value="10"
@@ -661,7 +671,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="true"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
               tabindex="0"
               type="button"
               value="12"
@@ -681,7 +691,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
               tabindex="0"
               type="button"
               value="16"
@@ -701,7 +711,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
               tabindex="0"
               type="button"
               value="20"

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -754,7 +754,7 @@ const styles = (theme: Theme) =>
       left: 0,
       zIndex: 2,
       display: 'flex',
-      justifyContent: 'flex-end',
+      justifyContent: 'flex-start',
       color: 'black',
       backgroundColor: 'white',
       width: '100%',

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -341,6 +341,13 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
   };
 
   const scalePercent = useAAMarkerScalePercent(mapRef.current?.getMap());
+  const dateText = `${t('Publication date: ')}${getFormattedDate(
+    new Date(),
+    'default',
+  )}. ${t('Layer selection date: ')}${getFormattedDate(
+    dateRange.startDate,
+    'default',
+  )}.`;
 
   return (
     <>
@@ -403,6 +410,16 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
                       }}
                     >
                       <div style={{ padding: '8px' }}>{footerText}</div>
+                    </div>
+                  )}
+                  {dateText && (
+                    <div
+                      className={classes.dateFooterOverlay}
+                      style={{
+                        fontSize: `${footerTextSize}px`,
+                      }}
+                    >
+                      <div style={{ padding: '8px' }}>{dateText}</div>
                     </div>
                   )}
                   {legendPosition !== -1 && (
@@ -731,11 +748,22 @@ const styles = (theme: Theme) =>
       padding: '8px 0 8px 0',
       borderBottom: `1px solid ${lightGrey}`,
     },
-    footerOverlay: {
+    dateFooterOverlay: {
       position: 'absolute',
       bottom: 0,
       left: 0,
       zIndex: 2,
+      display: 'flex',
+      justifyContent: 'flex-end',
+      color: 'black',
+      backgroundColor: 'white',
+      width: '100%',
+    },
+    footerOverlay: {
+      position: 'absolute',
+      bottom: 20, // leave room for the date text
+      left: 0,
+      zIndex: 3,
       color: 'black',
       backgroundColor: 'white',
       width: '100%',

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -341,12 +341,12 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
   };
 
   const scalePercent = useAAMarkerScalePercent(mapRef.current?.getMap());
-  const dateText = `${t('Publication date: ')}${getFormattedDate(
+  const dateText = `${t('Publication date')}: ${getFormattedDate(
     new Date(),
     'default',
   )}${
     dateRange.startDate
-      ? `. ${t('Layer selection date: ')}${getFormattedDate(
+      ? `. ${t('Layer selection date')}: ${getFormattedDate(
           dateRange.startDate,
           'default',
         )}`

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -344,10 +344,14 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
   const dateText = `${t('Publication date: ')}${getFormattedDate(
     new Date(),
     'default',
-  )}. ${t('Layer selection date: ')}${getFormattedDate(
-    dateRange.startDate,
-    'default',
-  )}.`;
+  )}${
+    dateRange.startDate
+      ? `. ${t('Layer selection date: ')}${getFormattedDate(
+          dateRange.startDate,
+          'default',
+        )}`
+      : ''
+  }.`;
 
   return (
     <>

--- a/frontend/src/config/shared/prism.json
+++ b/frontend/src/config/shared/prism.json
@@ -1,27 +1,23 @@
 {
-    "country": "Global",
-    "alertFormActive": false,
-    "hidePanel": false,
-    "icons": {
-        "capacity": "icon_capacity.png",
-        "tables": "icon_table.png",
-        "rainfall": "icon_rain.png",
-        "vegetation": "icon_veg.png",
-        "temperature": "icon_climate.png",
-        "vulnerability": "icon_vulnerable.png"
-    },
-    "serversUrls": {
-        "wms": [
-            "https://api.earthobservation.vam.wfp.org/ows/wms"
-        ]
-    },
-    "map": {
-        "boundingBox": [
-            -171,
-            -56,
-            180,
-            76
-        ]
-    },
-    "categories": {}
+  "country": "Global",
+  "alertFormActive": false,
+  "hidePanel": false,
+  "printConfig": {
+    "defaultFooterText": "The designations employed and the presentation of material in the map(s) do not imply the expression of any opinion on the part of WFP concerning the legal of constitutional status of any country, territory, city, or sea, or concerning the delimitation of its frontiers or boundaries."
+  },
+  "icons": {
+    "capacity": "icon_capacity.png",
+    "tables": "icon_table.png",
+    "rainfall": "icon_rain.png",
+    "vegetation": "icon_veg.png",
+    "temperature": "icon_climate.png",
+    "vulnerability": "icon_vulnerable.png"
+  },
+  "serversUrls": {
+    "wms": ["https://api.earthobservation.vam.wfp.org/ows/wms"]
+  },
+  "map": {
+    "boundingBox": [-171, -56, 180, 76]
+  },
+  "categories": {}
 }


### PR DESCRIPTION
### Description

This fixes #1208 and #1222.

This PR adds a footer with the publication and layer selection dates. Not editable for now but translatable.

This also re-adds the default footer text in the shared prism.json, making it easy to override. Eventually, we should have a reasonable set of defaults in the `shared/prism.json` showing users what settings they can easily configure and toggle.

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
<img width="1246" alt="Screenshot 2024-05-03 at 11 40 13 AM" src="https://github.com/WFP-VAM/prism-app/assets/16843267/92488af2-f1ac-4a53-ad60-1993a0e3212d">
