### PR TITLE
Fix composite input layer invert bug; COUNTRY=jordan

### DIFF
--- a/frontend/src/context/layers/composite_data.ts
+++ b/frontend/src/context/layers/composite_data.ts
@@ -84,7 +84,7 @@ export const fetchCompositeLayerData: LazyLoader<CompositeLayerProps> =
         key,
         aggregation,
         importance,
-        invert: Boolean(invert),
+        invert,
       })),
       ...aggregationMaskParam,
       ...aggregateByParam,


### PR DESCRIPTION
### Description

This fixes https://github.com/WFP-VAM/prism-app/issues/1425

## How to test the feature:

- [ ] check CDI config in layers.json, look for invert attribute of input layer
- [ ] load the same CDI layer in prism
- [ ] verify that the correct invert attribute is sent to hip-analysis

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
