### PR TITLE
Add AA icons for the Normal category; COUNTRY=zimbabwe

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/DistrictView/ActionsModal/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/DistrictView/ActionsModal/__snapshots__/index.test.tsx.snap
@@ -402,6 +402,199 @@ exports[`renders actions modal 1`] = `
           >
             <svg
               aria-hidden="true"
+              class="svg-inline--fa fa-people-group "
+              data-icon="people-group"
+              data-prefix="fas"
+              focusable="false"
+              font-size="1rem"
+              role="img"
+              viewBox="0 0 640 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M72 88a56 56 0 1 1 112 0A56 56 0 1 1 72 88zM64 245.7C54 256.9 48 271.8 48 288s6 31.1 16 42.3V245.7zm144.4-49.3C178.7 222.7 160 261.2 160 304c0 34.3 12 65.8 32 90.5V416c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V389.2C26.2 371.2 0 332.7 0 288c0-61.9 50.1-112 112-112h32c24 0 46.2 7.5 64.4 20.3zM448 416V394.5c20-24.7 32-56.2 32-90.5c0-42.8-18.7-81.3-48.4-107.7C449.8 183.5 472 176 496 176h32c61.9 0 112 50.1 112 112c0 44.7-26.2 83.2-64 101.2V416c0 17.7-14.3 32-32 32H480c-17.7 0-32-14.3-32-32zm8-328a56 56 0 1 1 112 0A56 56 0 1 1 456 88zM576 245.7v84.7c10-11.3 16-26.1 16-42.3s-6-31.1-16-42.3zM320 32a64 64 0 1 1 0 128 64 64 0 1 1 0-128zM240 304c0 16.2 6 31 16 42.3V261.7c-10 11.3-16 26.1-16 42.3zm144-42.3v84.7c10-11.3 16-26.1 16-42.3s-6-31.1-16-42.3zM448 304c0 44.7-26.2 83.2-64 101.2V448c0 17.7-14.3 32-32 32H288c-17.7 0-32-14.3-32-32V405.2c-37.8-18-64-56.5-64-101.2c0-61.9 50.1-112 112-112h32c61.9 0 112 50.1 112 112z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <mock-typography
+            variant="h3"
+          >
+            Convening with stakeholders
+          </mock-typography>
+        </div>
+        <div
+          class="makeStyles-actionRow-3"
+        >
+          <div
+            class="makeStyles-actionIconWrapper-4"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-money-bill-wave "
+              data-icon="money-bill-wave"
+              data-prefix="fas"
+              focusable="false"
+              font-size="1rem"
+              role="img"
+              viewBox="0 0 576 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0 112.5V422.3c0 18 10.1 35 27 41.3c87 32.5 174 10.3 261-11.9c79.8-20.3 159.6-40.7 239.3-18.9c23 6.3 48.7-9.5 48.7-33.4V89.7c0-18-10.1-35-27-41.3C462 15.9 375 38.1 288 60.3C208.2 80.6 128.4 100.9 48.7 79.1C25.6 72.8 0 88.6 0 112.5zM288 352c-44.2 0-80-43-80-96s35.8-96 80-96s80 43 80 96s-35.8 96-80 96zM64 352c35.3 0 64 28.7 64 64H64V352zm64-208c0 35.3-28.7 64-64 64V144h64zM512 304v64H448c0-35.3 28.7-64 64-64zM448 96h64v64c-35.3 0-64-28.7-64-64z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <mock-typography
+            variant="h3"
+          >
+            Requesting funds
+          </mock-typography>
+        </div>
+        <div
+          class="makeStyles-actionRow-3"
+        >
+          <div
+            class="makeStyles-actionIconWrapper-4"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-list "
+              data-icon="list"
+              data-prefix="fas"
+              focusable="false"
+              font-size="1rem"
+              role="img"
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M40 48C26.7 48 16 58.7 16 72v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V72c0-13.3-10.7-24-24-24H40zM192 64c-17.7 0-32 14.3-32 32s14.3 32 32 32H480c17.7 0 32-14.3 32-32s-14.3-32-32-32H192zm0 160c-17.7 0-32 14.3-32 32s14.3 32 32 32H480c17.7 0 32-14.3 32-32s-14.3-32-32-32H192zm0 160c-17.7 0-32 14.3-32 32s14.3 32 32 32H480c17.7 0 32-14.3 32-32s-14.3-32-32-32H192zM16 232v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V232c0-13.3-10.7-24-24-24H40c-13.3 0-24 10.7-24 24zM40 368c-13.3 0-24 10.7-24 24v48c0 13.3 10.7 24 24 24H88c13.3 0 24-10.7 24-24V392c0-13.3-10.7-24-24-24H40z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <mock-typography
+            variant="h3"
+          >
+            Updating beneficiary lists
+          </mock-typography>
+        </div>
+        <div
+          class="makeStyles-actionRow-3"
+        >
+          <div
+            class="makeStyles-actionIconWrapper-4"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              style="font-size: 1rem;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6zm-2 0l-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z"
+              />
+            </svg>
+          </div>
+          <mock-typography
+            variant="h3"
+          >
+            Dissemination of climate information
+          </mock-typography>
+        </div>
+        <div
+          class="makeStyles-actionRow-3"
+        >
+          <div
+            class="makeStyles-actionIconWrapper-4"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-seedling "
+              data-icon="seedling"
+              data-prefix="fas"
+              focusable="false"
+              font-size="1rem"
+              role="img"
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M512 32c0 113.6-84.6 207.5-194.2 222c-7.1-53.4-30.6-101.6-65.3-139.3C290.8 46.3 364 0 448 0h32c17.7 0 32 14.3 32 32zM0 96C0 78.3 14.3 64 32 64H64c123.7 0 224 100.3 224 224v32V480c0 17.7-14.3 32-32 32s-32-14.3-32-32V320C100.3 320 0 219.7 0 96z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <mock-typography
+            variant="h3"
+          >
+            Distribution of drought tolerant inputs
+          </mock-typography>
+        </div>
+        <div
+          class="makeStyles-actionRow-3"
+        >
+          <div
+            class="makeStyles-actionIconWrapper-4"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root"
+              focusable="false"
+              style="font-size: 1rem;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M3 2l2.01 18.23C5.13 21.23 5.97 22 7 22h10c1.03 0 1.87-.77 1.99-1.77L21 2H3zm9 17c-1.66 0-3-1.34-3-3 0-2 3-5.4 3-5.4s3 3.4 3 5.4c0 1.66-1.34 3-3 3zm6.33-11H5.67l-.44-4h13.53l-.43 4z"
+              />
+            </svg>
+          </div>
+          <mock-typography
+            variant="h3"
+          >
+            Water provision
+          </mock-typography>
+        </div>
+        <div
+          class="makeStyles-actionRow-3"
+        >
+          <div
+            class="makeStyles-actionIconWrapper-4"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-money-bill-transfer "
+              data-icon="money-bill-transfer"
+              data-prefix="fas"
+              focusable="false"
+              font-size="1rem"
+              role="img"
+              viewBox="0 0 640 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M535 41c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l64 64c4.5 4.5 7 10.6 7 17s-2.5 12.5-7 17l-64 64c-9.4 9.4-24.6 9.4-33.9 0s-9.4-24.6 0-33.9l23-23L384 112c-13.3 0-24-10.7-24-24s10.7-24 24-24l174.1 0L535 41zM105 377l-23 23L256 400c13.3 0 24 10.7 24 24s-10.7 24-24 24L81.9 448l23 23c9.4 9.4 9.4 24.6 0 33.9s-24.6 9.4-33.9 0L7 441c-4.5-4.5-7-10.6-7-17s2.5-12.5 7-17l64-64c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9zM96 64H337.9c-3.7 7.2-5.9 15.3-5.9 24c0 28.7 23.3 52 52 52l117.4 0c-4 17 .6 35.5 13.8 48.8c20.3 20.3 53.2 20.3 73.5 0L608 169.5V384c0 35.3-28.7 64-64 64H302.1c3.7-7.2 5.9-15.3 5.9-24c0-28.7-23.3-52-52-52l-117.4 0c4-17-.6-35.5-13.8-48.8c-20.3-20.3-53.2-20.3-73.5 0L32 342.5V128c0-35.3 28.7-64 64-64zm64 64H96v64c35.3 0 64-28.7 64-64zM544 320c-35.3 0-64 28.7-64 64h64V320zM320 352a96 96 0 1 0 0-192 96 96 0 1 0 0 192z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <mock-typography
+            variant="h3"
+          >
+            In kind/cash transfer
+          </mock-typography>
+        </div>
+        <div
+          class="makeStyles-actionRow-3"
+        >
+          <div
+            class="makeStyles-actionIconWrapper-4"
+          >
+            <svg
+              aria-hidden="true"
               class="MuiSvgIcon-root"
               focusable="false"
               style="font-size: 1rem; color: darkgrey;"

--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/DistrictView/ActionsModal/actions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/DistrictView/ActionsModal/actions.tsx
@@ -10,11 +10,14 @@ import {
 import {
   faCow,
   faHandshake,
+  faMoneyBillWave,
+  faMoneyBillTransfer,
   faPeopleGroup,
   faPersonDigging,
   faPlateWheat,
   faSeedling,
   faSyringe,
+  faList,
 } from '@fortawesome/free-solid-svg-icons';
 import {
   FontAwesomeIcon,
@@ -95,6 +98,36 @@ export const AActions = {
     name: 'Signing contracts and mobilization of assets',
     icon: <FontAwesomeIconWrap icon={faHandshake} />,
   },
+  // Actions for Normal Phase (Zimbabwe)
+  convening: {
+    name: 'Convening with stakeholders',
+    icon: <FontAwesomeIconWrap icon={faPeopleGroup} />,
+  },
+  requestingFunds: {
+    name: 'Requesting funds',
+    icon: <FontAwesomeIconWrap icon={faMoneyBillWave} />,
+  },
+  updatingLists: {
+    name: 'Updating beneficiary lists',
+    icon: <FontAwesomeIconWrap icon={faList} />,
+  },
+  climateInfo: {
+    name: 'Dissemination of climate information',
+    icon: <MarkunreadOutlined style={{ fontSize: IconSize }} />,
+  },
+  droughtInputs: {
+    name: 'Distribution of drought tolerant inputs',
+    icon: <FontAwesomeIconWrap icon={faSeedling} />,
+  },
+  waterProvision: {
+    name: 'Water provision',
+    icon: <LocalDrink style={{ fontSize: IconSize }} />,
+  },
+  cashTransfer: {
+    name: 'In kind/cash transfer',
+    icon: <FontAwesomeIconWrap icon={faMoneyBillTransfer} />,
+  },
+  // No Action
   naMild: {
     name: 'No anticipatory action linked to Mild levels',
     icon: <Remove style={{ fontSize: IconSize, color: 'darkgrey' }} />,
@@ -143,6 +176,22 @@ const actionsMap: ActionsMap = {
     AActions.schoolLunch,
     AActions.socialAssistance,
   ],
+  ReadyNormalW1: [
+    AActions.convening,
+    AActions.requestingFunds,
+    AActions.updatingLists,
+  ],
+  ReadyNormalW2: [
+    AActions.convening,
+    AActions.requestingFunds,
+    AActions.updatingLists,
+  ],
+  SetNormalW1: [
+    AActions.climateInfo,
+    AActions.droughtInputs,
+    AActions.waterProvision,
+  ],
+  SetNormalW2: [AActions.climateInfo, AActions.cashTransfer],
 };
 
 // Function to get actions by state, severity, and window


### PR DESCRIPTION
### Description

Add AA icons for the Normal category.

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
<img width="443" alt="Screenshot 2024-05-23 at 2 30 12 PM" src="https://github.com/WFP-VAM/prism-app/assets/16843267/2dbcc555-0528-4356-abdd-c53814dee14a">
