### PR TITLE
Fix season prevMax reset for AA; COUNTRY=zimbabwe

### DIFF
--- a/frontend/src/context/anticipatoryActionStateSlice/utils.ts
+++ b/frontend/src/context/anticipatoryActionStateSlice/utils.ts
@@ -159,6 +159,7 @@ export function parseAndTransformAA(data: any[]) {
           dateData.forEach(x => {
             // reset prevMax when entering a new season
             if (prevMax && x.season !== prevMax.season) {
+              // eslint-disable-next-line fp/no-mutation
               prevMax = undefined;
             }
             if (!x.isValid) {

--- a/frontend/src/context/anticipatoryActionStateSlice/utils.ts
+++ b/frontend/src/context/anticipatoryActionStateSlice/utils.ts
@@ -157,7 +157,11 @@ export function parseAndTransformAA(data: any[]) {
 
           // If a district reaches a set state, it will propagate until the end of the window
           dateData.forEach(x => {
-            if (!x.isValid || (prevMax && x.season !== prevMax?.season)) {
+            // reset prevMax when entering a new season
+            if (prevMax && x.season !== prevMax.season) {
+              prevMax = undefined;
+            }
+            if (!x.isValid) {
               return;
             }
             if (x.phase === 'Set') {

--- a/frontend/src/utils/layers-utils.tsx
+++ b/frontend/src/utils/layers-utils.tsx
@@ -409,7 +409,8 @@ const useLayers = () => {
     if (
       selectedLayerDates.length !== 0 ||
       selectedLayersWithDateSupport.length === 0 ||
-      !selectedDate
+      !selectedDate ||
+      nonBoundaryLayers.length < 2
     ) {
       return;
     }


### PR DESCRIPTION
### Description

This fixes an issue where the prevMax was not getting properly reset when going through the AA data and entering a new season.

@gislawill this also fixes a bug with the layer removal process that was trying to remove "undefined" layers when loading AA from URL. Eg. loading http://localhost:3000/?hazardLayerIds=anticipatory_action&date=2024-08-14. 

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
