### PR TITLE
Fix footer overlapping scale bar

### DIFF
--- a/frontend/src/components/NavBar/PrintImage/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/NavBar/PrintImage/__snapshots__/index.test.tsx.snap
@@ -42,10 +42,10 @@ exports[`renders as expected 1`] = `
     open="false"
   >
     <mock-dialogcontent
-      classname="DownloadImage-contentContainer-13"
+      classname="DownloadImage-contentContainer-12"
     >
       <div
-        class="DownloadImage-previewContainer-17"
+        class="DownloadImage-previewContainer-16"
       >
         <div>
           <mock-typography
@@ -80,11 +80,11 @@ exports[`renders as expected 1`] = `
               >
                 Mozambique
               </div>
-              
               <div
-                class="DownloadImage-dateFooterOverlay-10"
+                class="DownloadImage-footerOverlay-10"
                 style="font-size: 12px;"
               >
+                
                 <div
                   style="padding: 8px;"
                 >
@@ -95,7 +95,7 @@ exports[`renders as expected 1`] = `
                 style="position: absolute; z-index: 2; top: 0px; left: 8px; display: flex; justify-content: flex-start; width: 20px; transform: scale(1);"
               >
                 <mock-list
-                  classname="DownloadImage-legendListStyle-15"
+                  classname="DownloadImage-legendListStyle-14"
                   disablepadding="true"
                 />
               </div>
@@ -107,11 +107,11 @@ exports[`renders as expected 1`] = `
         </div>
       </div>
       <div
-        class="DownloadImage-optionsContainer-14"
+        class="DownloadImage-optionsContainer-13"
       >
         <div>
           <div
-            class="MuiBox-root MuiBox-root-18 DownloadImage-title-1"
+            class="MuiBox-root MuiBox-root-17 DownloadImage-title-1"
           >
             Map Options
           </div>
@@ -155,10 +155,10 @@ exports[`renders as expected 1`] = `
           />
         </div>
         <div
-          class="DownloadImage-sameRowToggles-16"
+          class="DownloadImage-sameRowToggles-15"
         >
           <div
-            class="makeStyles-wrapper-19"
+            class="makeStyles-wrapper-18"
           >
             <mock-typography
               variant="h4"
@@ -166,12 +166,12 @@ exports[`renders as expected 1`] = `
               Logo Position
             </mock-typography>
             <div
-              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
+              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
               role="group"
             >
               <button
                 aria-pressed="true"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
                 tabindex="0"
                 type="button"
                 value="-1"
@@ -187,7 +187,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                 tabindex="0"
                 type="button"
                 value="0"
@@ -211,7 +211,7 @@ exports[`renders as expected 1`] = `
             style="opacity: 0.5; pointer-events: none;"
           >
             <div
-              class="makeStyles-wrapper-19"
+              class="makeStyles-wrapper-18"
             >
               <mock-typography
                 style="text-align: end;"
@@ -220,13 +220,13 @@ exports[`renders as expected 1`] = `
                 Logo Size
               </mock-typography>
               <div
-                class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
+                class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
                 role="group"
                 style="justify-content: end;"
               >
                 <button
                   aria-pressed="false"
-                  class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                  class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                   tabindex="0"
                   type="button"
                   value="0.5"
@@ -246,7 +246,7 @@ exports[`renders as expected 1`] = `
                 </button>
                 <button
                   aria-pressed="true"
-                  class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
+                  class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
                   tabindex="0"
                   type="button"
                   value="1"
@@ -266,7 +266,7 @@ exports[`renders as expected 1`] = `
                 </button>
                 <button
                   aria-pressed="false"
-                  class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                  class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                   tabindex="0"
                   type="button"
                   value="1.5"
@@ -289,10 +289,10 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="DownloadImage-sameRowToggles-16"
+          class="DownloadImage-sameRowToggles-15"
         >
           <div
-            class="makeStyles-wrapper-19"
+            class="makeStyles-wrapper-18"
           >
             <mock-typography
               variant="h4"
@@ -300,12 +300,12 @@ exports[`renders as expected 1`] = `
               Admin Area Mask
             </mock-typography>
             <div
-              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
+              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
               role="group"
             >
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                 tabindex="0"
                 type="button"
                 value="1"
@@ -321,7 +321,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="true"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
                 tabindex="0"
                 type="button"
                 value="0"
@@ -338,7 +338,7 @@ exports[`renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-wrapper-19"
+            class="makeStyles-wrapper-18"
           >
             <mock-typography
               style="text-align: end;"
@@ -347,13 +347,13 @@ exports[`renders as expected 1`] = `
               Map Labels
             </mock-typography>
             <div
-              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
+              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
               role="group"
               style="justify-content: end;"
             >
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                 tabindex="0"
                 type="button"
                 value="0"
@@ -369,7 +369,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="true"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
                 tabindex="0"
                 type="button"
                 value="1"
@@ -387,10 +387,10 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="DownloadImage-sameRowToggles-16"
+          class="DownloadImage-sameRowToggles-15"
         >
           <div
-            class="makeStyles-wrapper-19"
+            class="makeStyles-wrapper-18"
           >
             <mock-typography
               variant="h4"
@@ -398,12 +398,12 @@ exports[`renders as expected 1`] = `
               Legend Position
             </mock-typography>
             <div
-              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
+              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
               role="group"
             >
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                 tabindex="0"
                 type="button"
                 value="-1"
@@ -419,7 +419,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="true"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
                 tabindex="0"
                 type="button"
                 value="0"
@@ -440,7 +440,7 @@ exports[`renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="makeStyles-wrapper-19"
+            class="makeStyles-wrapper-18"
           >
             <mock-typography
               style="text-align: end;"
@@ -449,13 +449,13 @@ exports[`renders as expected 1`] = `
               Full Layer Description
             </mock-typography>
             <div
-              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
+              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
               role="group"
               style="justify-content: end;"
             >
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                 tabindex="0"
                 type="button"
                 value="0"
@@ -471,7 +471,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="true"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
                 tabindex="0"
                 type="button"
                 value="1"
@@ -492,7 +492,7 @@ exports[`renders as expected 1`] = `
           style="opacity: 1; pointer-events: auto;"
         >
           <div
-            class="makeStyles-wrapper-19"
+            class="makeStyles-wrapper-18"
           >
             <mock-typography
               variant="h4"
@@ -500,12 +500,12 @@ exports[`renders as expected 1`] = `
               Legend Size
             </mock-typography>
             <div
-              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
+              class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
               role="group"
             >
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                 tabindex="0"
                 type="button"
                 value="0.5"
@@ -523,7 +523,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                 tabindex="0"
                 type="button"
                 value="0.4"
@@ -541,7 +541,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                 tabindex="0"
                 type="button"
                 value="0.3"
@@ -559,7 +559,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                 tabindex="0"
                 type="button"
                 value="0.2"
@@ -577,7 +577,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="false"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
                 tabindex="0"
                 type="button"
                 value="0.1"
@@ -595,7 +595,7 @@ exports[`renders as expected 1`] = `
               </button>
               <button
                 aria-pressed="true"
-                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
+                class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
                 tabindex="0"
                 type="button"
                 value="0"
@@ -615,7 +615,7 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-wrapper-19"
+          class="makeStyles-wrapper-18"
         >
           <mock-typography
             variant="h4"
@@ -623,12 +623,12 @@ exports[`renders as expected 1`] = `
             Map Width
           </mock-typography>
           <div
-            class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
+            class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
             role="group"
           >
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
               tabindex="0"
               type="button"
               value="50"
@@ -646,7 +646,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
               tabindex="0"
               type="button"
               value="60"
@@ -664,7 +664,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
               tabindex="0"
               type="button"
               value="70"
@@ -682,7 +682,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
               tabindex="0"
               type="button"
               value="80"
@@ -700,7 +700,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
               tabindex="0"
               type="button"
               value="90"
@@ -718,7 +718,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="true"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
               tabindex="0"
               type="button"
               value="100"
@@ -737,7 +737,7 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="makeStyles-wrapper-19"
+          class="makeStyles-wrapper-18"
         >
           <mock-typography
             variant="h4"
@@ -745,12 +745,12 @@ exports[`renders as expected 1`] = `
             Footer Text
           </mock-typography>
           <div
-            class="MuiToggleButtonGroup-root makeStyles-buttonGroup-20"
+            class="MuiToggleButtonGroup-root makeStyles-buttonGroup-19"
             role="group"
           >
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
               tabindex="0"
               type="button"
               value="0"
@@ -766,7 +766,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
               tabindex="0"
               type="button"
               value="8"
@@ -786,7 +786,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
               tabindex="0"
               type="button"
               value="10"
@@ -806,7 +806,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="true"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21 Mui-selected"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20 Mui-selected"
               tabindex="0"
               type="button"
               value="12"
@@ -826,7 +826,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
               tabindex="0"
               type="button"
               value="16"
@@ -846,7 +846,7 @@ exports[`renders as expected 1`] = `
             </button>
             <button
               aria-pressed="false"
-              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-21"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal makeStyles-button-20"
               tabindex="0"
               type="button"
               value="20"

--- a/frontend/src/components/NavBar/PrintImage/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/NavBar/PrintImage/__snapshots__/index.test.tsx.snap
@@ -85,11 +85,9 @@ exports[`renders as expected 1`] = `
                 style="font-size: 12px;"
               >
                 
-                <div
-                  style="padding: 8px;"
-                >
+                <mock-typography>
                   Publication date: 2018-07-02. Layer selection date: 2018-07-02.
-                </div>
+                </mock-typography>
               </div>
               <div
                 style="position: absolute; z-index: 2; top: 0px; left: 8px; display: flex; justify-content: flex-start; width: 20px; transform: scale(1);"

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -434,7 +434,7 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
                       {titleText}
                     </div>
                   )}
-                  {footerTextSize > 0 && footerText && (
+                  {footerTextSize > 0 && (footerText || dateText) && (
                     <div
                       ref={footerRef}
                       className={classes.footerOverlay}
@@ -442,7 +442,12 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
                         fontSize: `${footerTextSize}px`,
                       }}
                     >
-                      <div style={{ padding: '8px' }}>{footerText}</div>
+                      {footerText && (
+                        <div style={{ padding: '8px' }}>{footerText}</div>
+                      )}
+                      {dateText && (
+                        <div style={{ padding: '8px' }}>{dateText}</div>
+                      )}
                     </div>
                   )}
                   {logoPosition !== -1 && (
@@ -461,16 +466,6 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
                       src={logo}
                       alt="logo"
                     />
-                  )}
-                  {dateText && (
-                    <div
-                      className={classes.dateFooterOverlay}
-                      style={{
-                        fontSize: `${footerTextSize}px`,
-                      }}
-                    >
-                      <div style={{ padding: '8px' }}>{dateText}</div>
-                    </div>
                   )}
                   {legendPosition !== -1 && (
                     <div
@@ -835,20 +830,9 @@ const styles = (theme: Theme) =>
       padding: '8px 0 8px 0',
       borderBottom: `1px solid ${lightGrey}`,
     },
-    dateFooterOverlay: {
-      position: 'absolute',
-      bottom: 0,
-      left: 0,
-      zIndex: 2,
-      display: 'flex',
-      justifyContent: 'flex-start',
-      color: 'black',
-      backgroundColor: 'white',
-      width: '100%',
-    },
     footerOverlay: {
       position: 'absolute',
-      bottom: 20, // leave room for the date text
+      bottom: 0,
       left: 0,
       zIndex: 3,
       color: 'black',

--- a/frontend/src/components/NavBar/PrintImage/image.tsx
+++ b/frontend/src/components/NavBar/PrintImage/image.tsx
@@ -443,11 +443,11 @@ function DownloadImage({ classes, open, handleClose }: DownloadImageProps) {
                       }}
                     >
                       {footerText && (
-                        <div style={{ padding: '8px' }}>{footerText}</div>
+                        <Typography style={{ whiteSpace: 'pre-line' }}>
+                          {footerText}
+                        </Typography>
                       )}
-                      {dateText && (
-                        <div style={{ padding: '8px' }}>{dateText}</div>
-                      )}
+                      {dateText && <Typography>{dateText}</Typography>}
                     </div>
                   )}
                   {logoPosition !== -1 && (
@@ -831,6 +831,7 @@ const styles = (theme: Theme) =>
       borderBottom: `1px solid ${lightGrey}`,
     },
     footerOverlay: {
+      padding: '8px',
       position: 'absolute',
       bottom: 0,
       left: 0,


### PR DESCRIPTION
### Description

A quick fix for the footer overlapping with the scale bar

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
before
![image](https://github.com/WFP-VAM/prism-app/assets/80451946/3ffcaf42-15a9-4885-bc07-8ae2d9203223)

after
![image](https://github.com/WFP-VAM/prism-app/assets/80451946/57596d8f-c494-4749-86b9-db5aaec47791)


