### PR TITLE
Alerting - source AWS secrets

### DIFF
--- a/alerting/package.json
+++ b/alerting/package.json
@@ -22,7 +22,7 @@
     "migration:revert": "yarn typeorm migration:revert",
     "typeorm-seeding": "ts-node $(yarn bin typeorm-seeding)",
     "alert-worker": "yarn ts-node src/alert-worker.ts",
-    "docker-alert": "docker compose run --entrypoint 'yarn alert-worker' alerting-node"
+    "docker-alert": "source ../api/set_envs.sh && docker compose run --entrypoint 'yarn alert-worker' alerting-node"
   },
   "dependencies": {
     "@turf/bbox": "^6.3.0",


### PR DESCRIPTION
### Description

This ensures that the alerting module is sourcing the updated secrets from AWS.
@wadhwamatic not that the corresponding prism_alerts_email secrets are currently incomplete. We have `prism.alerts.wfp@gmail.com` as the email but no password. Should we roll back to an ovio email? Or can you get an email and password pair from the IT team?