### PR TITLE
Fix failing area exposed

### DIFF
--- a/api/app/zonal_stats.py
+++ b/api/app/zonal_stats.py
@@ -31,7 +31,7 @@ from shapely.ops import unary_union  # type: ignore
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_STATS = ["min", "max", "mean", "median", "sum", "std", "count"]
+DEFAULT_STATS = ["min", "max", "mean", "median", "sum", "std", "count", "nodata"]
 
 AreaInSqKm = NewType("AreaInSqKm", float)
 Percentage = NewType("Percentage", float)


### PR DESCRIPTION
### Description

This fixes #1376. The code needs to be able to count `nodata` areas as well to calculate exposure.

<!-- what this does -->


## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
