### PR TITLE
Override default tooltip for date-time

### DIFF
--- a/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/AAStormDatePopup/index.tsx
+++ b/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/AAStormDatePopup/index.tsx
@@ -65,7 +65,7 @@ function AAStormDatePopup() {
       longitude={lng}
       latitude={lat}
       anchor="top"
-      offset={15}
+      offset={25}
       closeButton={false}
       onClose={() => null}
       closeOnClick={false}

--- a/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/AAStormDatePopup/index.tsx
+++ b/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/AAStormDatePopup/index.tsx
@@ -87,13 +87,27 @@ const useStyles = makeStyles(() =>
     },
     popup: {
       '& > .maplibregl-popup-content': {
-        border: '1px solid #A4A4A4',
-        padding: 5,
+        border: 'none',
+        padding: '8px 16px',
+        borderRadius: '4px',
+        background: 'white',
+        boxShadow: 'inset 0px 0px 0px 1px #A4A4A4',
+        position: 'relative',
       },
       '& > .maplibregl-popup-tip': {
-        borderBottomColor: '#A4A4A4',
-        borderLeftWidth: '8px',
-        borderRightWidth: '8px',
+        display: 'none',
+      },
+      // hack to display the popup tip without overlapping border
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        left: '50%',
+        top: -6,
+        width: '12px',
+        height: '12px',
+        background: 'white',
+        transform: 'translateX(-50%) rotate(45deg)',
+        boxShadow: 'inset 1px 1px 0px 0px #A4A4A4',
       },
     },
   }),


### PR DESCRIPTION
### Description

<img width="170" alt="Screenshot 2024-12-09 at 10 29 33 PM" src="https://github.com/user-attachments/assets/f9e5352e-9815-4102-a74c-f4ff10fc6bc0">

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
