### PR TITLE
fix display of the landfall details popup

### DIFF
--- a/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
@@ -103,8 +103,10 @@ const TimelineItems = memo(
               classes={{
                 tooltip: isShowingAAStormLayer
                   ? classes.AAStormTooltip
-                  : classes.AADroughtTooltip,
-                arrow: classes.arrow,
+                  : classes.defaultTooltip,
+                arrow: isShowingAAStormLayer
+                  ? classes.AAStormTooltipArrow
+                  : undefined,
               }}
             >
               <Grid
@@ -185,7 +187,7 @@ const useStyles = makeStyles(() =>
         },
       },
     },
-    AADroughtTooltip: {
+    defaultTooltip: {
       backgroundColor: '#222222',
       opacity: '0.85 !important',
       maxWidth: 'none',
@@ -218,7 +220,7 @@ const useStyles = makeStyles(() =>
       },
     },
 
-    arrow: {
+    AAStormTooltipArrow: {
       width: '11px',
       height: '11px',
       bottom: '-1px !important',


### PR DESCRIPTION
### Description

It fixes the display of the popup showing details about the landfall. This popups appears only when clicking on the windpoint corresponding to the landfall time. It is also marked with a permanent popup showing 'LF....' 

![image](https://github.com/user-attachments/assets/32ba3d0b-e75d-4e3c-a297-54d7df0f5bf2)


## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
