### PR TITLE
Fix the filename of the second chart for downloading  

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -81,100 +81,6 @@ function getProperties(
   return item?.properties ?? {};
 }
 
-const useStyles = makeStyles(() =>
-  createStyles({
-    root: {
-      display: 'flex',
-      flexDirection: 'row',
-      width: '100%',
-      height: '100%',
-    },
-    formGroup: {
-      marginBottom: 20,
-      marginLeft: 20,
-      width: '100%',
-    },
-    chartsPanelParams: {
-      marginTop: 30,
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      width: PanelSize.medium,
-      flexShrink: 0,
-    },
-    layerFormControl: {
-      marginTop: 30,
-      marginBottom: '2em',
-      minWidth: '300px',
-      maxWidth: '350px',
-      '& .MuiFormLabel-root': {
-        color: 'black',
-      },
-      '& .MuiSelect-root': {
-        color: 'black',
-      },
-    },
-    textLabel: {
-      color: 'black',
-    },
-    chartsContainer: {
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'space-between',
-      width: '100%',
-    },
-    chartsPanelCharts: {
-      alignContent: 'start',
-      overflowY: 'auto',
-      overflowX: 'hidden',
-      display: 'flex',
-      justifyContent: 'center',
-      flexWrap: 'wrap',
-      flexGrow: 4,
-      gap: '16px',
-      padding: '16px',
-      marginTop: 0,
-      paddingBottom: '1em',
-    },
-    clearAllSelectionsButton: {
-      backgroundColor: '#788489',
-      '&:hover': {
-        backgroundColor: '#788489',
-      },
-      marginTop: 10,
-      marginBottom: 10,
-      marginLeft: '25%',
-      marginRight: '25%',
-      width: '50%',
-      '&.Mui-disabled': { opacity: 0.5 },
-    },
-    switch: {
-      marginRight: 2,
-    },
-    switchTrack: {
-      backgroundColor: '#E0E0E0',
-    },
-    switchBase: {
-      color: '#E0E0E0',
-      '&.Mui-checked': {
-        color: '#53888F',
-      },
-      '&.Mui-checked + .MuiSwitch-track': {
-        backgroundColor: '#B1D6DB',
-      },
-    },
-    switchTitle: {
-      lineHeight: 1.8,
-      color: 'black',
-      fontWeight: 400,
-    },
-    switchTitleUnchecked: {
-      lineHeight: 1.8,
-      fontWeight: 400,
-    },
-  }),
-);
-
 const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
 const menuProps: Partial<MenuProps> = {
@@ -972,5 +878,99 @@ const ChartsPanel = memo(() => {
     </div>
   );
 });
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    root: {
+      display: 'flex',
+      flexDirection: 'row',
+      width: '100%',
+      height: '100%',
+    },
+    formGroup: {
+      marginBottom: 20,
+      marginLeft: 20,
+      width: '100%',
+    },
+    chartsPanelParams: {
+      marginTop: 30,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      width: PanelSize.medium,
+      flexShrink: 0,
+    },
+    layerFormControl: {
+      marginTop: 30,
+      marginBottom: '2em',
+      minWidth: '300px',
+      maxWidth: '350px',
+      '& .MuiFormLabel-root': {
+        color: 'black',
+      },
+      '& .MuiSelect-root': {
+        color: 'black',
+      },
+    },
+    textLabel: {
+      color: 'black',
+    },
+    chartsContainer: {
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+      width: '100%',
+    },
+    chartsPanelCharts: {
+      alignContent: 'start',
+      overflowY: 'auto',
+      overflowX: 'hidden',
+      display: 'flex',
+      justifyContent: 'center',
+      flexWrap: 'wrap',
+      flexGrow: 4,
+      gap: '16px',
+      padding: '16px',
+      marginTop: 0,
+      paddingBottom: '1em',
+    },
+    clearAllSelectionsButton: {
+      backgroundColor: '#788489',
+      '&:hover': {
+        backgroundColor: '#788489',
+      },
+      marginTop: 10,
+      marginBottom: 10,
+      marginLeft: '25%',
+      marginRight: '25%',
+      width: '50%',
+      '&.Mui-disabled': { opacity: 0.5 },
+    },
+    switch: {
+      marginRight: 2,
+    },
+    switchTrack: {
+      backgroundColor: '#E0E0E0',
+    },
+    switchBase: {
+      color: '#E0E0E0',
+      '&.Mui-checked': {
+        color: '#53888F',
+      },
+      '&.Mui-checked + .MuiSwitch-track': {
+        backgroundColor: '#B1D6DB',
+      },
+    },
+    switchTitle: {
+      lineHeight: 1.8,
+      color: 'black',
+      fontWeight: 400,
+    },
+    switchTitleUnchecked: {
+      lineHeight: 1.8,
+      fontWeight: 400,
+    },
+  }),
+);
 
 export default ChartsPanel;

--- a/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/ChartsPanel/index.tsx
@@ -359,7 +359,7 @@ const ChartsPanel = memo(() => {
     }
   }, [secondAdminProperties, countryAdmin0Id, data]);
 
-  const singleDownloadChartPrefix = React.useMemo(
+  const singleChartFilenamePrefix = React.useMemo(
     () =>
       adminProperties
         ? [
@@ -379,7 +379,7 @@ const ChartsPanel = memo(() => {
 
   const firstCSVFilename = adminProperties
     ? buildCsvFileName([
-        ...singleDownloadChartPrefix,
+        ...singleChartFilenamePrefix,
         ...(selectedLayerTitles as string[]),
         comparePeriods ? 'first_period' : '',
       ])
@@ -433,7 +433,7 @@ const ChartsPanel = memo(() => {
             dataForCsv={dataForCsv}
             chartProps={{
               showDownloadIcons: true,
-              downloadFilenamePrefix: singleDownloadChartPrefix,
+              downloadFilenamePrefix: singleChartFilenamePrefix,
             }}
           />
         </Box>
@@ -480,12 +480,13 @@ const ChartsPanel = memo(() => {
                   }
                   chartProps={{
                     showDownloadIcons: true,
-                    downloadFilenamePrefix: singleDownloadChartPrefix,
+                    downloadFilenamePrefix: singleChartFilenamePrefix,
                   }}
                 />
               </Box>
             ))
         : [];
+
     // now add comparison charts
     const comparedAdminProperties = compareLocations
       ? secondAdminProperties
@@ -499,6 +500,14 @@ const ChartsPanel = memo(() => {
       : selectedAdmin2Area;
     const comparedStartDate = comparePeriods ? startDate2 : startDate1;
     const comparedEndDate = comparePeriods ? endDate2 : endDate1;
+
+    const secondChartFilenamePrefix = secondAdminProperties
+      ? [
+          getCountryName(secondAdminProperties),
+          secondSelectedAdmin1Area,
+          secondSelectedAdmin2Area,
+        ].map(x => t(x))
+      : [];
 
     const comparisonChartList = comparing
       ? chartLayers
@@ -537,7 +546,7 @@ const ChartsPanel = memo(() => {
                 minChartValue={Math.min(...minChartValues)}
                 chartProps={{
                   showDownloadIcons: true,
-                  downloadFilenamePrefix: singleDownloadChartPrefix,
+                  downloadFilenamePrefix: secondChartFilenamePrefix,
                 }}
               />
             </Box>
@@ -657,7 +666,7 @@ const ChartsPanel = memo(() => {
     selectedAdmin1Area,
     selectedAdmin2Area,
     selectedLayerTitles,
-    singleDownloadChartPrefix,
+    singleChartFilenamePrefix,
     startDate1,
     startDate2,
     t,


### PR DESCRIPTION
### Description

it fixes #1413 

## How to test the feature:

- Go to the charts module
- Toggle on compare locations
- Choose any two locations for example: 
  - location1, admin1 : cabo Delgado
  - location1, admin2: ancuabe
  - location2, admin1: Gaza
  - location2, admin2: Bilene
- select data to plot, for example "10-day NVDI (MODIS)"
- Click download CSV in the top right of the chart in location 2
- assert that the filename is mozambique_gaza_bilene_10_day_ndvi_modis.csv

- Click download image in the top right of the chart in location 2
- assert that the filename is mozambique_gaza_bilene_10_day_ndvi_modis.png

You can do the same for the chart corresponding to location 1
- Click download CSV in the top right of the chart
- assert that the filename is mozambique_cabo_delgado_ancuabe_10_day_ndvi_modis.csv

- Click download image in the top right of the chart
- assert that the filename is mozambique_cabo_delgado_ancuabe_10_day_ndvi_modis.png


## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:
