### PR TITLE
Only log missing key if language not English

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -102,7 +102,10 @@ i18n
     defaultNS: 'translation',
     saveMissing: true,
     missingKeyHandler: (lng, _ns, key) => {
-      logMissingKey(Array.isArray(lng) ? lng[0] : lng, key);
+      const foundLng = Array.isArray(lng) ? lng[0] : lng;
+      if (foundLng !== 'en') {
+        logMissingKey(foundLng, key);
+      }
     },
   });
 


### PR DESCRIPTION
### Description
Running the app in English results in every translation key reported as missing (because there are no english translations provided). This suppresses the unhelpful warning for English.
<img width="1228" alt="Screenshot 2024-07-12 at 2 56 34 PM" src="https://github.com/user-attachments/assets/575feb6e-6420-4dd5-8f54-ca077b5cf588">

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
