### PR TITLE
Fix chart comparison crash

### DIFF
--- a/frontend/src/config/shared/translation/english.json
+++ b/frontend/src/config/shared/translation/english.json
@@ -27,7 +27,7 @@
   "Country": "Country",
   "Create Alert": "Create Alert",
   "Date Range": "Date Range",
-  "date_locale": "date_locale",
+  "date_locale": "en",
   "Date": "Date",
   "Deselect All": "Deselect All",
   "District in new phase this month": "District in new phase this month",


### PR DESCRIPTION
### Description

This fixes #1364.

There was a mistake in translation file for `date_locale` that was causing the bug.

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
