### PR TITLE
Fix CDI invert error & add water-based version; COUNTRY=jordan

### DIFF
--- a/frontend/src/config/jordan/layers.json
+++ b/frontend/src/config/jordan/layers.json
@@ -1413,58 +1413,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index v1. SPI weight = 0.5; LST weight = 0.25; NDVI weight = 0.25",
     "opacity": 0.7
   },
@@ -1523,58 +1472,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index v1. SPI weight = 0.5; LST weight = 0.25; NDVI weight = 0.25",
     "opacity": 0.7
   },
@@ -1632,58 +1530,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index v1. SPI weight = 0.5; LST weight = 0.25; NDVI weight = 0.25",
     "opacity": 0.7
   },
@@ -1750,58 +1597,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index v1. SPI weight = 0.5; LST weight = 0.25; NDVI weight = 0.25",
     "opacity": 0.7
   },
@@ -1851,58 +1647,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index v2. SPI weight = 0.3; LST weight = 0.3; NDVI weight = 0.4",
     "opacity": 0.7
   },
@@ -1961,58 +1706,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index v2. SPI weight = 0.3; LST weight = 0.3; NDVI weight = 0.4",
     "opacity": 0.7
   },
@@ -2070,58 +1764,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index v2. SPI weight = 0.3; LST weight = 0.3; NDVI weight = 0.4",
     "opacity": 0.7
   },
@@ -2188,58 +1831,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index v2. SPI weight = 0.3; LST weight = 0.3; NDVI weight = 0.4",
     "opacity": 0.7
   },
@@ -2286,58 +1878,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index (water-based). Rainfall amount weight = 0.4; evapotranspiration weight = 0.3; soil moisture weight = 0.3",
     "opacity": 0.7
   },
@@ -2393,58 +1934,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index (water-based). Rainfall amount weight = 0.4; evapotranspiration weight = 0.3; soil moisture weight = 0.3",
     "opacity": 0.7
   },
@@ -2499,58 +1989,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index (water-based). Rainfall amount weight = 0.4; evapotranspiration weight = 0.3; soil moisture weight = 0.3",
     "opacity": 0.7
   },
@@ -2614,58 +2053,7 @@
         ]
       }
     ],
-    "legend": [
-      {
-        "value": 0,
-        "label": "0 - 0.1",
-        "color": "#672200"
-      },
-      {
-        "value": 0.1,
-        "label": "0.1 - 0.2",
-        "color": "#a93800"
-      },
-      {
-        "value": 0.2,
-        "label": "0.2 - 0.3",
-        "color": "#e59800"
-      },
-      {
-        "value": 0.3,
-        "label": "0.3 - 0.4",
-        "color": "#ffe769"
-      },
-      {
-        "value": 0.4,
-        "label": "0.4 - 0.5",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.5,
-        "label": "0.5 - 0.6",
-        "color": "#f0f0f0"
-      },
-      {
-        "value": 0.6,
-        "label": "0.6 - 0.7",
-        "color": "#a9c6d6"
-      },
-      {
-        "value": 0.7,
-        "label": "0.7 - 0.8",
-        "color": "#019ac4"
-      },
-      {
-        "value": 0.8,
-        "label": "0.8 - 0.9",
-        "color": "#014c73"
-      },
-      {
-        "value": 0.9,
-        "label": "0.9 - 1",
-        "color": "#014c73"
-      }
-    ],
+    "legend": "cdi_10_0_1",
     "legend_text": "Composite Drought Index (water-based). Rainfall amount weight = 0.4; evapotranspiration weight = 0.3; soil moisture weight = 0.3",
     "opacity": 0.7
   }

--- a/frontend/src/config/jordan/layers.json
+++ b/frontend/src/config/jordan/layers.json
@@ -2249,7 +2249,7 @@
     "period": "monthly",
     "base_url": "https://hip-service.ovio.org/q_multi_geojson",
     "start_date": "1981-01-01",
-    "end_date": "2024-12-21",
+    "end_date": "2024-01-01",
     "aggregation": "pixel",
     "date_layer": "rainfall_dekad",
     "validity": {

--- a/frontend/src/config/jordan/layers.json
+++ b/frontend/src/config/jordan/layers.json
@@ -1386,7 +1386,7 @@
         "id": "spi_1m",
         "importance": 0.5,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "CHIRPS",
           "R1S_DEKAD"
@@ -1396,7 +1396,7 @@
         "id": "lst_anomaly",
         "importance": 0.25,
         "aggregation": "average",
-        "invert": "True",
+        "invert": true,
         "key": [
           "MODIS",
           "MYD11C2_TDD_DEKAD"
@@ -1406,7 +1406,7 @@
         "id": "ndvi_dekad",
         "importance": 0.25,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "MODIS",
           "NDVI_smoothed_5KM"
@@ -1496,7 +1496,7 @@
         "id": "spi_1m",
         "importance": 0.5,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "CHIRPS",
           "R1S_DEKAD"
@@ -1506,7 +1506,7 @@
         "id": "lst_anomaly",
         "importance": 0.25,
         "aggregation": "average",
-        "invert": "True",
+        "invert": true,
         "key": [
           "MODIS",
           "MYD11C2_TDD_DEKAD"
@@ -1516,7 +1516,7 @@
         "id": "ndvi_dekad",
         "importance": 0.25,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "MODIS",
           "NDVI_smoothed_5KM"
@@ -1605,7 +1605,7 @@
         "id": "spi_3m",
         "importance": 0.5,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "CHIRPS",
           "R1S_DEKAD"
@@ -1615,7 +1615,7 @@
         "id": "lst_anomaly",
         "importance": 0.25,
         "aggregation": "average",
-        "invert": "True",
+        "invert": true,
         "key": [
           "MODIS",
           "MYD11C2_TDD_DEKAD"
@@ -1625,7 +1625,7 @@
         "id": "ndvi_dekad",
         "importance": 0.25,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "MODIS",
           "NDVI_smoothed_5KM"
@@ -1723,7 +1723,7 @@
         "id": "spi_3m",
         "importance": 0.5,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "CHIRPS",
           "R1S_DEKAD"
@@ -1733,7 +1733,7 @@
         "id": "lst_anomaly",
         "importance": 0.25,
         "aggregation": "average",
-        "invert": "True",
+        "invert": true,
         "key": [
           "MODIS",
           "MYD11C2_TDD_DEKAD"
@@ -1743,7 +1743,7 @@
         "id": "ndvi_dekad",
         "importance": 0.25,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "MODIS",
           "NDVI_smoothed_5KM"
@@ -1824,7 +1824,7 @@
         "id": "spi_1m",
         "importance": 0.3,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "CHIRPS",
           "R1S_DEKAD"
@@ -1834,7 +1834,7 @@
         "id": "lst_anomaly",
         "importance": 0.3,
         "aggregation": "average",
-        "invert": "True",        
+        "invert": true,        
         "key": [
           "MODIS",
           "MYD11C2_TDD_DEKAD"
@@ -1844,7 +1844,7 @@
         "id": "ndvi_dekad",
         "importance": 0.4,
         "aggregation": "average",
-        "invert": "False",        
+        "invert": false,        
         "key": [
           "MODIS",
           "NDVI_smoothed_5KM"
@@ -1934,7 +1934,7 @@
         "id": "spi_1m",
         "importance": 0.3,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "CHIRPS",
           "R1S_DEKAD"
@@ -1944,7 +1944,7 @@
         "id": "lst_anomaly",
         "importance": 0.3,
         "aggregation": "average",
-        "invert": "True",
+        "invert": true,
         "key": [
           "MODIS",
           "MYD11C2_TDD_DEKAD"
@@ -1954,7 +1954,7 @@
         "id": "ndvi_dekad",
         "importance": 0.4,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "MODIS",
           "NDVI_smoothed_5KM"
@@ -2043,7 +2043,7 @@
         "id": "spi_3m",
         "importance": 0.3,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "CHIRPS",
           "R1S_DEKAD"
@@ -2053,7 +2053,7 @@
         "id": "lst_anomaly",
         "importance": 0.3,
         "aggregation": "average",
-        "invert": "True",        
+        "invert": true,        
         "key": [
           "MODIS",
           "MYD11C2_TDD_DEKAD"
@@ -2063,7 +2063,7 @@
         "id": "ndvi_dekad",
         "importance": 0.4,
         "aggregation": "average",
-        "invert": "False",        
+        "invert": false,        
         "key": [
           "MODIS",
           "NDVI_smoothed_5KM"
@@ -2161,7 +2161,7 @@
         "id": "spi_3m",
         "importance": 0.3,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "CHIRPS",
           "R1S_DEKAD"
@@ -2171,7 +2171,7 @@
         "id": "lst_anomaly",
         "importance": 0.3,
         "aggregation": "average",
-        "invert": "True",
+        "invert": true,
         "key": [
           "MODIS",
           "MYD11C2_TDD_DEKAD"
@@ -2181,7 +2181,7 @@
         "id": "ndvi_dekad",
         "importance": 0.4,
         "aggregation": "average",
-        "invert": "False",
+        "invert": false,
         "key": [
           "MODIS",
           "NDVI_smoothed_5KM"
@@ -2241,6 +2241,432 @@
       }
     ],
     "legend_text": "Composite Drought Index v2. SPI weight = 0.3; LST weight = 0.3; NDVI weight = 0.4",
+    "opacity": 0.7
+  },
+  "cdi_v3_monthly": {
+    "title": "Monthly Combined Drought Index (water-based)",
+    "type": "composite",
+    "period": "monthly",
+    "base_url": "https://hip-service.ovio.org/q_multi_geojson",
+    "start_date": "1981-01-01",
+    "end_date": "2024-12-21",
+    "aggregation": "pixel",
+    "date_layer": "rainfall_dekad",
+    "validity": {
+      "forward": 1,
+      "backward": 2,
+      "mode": "dekad"
+    },
+    "input_layers": [
+      {
+        "importance": 0.4,
+        "aggregation": "last_dekad",
+        "invert": false,
+        "key": [
+          "CHIRPS",
+          "r1h_dekad"
+        ]
+      },
+      {
+        "importance": 0.3,
+        "aggregation": "average",
+        "invert": true,
+        "key": [
+          "FAO",
+          "ET0"
+        ]
+      },
+      {
+        "importance": 0.3,
+        "aggregation": "last_dekad",
+        "invert": false,
+        "key": [
+          "AGERA5",
+          "soil_moist"
+        ]
+      }
+    ],
+    "legend": [
+      {
+        "value": 0,
+        "label": "0 - 0.1",
+        "color": "#672200"
+      },
+      {
+        "value": 0.1,
+        "label": "0.1 - 0.2",
+        "color": "#a93800"
+      },
+      {
+        "value": 0.2,
+        "label": "0.2 - 0.3",
+        "color": "#e59800"
+      },
+      {
+        "value": 0.3,
+        "label": "0.3 - 0.4",
+        "color": "#ffe769"
+      },
+      {
+        "value": 0.4,
+        "label": "0.4 - 0.5",
+        "color": "#f0f0f0"
+      },
+      {
+        "value": 0.5,
+        "label": "0.5 - 0.6",
+        "color": "#f0f0f0"
+      },
+      {
+        "value": 0.6,
+        "label": "0.6 - 0.7",
+        "color": "#a9c6d6"
+      },
+      {
+        "value": 0.7,
+        "label": "0.7 - 0.8",
+        "color": "#019ac4"
+      },
+      {
+        "value": 0.8,
+        "label": "0.8 - 0.9",
+        "color": "#014c73"
+      },
+      {
+        "value": 0.9,
+        "label": "0.9 - 1",
+        "color": "#014c73"
+      }
+    ],
+    "legend_text": "Composite Drought Index (water-based). Rainfall amount weight = 0.4; evapotranspiration weight = 0.3; soil moisture weight = 0.3",
+    "opacity": 0.7
+  },
+  "cdi_v3_aggregated_monthly": {
+    "title": "Monthly Combined Drought Index Aggregated (water-based)",
+    "type": "composite",
+    "period": "monthly",
+    "base_url": "https://hip-service.ovio.org/q_multi_aggregated",
+    "start_date": "1981-01-01",
+    "end_date": "2024-01-01",
+    "aggregation": "pixel",
+    "aggregate_by": "mean",
+    "admin_code": "admin3Pcod",
+    "aggregation_boundary_path": "data/jordan/jor_admbnda_adm3_jdos_merged.json",
+    "date_layer": "spi_1m",
+    "validity": {
+      "forward": 1,
+      "backward": 2,
+      "mode": "dekad"
+    },
+    "feature_info_props": {
+      "value": {
+        "type": "number",
+        "dataTitle": "Event name"
+      }
+    },
+    "input_layers": [
+      {
+        "importance": 0.4,
+        "aggregation": "last_dekad",
+        "invert": false,
+        "key": [
+          "CHIRPS",
+          "r1h_dekad"
+        ]
+      },
+      {
+        "importance": 0.3,
+        "aggregation": "average",
+        "invert": true,
+        "key": [
+          "FAO",
+          "ET0"
+        ]
+      },
+      {
+        "importance": 0.3,
+        "aggregation": "last_dekad",
+        "invert": false,
+        "key": [
+          "AGERA5",
+          "soil_moist"
+        ]
+      }
+    ],
+    "legend": [
+      {
+        "value": 0,
+        "label": "0 - 0.1",
+        "color": "#672200"
+      },
+      {
+        "value": 0.1,
+        "label": "0.1 - 0.2",
+        "color": "#a93800"
+      },
+      {
+        "value": 0.2,
+        "label": "0.2 - 0.3",
+        "color": "#e59800"
+      },
+      {
+        "value": 0.3,
+        "label": "0.3 - 0.4",
+        "color": "#ffe769"
+      },
+      {
+        "value": 0.4,
+        "label": "0.4 - 0.5",
+        "color": "#f0f0f0"
+      },
+      {
+        "value": 0.5,
+        "label": "0.5 - 0.6",
+        "color": "#f0f0f0"
+      },
+      {
+        "value": 0.6,
+        "label": "0.6 - 0.7",
+        "color": "#a9c6d6"
+      },
+      {
+        "value": 0.7,
+        "label": "0.7 - 0.8",
+        "color": "#019ac4"
+      },
+      {
+        "value": 0.8,
+        "label": "0.8 - 0.9",
+        "color": "#014c73"
+      },
+      {
+        "value": 0.9,
+        "label": "0.9 - 1",
+        "color": "#014c73"
+      }
+    ],
+    "legend_text": "Composite Drought Index (water-based). Rainfall amount weight = 0.4; evapotranspiration weight = 0.3; soil moisture weight = 0.3",
+    "opacity": 0.7
+  },
+  "cdi_v3_seasonal": {
+    "title": "Seasonal Combined Drought Index (water-based)",
+    "type": "composite",
+    "period": "seasonal",
+    "base_url": "https://hip-service.ovio.org/q_multi_geojson",
+    "start_date": "1981-01-01",
+    "end_date": "2024-01-01",
+    "aggregation": "pixel",
+    "date_layer": "spi_3m",
+    "validity": {
+      "mode": "season",
+      "seasons": [
+        {
+          "start": "01-May",
+          "end": "31-October"
+        },
+        {
+          "start": "01-November",
+          "end": "30-April"
+        }
+      ]
+    },
+    "input_layers": [
+      {
+        "importance": 0.4,
+        "aggregation": "last_dekad",
+        "invert": false,
+        "key": [
+          "CHIRPS",
+          "r1h_dekad"
+        ]
+      },
+      {
+        "importance": 0.3,
+        "aggregation": "average",
+        "invert": true,
+        "key": [
+          "FAO",
+          "ET0"
+        ]
+      },
+      {
+        "importance": 0.3,
+        "aggregation": "last_dekad",
+        "invert": false,
+        "key": [
+          "AGERA5",
+          "soil_moist"
+        ]
+      }
+    ],
+    "legend": [
+      {
+        "value": 0,
+        "label": "0 - 0.1",
+        "color": "#672200"
+      },
+      {
+        "value": 0.1,
+        "label": "0.1 - 0.2",
+        "color": "#a93800"
+      },
+      {
+        "value": 0.2,
+        "label": "0.2 - 0.3",
+        "color": "#e59800"
+      },
+      {
+        "value": 0.3,
+        "label": "0.3 - 0.4",
+        "color": "#ffe769"
+      },
+      {
+        "value": 0.4,
+        "label": "0.4 - 0.5",
+        "color": "#f0f0f0"
+      },
+      {
+        "value": 0.5,
+        "label": "0.5 - 0.6",
+        "color": "#f0f0f0"
+      },
+      {
+        "value": 0.6,
+        "label": "0.6 - 0.7",
+        "color": "#a9c6d6"
+      },
+      {
+        "value": 0.7,
+        "label": "0.7 - 0.8",
+        "color": "#019ac4"
+      },
+      {
+        "value": 0.8,
+        "label": "0.8 - 0.9",
+        "color": "#014c73"
+      },
+      {
+        "value": 0.9,
+        "label": "0.9 - 1",
+        "color": "#014c73"
+      }
+    ],
+    "legend_text": "Composite Drought Index (water-based). Rainfall amount weight = 0.4; evapotranspiration weight = 0.3; soil moisture weight = 0.3",
+    "opacity": 0.7
+  },
+  "cdi_v3_aggregated_seasonal": {
+    "title": "Seasonal Combined Drought Index Aggregated (water-based)",
+    "type": "composite",
+    "period": "seasonal",
+    "base_url": "https://hip-service.ovio.org/q_multi_aggregated",
+    "start_date": "1981-01-01",
+    "end_date": "2024-01-01",
+    "aggregation": "pixel",
+    "aggregate_by": "mean",
+    "admin_code": "admin3Pcod",
+    "aggregation_boundary_path": "data/jordan/jor_admbnda_adm3_jdos_merged.json",
+    "date_layer": "spi_3m",
+    "validity": {
+      "mode": "season",
+      "seasons": [
+        {
+          "start": "01-May",
+          "end": "31-October"
+        },
+        {
+          "start": "01-November",
+          "end": "30-April"
+        }
+      ]
+    },
+    "feature_info_props": {
+      "value": {
+        "type": "number",
+        "dataTitle": "Event name"
+      }
+    },
+    "input_layers": [
+      {
+        "importance": 0.4,
+        "aggregation": "last_dekad",
+        "invert": false,
+        "key": [
+          "CHIRPS",
+          "r1h_dekad"
+        ]
+      },
+      {
+        "importance": 0.3,
+        "aggregation": "average",
+        "invert": true,
+        "key": [
+          "FAO",
+          "ET0"
+        ]
+      },
+      {
+        "importance": 0.3,
+        "aggregation": "last_dekad",
+        "invert": false,
+        "key": [
+          "AGERA5",
+          "soil_moist"
+        ]
+      }
+    ],
+    "legend": [
+      {
+        "value": 0,
+        "label": "0 - 0.1",
+        "color": "#672200"
+      },
+      {
+        "value": 0.1,
+        "label": "0.1 - 0.2",
+        "color": "#a93800"
+      },
+      {
+        "value": 0.2,
+        "label": "0.2 - 0.3",
+        "color": "#e59800"
+      },
+      {
+        "value": 0.3,
+        "label": "0.3 - 0.4",
+        "color": "#ffe769"
+      },
+      {
+        "value": 0.4,
+        "label": "0.4 - 0.5",
+        "color": "#f0f0f0"
+      },
+      {
+        "value": 0.5,
+        "label": "0.5 - 0.6",
+        "color": "#f0f0f0"
+      },
+      {
+        "value": 0.6,
+        "label": "0.6 - 0.7",
+        "color": "#a9c6d6"
+      },
+      {
+        "value": 0.7,
+        "label": "0.7 - 0.8",
+        "color": "#019ac4"
+      },
+      {
+        "value": 0.8,
+        "label": "0.8 - 0.9",
+        "color": "#014c73"
+      },
+      {
+        "value": 0.9,
+        "label": "0.9 - 1",
+        "color": "#014c73"
+      }
+    ],
+    "legend_text": "Composite Drought Index (water-based). Rainfall amount weight = 0.4; evapotranspiration weight = 0.3; soil moisture weight = 0.3",
     "opacity": 0.7
   }
 }

--- a/frontend/src/config/jordan/prism.json
+++ b/frontend/src/config/jordan/prism.json
@@ -273,6 +273,38 @@
             }
           ]
         }
+      ],
+      "combined_drought_index_water_based": [
+        {
+          "group_title": "Monthly",
+          "activate_all": false,
+          "layers": [
+            {
+              "id": "cdi_v3_aggregated_monthly",
+              "label": "Aggregated",
+              "main": true
+            },
+            {
+              "id": "cdi_v3_monthly",
+              "label": "Pixel level"
+            }
+          ]
+        },
+        {
+          "group_title": "Seasonal",
+          "activate_all": false,
+          "layers": [
+            {
+              "id": "cdi_v3_aggregated_seasonal",
+              "label": "Aggregated",
+              "main": true
+            },
+            {
+              "id": "cdi_v3_seasonal",
+              "label": "Pixel level"
+            }
+          ]
+        }
       ]
     }
   }

--- a/frontend/src/config/shared/legends.json
+++ b/frontend/src/config/shared/legends.json
@@ -337,5 +337,17 @@
     { "value": 12, "label": "11-12 Days", "color": "#0031ac" },
     { "value": 14, "label": "13-14 Days", "color": "#a002fa" },
     { "value": 15, "label": "> 14 Days", "color": "#ffc4ee" }
+  ],
+  "cdi_10_0_1": [
+    { "value": 0, "label": "0 - 0.1", "color": "#672200" },
+    { "value": 0.1, "label": "0.1 - 0.2", "color": "#a93800" },
+    { "value": 0.2, "label": "0.2 - 0.3", "color": "#e59800" },
+    { "value": 0.3, "label": "0.3 - 0.4", "color": "#ffe769" },
+    { "value": 0.4, "label": "0.4 - 0.5", "color": "#f0f0f0" },
+    { "value": 0.5, "label": "0.5 - 0.6", "color": "#f0f0f0" },
+    { "value": 0.6, "label": "0.6 - 0.7", "color": "#a9c6d6" },
+    { "value": 0.7, "label": "0.7 - 0.8", "color": "#019ac4" },
+    { "value": 0.8, "label": "0.8 - 0.9", "color": "#014c73" },
+    { "value": 0.9, "label": "0.9 - 1", "color": "#014c73" }
   ]
 }


### PR DESCRIPTION
### Description

This fixes https://github.com/WFP-VAM/prism-app/issues/1425

1. Fixes an error in the configuration of input layers for CDI (invert used string instead of boolean)
2. Adds CDI v3 (water-based) which matches what's being used across Africa

## How to test the feature:

- [ ] Verify that CDI request to hip-service correct implements the invert configuration in layers.json
- [ ] Verify that CDI v3 (water-based) loads properly

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
