### PR TITLE
Adding capability for CSV + GeoJSON download of composite data; COUNTRY=jordan

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -78,7 +78,11 @@ function LayerDownloadOptions({
 
   const getFilename = useCallback((): string => {
     const safeTitle = layer.title ?? layer.id;
-    if (selectedDate && (layer as AdminLevelDataLayerProps).dates) {
+    if (
+      selectedDate &&
+      ((layer as AdminLevelDataLayerProps).dates ||
+        (layer as CompositeLayerProps).dateLayer)
+    ) {
       const dateString = getFormattedDate(selectedDate, 'snake');
       return `${safeCountry}_${safeTitle}_${dateString}`;
     }
@@ -126,7 +130,6 @@ function LayerDownloadOptions({
       handleDownloadMenuClose();
     }
     if (layerData && layer.type === 'composite') {
-      // set layerData as LayerData<CompositeLayerProps>
       const compositeLayerData = layerData as LayerData<CompositeLayerProps>;
       const geoJsonFeatures = compositeLayerData?.data.features;
       const properties = geoJsonFeatures[0]?.properties;

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -110,7 +110,7 @@ function LayerDownloadOptions({
   };
 
   const handleDownloadCsv = (): void => {
-    if (adminLevelLayerData) {
+    if (adminLevelLayerData && layer.type === 'admin_level_data') {
       const translatedColumnsNames = mapValues(
         adminLevelLayerData?.data.layerData[0],
         (_v, k) => (k === 'value' ? t(adminLevelLayerData.layer.id) : t(k)),
@@ -129,7 +129,7 @@ function LayerDownloadOptions({
       );
       handleDownloadMenuClose();
     }
-    if (compositeLayerData) {
+    if (compositeLayerData && layer.type === 'composite') {
       const geoJsonFeatures = compositeLayerData?.data.features;
       const properties = geoJsonFeatures[0]?.properties;
 

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -92,7 +92,10 @@ function LayerDownloadOptions({
         adminLevelLayerData?.data.features || compositeLayerData?.data.features;
       downloadToFile(
         {
-          content: JSON.stringify(features),
+          content: JSON.stringify({
+            type: 'FeatureCollection',
+            features,
+          }),
           isUrl: false,
         },
         getFilename(),

--- a/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
+++ b/frontend/src/components/MapView/LeftPanel/layersPanel/MenuItem/MenuSwitch/SwitchItem/LayerDownloadOptions.tsx
@@ -6,7 +6,7 @@ import {
   MenuItem,
   Tooltip,
 } from '@material-ui/core';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { mapValues } from 'lodash';
 import GetAppIcon from '@material-ui/icons/GetApp';
@@ -31,7 +31,7 @@ import {
 import { useSafeTranslation } from 'i18n';
 import { isExposureAnalysisLoadingSelector } from 'context/analysisResultStateSlice';
 import { availableDatesSelector } from 'context/serverStateSlice';
-import { getRequestDate } from 'utils/server-utils';
+import { getRequestDateItem } from 'utils/server-utils';
 import { LayerDefinitions, getStacBand } from 'config/utils';
 import { getFormattedDate } from 'utils/date-utils';
 import { safeCountry } from 'config';
@@ -58,15 +58,17 @@ function LayerDownloadOptions({
   const { startDate: selectedDate } = useSelector(dateRangeSelector);
   const serverAvailableDates = useSelector(availableDatesSelector);
   const layerAvailableDates = serverAvailableDates[layer.id];
-  const queryDate = selected
-    ? getRequestDate(layerAvailableDates, selectedDate)
-    : undefined;
+  const queryDateItem = useMemo(
+    () => getRequestDateItem(layerAvailableDates, selectedDate, false),
+    [layerAvailableDates, selectedDate],
+  );
+  const requestDate = queryDateItem?.startDate || queryDateItem?.queryDate;
 
   const adminLevelLayerData = useSelector(
-    layerDataSelector(layer.id, queryDate),
+    layerDataSelector(layer.id, requestDate),
   ) as LayerData<AdminLevelDataLayerProps>;
   const compositeLayerData = useSelector(
-    layerDataSelector(layer.id),
+    layerDataSelector(layer.id, requestDate),
   ) as LayerData<CompositeLayerProps>;
 
   const handleDownloadMenuClose = () => {


### PR DESCRIPTION
### Description

This addresses #1336 by adding support for CSV + GeoJSON files of CDI data.

## How to test the feature:
- [ ] Open Jordan surge deployment
- [ ] Enable a CDI layer
- [ ] Select the download icon and download in both CSV and GeoJSON

## Checklist - did you ...
Test your changes with
- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
https://www.loom.com/share/a3c8cc4955a44112a0b3ed4983bbdf7b