### PR TITLE
Supporting Legend Markdown for analysis results; COUNTRY=rbd

### DIFF
--- a/frontend/src/components/MapView/Legends/LegendImpactResult/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/Legends/LegendImpactResult/__snapshots__/index.test.tsx.snap
@@ -2,10 +2,9 @@
 
 exports[`renders as expected 1`] = `
 <div>
-  Impact Analysis on: Some test legend text
-  <br />
+  Impact Analysis on:
+  Some test legend text
   
-  <br />
   
 </div>
 `;

--- a/frontend/src/components/MapView/Legends/LegendImpactResult/index.tsx
+++ b/frontend/src/components/MapView/Legends/LegendImpactResult/index.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
 import { useSafeTranslation } from 'i18n';
+import LegendMarkdown from '../LegendMarkdown';
 
 interface LegendImpactProps {
   legendText: string;
@@ -12,11 +13,24 @@ const LegendImpactResult = memo(
     const { t } = useSafeTranslation();
     return (
       <>
-        {`${t('Impact Analysis on')}: ${t(legendText)}`}
-        <br />
-        {thresholdAbove ? `${t('Above Threshold')}: ${thresholdAbove}` : ''}
-        <br />
-        {thresholdBelow ? `${t('Below Threshold')}: ${thresholdBelow}` : ''}
+        {`${t('Impact Analysis on')}:`}
+        <LegendMarkdown>{t(legendText)}</LegendMarkdown>
+        {thresholdAbove ? (
+          <>
+            <br />
+            {t('Above Threshold')}: {thresholdAbove}
+          </>
+        ) : (
+          ''
+        )}
+        {thresholdBelow ? (
+          <>
+            <br />
+            {t('Below Threshold')}: {thresholdBelow}
+          </>
+        ) : (
+          ''
+        )}
       </>
     );
   },

--- a/frontend/src/components/MapView/Legends/LegendItem/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/Legends/LegendItem/__snapshots__/index.test.tsx.snap
@@ -30,14 +30,14 @@ exports[`renders as expected 1`] = `
         />
       </div>
       <div
-        class="MuiLinearProgress-root makeStyles-root-11 MuiLinearProgress-colorPrimary MuiLinearProgress-indeterminate"
+        class="MuiLinearProgress-root makeStyles-root-10 MuiLinearProgress-colorPrimary MuiLinearProgress-indeterminate"
         role="progressbar"
       >
         <div
-          class="MuiLinearProgress-bar makeStyles-hide-13 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Indeterminate"
+          class="MuiLinearProgress-bar makeStyles-hide-12 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Indeterminate"
         />
         <div
-          class="MuiLinearProgress-bar makeStyles-hide-13 MuiLinearProgress-bar2Indeterminate MuiLinearProgress-barColorPrimary"
+          class="MuiLinearProgress-bar makeStyles-hide-12 MuiLinearProgress-bar2Indeterminate MuiLinearProgress-barColorPrimary"
         />
       </div>
       <div
@@ -55,7 +55,7 @@ exports[`renders as expected 1`] = `
         style="margin: 8px 0px;"
       />
       <div
-        class="MuiBox-root MuiBox-root-14"
+        class="MuiBox-root MuiBox-root-13"
       >
         <mock-tooltip
           title="Opacity"
@@ -89,7 +89,7 @@ exports[`renders as expected 1`] = `
           open="false"
         >
           <div
-            class="MuiBox-root MuiBox-root-15 memo-opacityBox-3"
+            class="MuiBox-root MuiBox-root-14 memo-opacityBox-3"
           >
             <mock-typography
               classes="[object Object]"

--- a/frontend/src/components/MapView/Legends/LegendItem/index.tsx
+++ b/frontend/src/components/MapView/Legends/LegendItem/index.tsx
@@ -41,8 +41,8 @@ import AnalysisDownloadButton from 'components/MapView/Legends//AnalysisDownload
 import { toggleRemoveLayer } from 'components/MapView/LeftPanel/layersPanel/MenuItem/MenuSwitch/SwitchItem/utils';
 import { opacitySelector, setOpacity } from 'context/opacityStateSlice';
 import { lightGrey } from 'muiTheme';
-import Markdown from 'react-markdown';
 import LoadingBar from '../LoadingBar';
+import LegendMarkdown from '../LegendMarkdown';
 
 // Children here is legendText
 const LegendItem = memo(
@@ -210,28 +210,13 @@ const LegendItem = memo(
       return (
         <Grid item>
           {typeof children === 'string' ? (
-            <Markdown
-              linkTarget="_blank"
-              components={{
-                p: ({ children: pChildren }: { children: React.ReactNode }) => (
-                  <Typography
-                    variant="h5"
-                    className={classes.legendTextMarkdown}
-                  >
-                    {pChildren}
-                  </Typography>
-                ),
-              }}
-              allowedElements={['p', 'h5', 'strong', 'em', 'a']}
-            >
-              {children}
-            </Markdown>
+            <LegendMarkdown>{children}</LegendMarkdown>
           ) : (
             <Typography variant="h5">{children}</Typography>
           )}
         </Grid>
       );
-    }, [children, classes.legendTextMarkdown]);
+    }, [children]);
 
     return (
       <ListItem disableGutters dense>
@@ -340,11 +325,6 @@ const styles = () =>
       marginRight: 5,
       width: 28,
       lineHeight: '36px',
-    },
-    legendTextMarkdown: {
-      '& a': {
-        textDecoration: 'underline',
-      },
     },
   });
 

--- a/frontend/src/components/MapView/Legends/LegendMarkdown.tsx
+++ b/frontend/src/components/MapView/Legends/LegendMarkdown.tsx
@@ -1,0 +1,39 @@
+import {
+  Typography,
+  WithStyles,
+  createStyles,
+  withStyles,
+} from '@material-ui/core';
+import React from 'react';
+import Markdown from 'react-markdown';
+
+interface LegendMarkdownProps extends WithStyles<typeof styles> {
+  children: string;
+}
+
+const LegendMarkdown = ({ children, classes }: LegendMarkdownProps) => (
+  <Markdown
+    linkTarget="_blank"
+    components={{
+      p: ({ children: pChildren }: { children: React.ReactNode }) => (
+        <Typography variant="h5" className={classes.legendTextMarkdown}>
+          {pChildren}
+        </Typography>
+      ),
+    }}
+    allowedElements={['p', 'h5', 'strong', 'em', 'a']}
+  >
+    {children}
+  </Markdown>
+);
+
+const styles = () =>
+  createStyles({
+    legendTextMarkdown: {
+      '& a': {
+        textDecoration: 'underline',
+      },
+    },
+  });
+
+export default withStyles(styles)(LegendMarkdown);


### PR DESCRIPTION
### Description
I noticed during my work on #1173 that the markdown wasn't working on the Legend panel for analysis results. This fixes that issue.

- Creating Legend Markdown component
- Applying in both LegendItem and LegendImpactResult

| Before | After |
| - | - |
| <img width="1137" alt="Screenshot 2024-07-03 at 12 27 06 PM" src="https://github.com/WFP-VAM/prism-app/assets/8203830/4a2a5884-df33-4461-8860-20b863805abf"> | <img width="1142" alt="Screenshot 2024-07-03 at 12 25 50 PM" src="https://github.com/WFP-VAM/prism-app/assets/8203830/a29d7a4e-df8a-4102-8899-bf9210d2b39d"> |

## How to test the feature:
- [ ] Run an analysis (such as RBD's 10-day rainfall estimate)
- [ ] Check that legend text is still 

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

