### PR TITLE
remove useless aa storm state items

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -18,6 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:

--- a/frontend/src/components/Common/AnticipatoryAction/icons.tsx
+++ b/frontend/src/components/Common/AnticipatoryAction/icons.tsx
@@ -2,7 +2,6 @@ import moderateStorm from '../../../../public/images/anticipatory-action-storm/m
 import inland from '../../../../public/images/anticipatory-action-storm/inland.png';
 import tropicalDepression from '../../../../public/images/anticipatory-action-storm/tropical-depression.png';
 import disturbance from '../../../../public/images/anticipatory-action-storm/disturbance.png';
-// import lowPressure from '../../../../../../public/images/anticipatory-action-storm/low-pressure.png';
 import severeTropicalStorm from '../../../../public/images/anticipatory-action-storm/severe-tropical-storm.png';
 import tropicalCyclone from '../../../../public/images/anticipatory-action-storm/tropical-cyclone.png';
 import intenseTropicalCyclone from '../../../../public/images/anticipatory-action-storm/intense-tropical-cyclone.png';

--- a/frontend/src/components/Common/AnticipatoryAction/icons.tsx
+++ b/frontend/src/components/Common/AnticipatoryAction/icons.tsx
@@ -1,0 +1,26 @@
+import moderateStorm from '../../../../public/images/anticipatory-action-storm/moderate-tropical-storm.png';
+import inland from '../../../../public/images/anticipatory-action-storm/inland.png';
+import tropicalDepression from '../../../../public/images/anticipatory-action-storm/tropical-depression.png';
+import disturbance from '../../../../public/images/anticipatory-action-storm/disturbance.png';
+// import lowPressure from '../../../../../../public/images/anticipatory-action-storm/low-pressure.png';
+import severeTropicalStorm from '../../../../public/images/anticipatory-action-storm/severe-tropical-storm.png';
+import tropicalCyclone from '../../../../public/images/anticipatory-action-storm/tropical-cyclone.png';
+import intenseTropicalCyclone from '../../../../public/images/anticipatory-action-storm/intense-tropical-cyclone.png';
+import veryIntensiveCyclone from '../../../../public/images/anticipatory-action-storm/very-intensive-tropical-cyclone.png';
+import dissipating from '../../../../public/images/anticipatory-action-storm/dissipating.png';
+import defaultIcon from '../../../../public/images/anticipatory-action-storm/default.png';
+
+const anticipatoryActionIcons = {
+  moderateStorm,
+  inland,
+  tropicalDepression,
+  disturbance,
+  severeTropicalStorm,
+  tropicalCyclone,
+  intenseTropicalCyclone,
+  veryIntensiveCyclone,
+  dissipating,
+  default: defaultIcon,
+};
+
+export default anticipatoryActionIcons;

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/AAStormTimelineItem/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/AAStormTimelineItem/index.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles(() =>
     },
     activated1Indicator: {
       position: 'absolute',
-      height: 10,
+      height: 20,
       width: TIMELINE_ITEM_WIDTH - 1,
       pointerEvents: 'none',
       top: 0,

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/hooks.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/hooks.tsx
@@ -30,6 +30,7 @@ export const useWindStatesByTime = (currentDate: number): WindStateReport => {
     if (dates.length === 0) {
       return { states: [], cycloneName: null };
     }
+
     // If currentDate is 0 or null, get the latest report
     if (!currentDate) {
       const latestDate = dates.reduce((latest, current) =>
@@ -50,21 +51,4 @@ export const useWindStatesByTime = (currentDate: number): WindStateReport => {
     const result = getWindStatesForDate(windStateReports, date || null);
     return result;
   }, [currentDate, windStateReports]);
-};
-
-export const useLatestWindStates = (): WindStateReport => {
-  const windStateReports = useSelector(AAWindStateReports);
-
-  return useMemo(() => {
-    const dates = Object.keys(windStateReports);
-    if (dates.length === 0) {
-      return { states: [], cycloneName: null };
-    }
-
-    const latestDate = dates.reduce((latest, current) =>
-      new Date(current) > new Date(latest) ? current : latest,
-    );
-
-    return getWindStatesForDate(windStateReports, latestDate);
-  }, [windStateReports]);
 };

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/types.ts
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/types.ts
@@ -1,3 +1,9 @@
+import {
+  CycloneName,
+  ShortDate,
+  TimeAndState,
+} from 'context/anticipatoryAction/AAStormStateSlice/types';
+
 export type DateItemStyle = {
   class: string;
   color: string;
@@ -5,15 +11,6 @@ export type DateItemStyle = {
   emphasis?: string;
 };
 
-export enum WindState {
-  monitoring = 'monitoring',
-  ready = 'ready',
-  activated_64 = 'activated_64',
-  activated_118 = 'activated_118',
-}
-type ShortDate = string;
-type CycloneName = string;
-export type TimeAndState = { ref_time: string; state: WindState };
 export type DateJSON = Record<ShortDate, Record<CycloneName, TimeAndState[]>>;
 
 export type WindStateReport = {

--- a/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/index.tsx
@@ -309,12 +309,15 @@ const AnticipatoryActionStormLayer = React.memo(
       return null;
     }
 
+    // Create a report id based on the reference time of the report
+    const reportId = stormData.forecastDetails?.reference_time || '';
+
     return (
       <>
         {/* First render all fill layers */}
         {coloredDistrictsLayer && (
           <Source
-            key="storm-districts"
+            key={`storm-districts-${reportId}`}
             id="storm-districts"
             type="geojson"
             data={coloredDistrictsLayer}
@@ -342,7 +345,7 @@ const AnticipatoryActionStormLayer = React.memo(
         <>
           {stormData.activeDistricts?.Moderate?.polygon && (
             <Source
-              key="exposed-area-48kt"
+              key={`exposed-area-48kt-${reportId}`}
               type="geojson"
               data={stormData.activeDistricts?.Moderate?.polygon}
             >
@@ -361,7 +364,7 @@ const AnticipatoryActionStormLayer = React.memo(
           )}
           {stormData.activeDistricts?.Severe?.polygon && (
             <Source
-              key="exposed-area-64kt"
+              key={`exposed-area-64kt-${reportId}`}
               type="geojson"
               data={stormData.activeDistricts?.Severe?.polygon}
             >
@@ -383,7 +386,7 @@ const AnticipatoryActionStormLayer = React.memo(
         {/* Uncertainty cone */}
         {stormData.uncertaintyCone && (
           <Source
-            key="uncertainty-cone-map"
+            key={`uncertainty-cone-map-${reportId}`}
             type="geojson"
             data={stormData.uncertaintyCone}
           >

--- a/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/index.tsx
@@ -15,7 +15,6 @@ import { LayerData } from 'context/layers/layer-data';
 import { getBoundaryLayersByAdminLevel } from 'config/utils';
 import {
   AADataSelector,
-  AAFiltersSelector,
   AALoadingSelector,
   loadStormReport,
 } from 'context/anticipatoryAction/AAStormStateSlice';
@@ -68,7 +67,6 @@ const AnticipatoryActionStormLayer = React.memo(
     const map = useSelector(mapSelector);
     const { startDate } = useSelector(dateRangeSelector);
     const selectedDate = useDefaultDate('anticipatory-action-storm');
-    const { selectedDateTime } = useSelector(AAFiltersSelector);
 
     const stormData = useSelector(AADataSelector);
     const loading = useSelector(AALoadingSelector);
@@ -315,9 +313,6 @@ const AnticipatoryActionStormLayer = React.memo(
       };
     }, [boundaryData, stormData]);
 
-    // Create a unique ID suffix based on the selected date
-    const dateId = selectedDateTime ? `-${selectedDateTime}` : '';
-
     if (!boundaryData || !stormData) {
       return null;
     }
@@ -327,7 +322,7 @@ const AnticipatoryActionStormLayer = React.memo(
         {/* First render all fill layers */}
         {coloredDistrictsLayer && (
           <Source
-            key={`storm-districts${dateId}`}
+            key="storm-districts"
             id="storm-districts"
             type="geojson"
             data={coloredDistrictsLayer}
@@ -355,7 +350,7 @@ const AnticipatoryActionStormLayer = React.memo(
         <>
           {stormData.activeDistricts?.Moderate?.polygon && (
             <Source
-              key={`exposed-area-48kt${dateId}`}
+              key="exposed-area-48kt"
               type="geojson"
               data={stormData.activeDistricts?.Moderate?.polygon}
             >
@@ -374,7 +369,7 @@ const AnticipatoryActionStormLayer = React.memo(
           )}
           {stormData.activeDistricts?.Severe?.polygon && (
             <Source
-              key={`exposed-area-64kt${dateId}`}
+              key="exposed-area-64kt"
               type="geojson"
               data={stormData.activeDistricts?.Severe?.polygon}
             >
@@ -396,7 +391,7 @@ const AnticipatoryActionStormLayer = React.memo(
         {/* Uncertainty cone */}
         {stormData.uncertaintyCone && (
           <Source
-            key={`uncertainty-cone-map${dateId}`}
+            key="uncertainty-cone-map"
             type="geojson"
             data={stormData.uncertaintyCone}
           >

--- a/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/index.tsx
@@ -22,19 +22,10 @@ import { AACategory } from 'context/anticipatoryAction/AAStormStateSlice/types';
 import { updateDateRange } from 'context/mapStateSlice';
 import { useWindStatesByTime } from 'components/MapView/DateSelector/TimelineItems/hooks';
 import { getAAColor } from 'components/MapView/LeftPanel/AnticipatoryActionPanel/AnticipatoryActionStormPanel/utils';
+import anticipatoryActionIcons from 'components/Common/AnticipatoryAction/icons';
 import AAStormDatePopup from './AAStormDatePopup';
 import AAStormLandfallPopup from './AAStormLandfallPopup';
-import moderateStorm from '../../../../../public/images/anticipatory-action-storm/moderate-tropical-storm.png';
-import inland from '../../../../../public/images/anticipatory-action-storm/inland.png';
-// import lowPressure from '../../../../../public/images/anticipatory-action-storm/low-pressure.png';
-import tropicalDepression from '../../../../../public/images/anticipatory-action-storm/tropical-depression.png';
-import severeTropicalStorm from '../../../../../public/images/anticipatory-action-storm/severe-tropical-storm.png';
-import tropicalCyclone from '../../../../../public/images/anticipatory-action-storm/tropical-cyclone.png';
-import intenseTropicalCyclone from '../../../../../public/images/anticipatory-action-storm/intense-tropical-cyclone.png';
-import veryIntensiveCyclone from '../../../../../public/images/anticipatory-action-storm/very-intensive-tropical-cyclone.png';
-import dissipating from '../../../../../public/images/anticipatory-action-storm/dissipating.png';
-import defaultIcon from '../../../../../public/images/anticipatory-action-storm/default.png';
-import disturbance from '../../../../../public/images/anticipatory-action-storm/disturbance.png';
+
 import { TimeSeries } from './types';
 
 interface AnticipatoryActionStormLayerProps {
@@ -46,18 +37,19 @@ const boundaryLayer = getBoundaryLayersByAdminLevel(2);
 
 // Add this mapping object at the top of the file with other imports
 const WIND_TYPE_TO_ICON_MAP: Record<string, string> = {
-  disturbance,
-  'tropical-disturbance': disturbance,
-  low: disturbance,
-  'tropical-depression': tropicalDepression,
-  'moderate-tropical-storm': moderateStorm,
-  'severe-tropical-storm': severeTropicalStorm,
-  'tropical-cyclone': tropicalCyclone,
-  'intense-tropical-cyclone': intenseTropicalCyclone,
-  'very-intensive-tropical-cyclone': veryIntensiveCyclone,
-  inland,
-  dissipating,
-  default: defaultIcon,
+  disturbance: anticipatoryActionIcons.disturbance,
+  'tropical-disturbance': anticipatoryActionIcons.disturbance,
+  low: anticipatoryActionIcons.disturbance,
+  'tropical-depression': anticipatoryActionIcons.tropicalDepression,
+  'moderate-tropical-storm': anticipatoryActionIcons.moderateStorm,
+  'severe-tropical-storm': anticipatoryActionIcons.severeTropicalStorm,
+  'tropical-cyclone': anticipatoryActionIcons.tropicalCyclone,
+  'intense-tropical-cyclone': anticipatoryActionIcons.intenseTropicalCyclone,
+  'very-intensive-tropical-cyclone':
+    anticipatoryActionIcons.veryIntensiveCyclone,
+  inland: anticipatoryActionIcons.inland,
+  dissipating: anticipatoryActionIcons.dissipating,
+  default: anticipatoryActionIcons.default,
 };
 
 const AnticipatoryActionStormLayer = React.memo(

--- a/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/index.tsx
@@ -35,7 +35,6 @@ interface AnticipatoryActionStormLayerProps {
 // Use admin level 2 boundary layer
 const boundaryLayer = getBoundaryLayersByAdminLevel(2);
 
-// Add this mapping object at the top of the file with other imports
 const WIND_TYPE_TO_ICON_MAP: Record<string, string> = {
   disturbance: anticipatoryActionIcons.disturbance,
   'tropical-disturbance': anticipatoryActionIcons.disturbance,

--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/AAStormLegend/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/AAStormLegend/index.tsx
@@ -4,51 +4,42 @@ import {
   createStyles,
   Divider,
 } from '@material-ui/core';
+import anticipatoryActionIcons from 'components/Common/AnticipatoryAction/icons';
 import { useSafeTranslation } from 'i18n';
-// TODO - create a file to make the icons easier to access
-import moderateStorm from '../../../../../../public/images/anticipatory-action-storm/moderate-tropical-storm.png';
-import inland from '../../../../../../public/images/anticipatory-action-storm/inland.png';
-import tropicalDepression from '../../../../../../public/images/anticipatory-action-storm/tropical-depression.png';
-import disturbance from '../../../../../../public/images/anticipatory-action-storm/disturbance.png';
-// import lowPressure from '../../../../../../public/images/anticipatory-action-storm/low-pressure.png';
-import severeTropicalStorm from '../../../../../../public/images/anticipatory-action-storm/severe-tropical-storm.png';
-import tropicalCyclone from '../../../../../../public/images/anticipatory-action-storm/tropical-cyclone.png';
-import intenseTropicalCyclone from '../../../../../../public/images/anticipatory-action-storm/intense-tropical-cyclone.png';
-import veryIntensiveCyclone from '../../../../../../public/images/anticipatory-action-storm/very-intensive-tropical-cyclone.png';
 
 const phases = [
   {
-    icon: disturbance,
+    icon: anticipatoryActionIcons.disturbance,
     label: 'Weak low pressure system',
     speed: '< 51 km/h',
   },
   {
-    icon: tropicalDepression,
+    icon: anticipatoryActionIcons.tropicalDepression,
     label: 'Tropical depression',
     speed: '51-62 km/h',
   },
   {
-    icon: moderateStorm,
+    icon: anticipatoryActionIcons.moderateStorm,
     label: 'Moderate tropical storm',
     speed: '63-88 km/h',
   },
   {
-    icon: severeTropicalStorm,
+    icon: anticipatoryActionIcons.severeTropicalStorm,
     label: 'Severe tropical storm',
     speed: '89-118 km/h',
   },
   {
-    icon: tropicalCyclone,
+    icon: anticipatoryActionIcons.tropicalCyclone,
     label: 'Tropical cyclone',
     speed: '119-166 km/h',
   },
   {
-    icon: intenseTropicalCyclone,
+    icon: anticipatoryActionIcons.intenseTropicalCyclone,
     label: 'Intense tropical cyclone',
     speed: '167-213 km/h',
   },
   {
-    icon: veryIntensiveCyclone,
+    icon: anticipatoryActionIcons.veryIntensiveCyclone,
     label: 'Very intense tropical cyclone',
     speed: '214 km/h and above',
   },
@@ -71,7 +62,7 @@ const buffers = [
 
 const tracks = [
   {
-    icon: inland,
+    icon: anticipatoryActionIcons.inland,
     label: 'Overland',
   },
   {

--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/useAnticipatoryAction.ts
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/useAnticipatoryAction.ts
@@ -86,7 +86,7 @@ export function useAnticipatoryAction<T extends AnticipatoryAction>(
 
         dispatch(updateLayersCapabilities(updatedCapabilities));
         dispatch(updateDateRange(updatedCapabilities));
-      } else {
+      } else if (actionType === AnticipatoryAction.drought) {
         const queryDate = getRequestDate(combinedAvailableDates, selectedDate);
         const date = getFormattedDate(queryDate, DateFormat.Default) as string;
         dispatch(setFilters({ selectedDate: date }));

--- a/frontend/src/context/anticipatoryAction/AAStormStateSlice/index.ts
+++ b/frontend/src/context/anticipatoryAction/AAStormStateSlice/index.ts
@@ -1,8 +1,7 @@
-import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { DateItem } from 'config/types';
 import type { CreateAsyncThunkTypes, RootState } from '../../store';
 import {
-  AACategory,
   AAStormData,
   AAStormWindStateReports,
   AnticipatoryActionState,
@@ -14,15 +13,6 @@ const initialState: AnticipatoryActionState = {
   data: {},
   windStateReports: {},
   availableDates: undefined,
-  filters: {
-    selectedDateTime: undefined,
-    selectedIndex: '',
-    categories: {
-      Severe: true,
-      Moderate: true,
-      Risk: true,
-    },
-  },
   loading: false,
   error: null,
 };
@@ -133,37 +123,7 @@ export const loadWindStateReports = createAsyncThunk<
 export const anticipatoryActionStormStateSlice = createSlice({
   name: 'anticipatoryActionStormState',
   initialState,
-  reducers: {
-    // TODO - setAAFilters is mostly used for the viewType. Maybe rename and make sure it's used for the viewType only?
-    setAAFilters: (
-      state,
-      {
-        payload,
-      }: PayloadAction<
-        Partial<{
-          viewType: 'forecast' | 'risk';
-          selectedDateTime: string | undefined;
-          selectedIndex: string;
-          categories: Partial<Record<AACategory, boolean>>;
-        }>
-      >,
-    ) => {
-      const { categories, ...rest } = payload;
-      const newCategories =
-        categories !== undefined
-          ? { ...state.filters.categories, ...categories }
-          : state.filters.categories;
-      const newFilters = {
-        ...state.filters,
-        ...rest,
-        categories: newCategories,
-      };
-      return {
-        ...state,
-        filters: newFilters,
-      };
-    },
-  },
+  reducers: {},
   extraReducers: builder => {
     builder.addCase(loadStormReport.fulfilled, (state, { payload }) => ({
       ...state,
@@ -220,13 +180,7 @@ export const AALoadingSelector = (state: RootState) =>
 export const AAAvailableDatesSelector = (state: RootState) =>
   state.anticipatoryActionStormState.availableDates;
 
-export const AAFiltersSelector = (state: RootState) =>
-  state.anticipatoryActionStormState.filters;
-
 export const AAWindStateReports = (state: RootState) =>
   state.anticipatoryActionStormState.windStateReports;
-
-// export actions
-export const { setAAFilters } = anticipatoryActionStormStateSlice.actions;
 
 export default anticipatoryActionStormStateSlice.reducer;

--- a/frontend/src/context/anticipatoryAction/AAStormStateSlice/types.ts
+++ b/frontend/src/context/anticipatoryAction/AAStormStateSlice/types.ts
@@ -70,8 +70,8 @@ export enum WindState {
   activated_64 = 'activated_64',
   activated_118 = 'activated_118',
 }
-type ShortDate = string;
-type CycloneName = string;
+export type ShortDate = string;
+export type CycloneName = string;
 export type TimeAndState = { ref_time: string; state: WindState };
 export type AAStormWindStateReports = Record<
   ShortDate,

--- a/frontend/src/context/anticipatoryAction/AAStormStateSlice/types.ts
+++ b/frontend/src/context/anticipatoryAction/AAStormStateSlice/types.ts
@@ -147,12 +147,6 @@ export type AnticipatoryActionState = {
   windStateReports: AAStormWindStateReports;
   // availableDates used to update layer available dates after csv processed
   availableDates?: DateItem[] | undefined;
-  filters: {
-    viewType?: 'forecast' | 'risk' | undefined;
-    selectedDateTime: string | undefined;
-    selectedIndex: string;
-    categories: Record<AACategory, boolean>;
-  };
   loading: boolean;
   error: string | null;
 };

--- a/frontend/src/context/anticipatoryAction/config.ts
+++ b/frontend/src/context/anticipatoryAction/config.ts
@@ -9,15 +9,14 @@ import {
   AAAvailableDatesSelector as stormAvailableDatesSelector,
   AADataSelector as stormDataSelector,
   loadAllAAStormData,
-  setAAFilters as setStormAAFilters,
 } from 'context/anticipatoryAction/AAStormStateSlice';
 
-export const anticipatoryActionConfig = {
+const anticipatoryActionConfig = {
   [AnticipatoryAction.storm]: {
     dataSelector: stormDataSelector,
     availableDatesSelector: stormAvailableDatesSelector,
     loadAction: loadAllAAStormData,
-    setFiltersAction: setStormAAFilters,
+    setFiltersAction: () => null,
   },
   [AnticipatoryAction.drought]: {
     dataSelector: droughtDataSelector,


### PR DESCRIPTION
### Description

- clean anticipatory action state
- handle TODO - create a file to make the icons easier to access
- handle // TODO - setAAFilters is mostly used for the viewType. Maybe rename and make sure it's used for the viewType only?


## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
