### PR TITLE
Bugfix: Dropdown layer selection remains after selection; COUNTRY=jordan

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/utils.ts
+++ b/frontend/src/components/MapView/LeftPanel/utils.ts
@@ -50,7 +50,7 @@ function formatLayersCategories(
           layer.group = group;
         }
 
-        return layer;
+        return { ...layer, group };
       }
       return LayerDefinitions[key as LayerKey];
     }),


### PR DESCRIPTION
### Description

This fixes #1324 by returning layer with group from formatLayersCategories regardless of whether layer is frozen.

## How to test the feature:
- [ ] Load up Jordan
- [ ] Toggle between monthly and seasonal CDI

## Checklist - did you ...

Test your changes with
- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
Bug:
https://www.loom.com/share/9836aea706db463f958c47928f092ab2?sid=30bd8f75-206e-4ce2-b470-0489a168e8e6
Fix: 
https://www.loom.com/share/5d8eaacc94b2426f922e3f3f58c19d47?sid=efb91ecc-a4f2-44eb-bb1e-c5a10e85f14d


