### PR TITLE
Improve tooltip design

### DIFF
--- a/frontend/src/components/MapView/DateSelector/TimelineItems/AAStormTooltipContent/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/AAStormTooltipContent/index.tsx
@@ -41,7 +41,20 @@ function AAStormTooltipContent({ date }: AAStormTooltipContentProps) {
     );
   };
 
-  const areMultipleCyclonesActive = allWindStates.length > 1;
+  const getButtonColor = (status: string | undefined) => {
+    switch (status) {
+      case 'monitoring':
+        return '#e0e0e0';
+      case 'ready':
+        return '#63B2BD';
+      case 'activated_48kt':
+        return '#FF8934';
+      case 'activated_68kt':
+        return '#E63701';
+      default:
+        return '#ffff';
+    }
+  };
 
   return (
     <div className={classes.container}>
@@ -54,13 +67,10 @@ function AAStormTooltipContent({ date }: AAStormTooltipContentProps) {
             )
             .map(windStates => (
               <div key={windStates.cycloneName} className={classes.cycloneRow}>
-                {areMultipleCyclonesActive && (
-                  <Typography className={classes.cycloneName}>
-                    {windStates.cycloneName?.toUpperCase()}
-                  </Typography>
-                )}
+                <Typography className={classes.cycloneName}>
+                  {windStates.cycloneName?.toUpperCase()}
+                </Typography>
                 <ToggleButtonGroup
-                  value={`${stormData.forecastDetails?.cyclone_name.toUpperCase()}::${stormData.forecastDetails?.reference_time}`}
                   exclusive
                   onChange={(e, value) =>
                     hourToggleHandler(e, value, windStates.cycloneName || '')
@@ -81,6 +91,18 @@ function AAStormTooltipContent({ date }: AAStormTooltipContentProps) {
                         value={`${windStates.cycloneName?.toUpperCase()}::${item.ref_time}`}
                         onMouseDown={e => e.preventDefault()}
                         className={classes.toggleButton}
+                        style={{
+                          backgroundColor: `${getButtonColor(item.state)}${
+                            `${windStates.cycloneName?.toUpperCase()}::${item.ref_time}` ===
+                            // eslint-disable-next-line no-unsafe-optional-chaining, prefer-template
+                            stormData.forecastDetails?.cyclone_name.toUpperCase() +
+                              '::' +
+                              // eslint-disable-next-line no-unsafe-optional-chaining
+                              stormData.forecastDetails?.reference_time
+                              ? ''
+                              : '50'
+                          }`,
+                        }}
                       >
                         <Typography className={classes.time}>
                           {formattedItemTime}

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/__snapshots__/index.test.tsx.snap
@@ -5,6 +5,8 @@ exports[`renders as expected 1`] = `
   <mock-tooltip
     arrow="true"
     classes="[object Object]"
+    enterdelay="300"
+    leavedelay="200"
     placement="top"
     title="[object Object]"
     transitioncomponent="[object Object]"

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/__snapshots__/index.test.tsx.snap
@@ -5,8 +5,6 @@ exports[`renders as expected 1`] = `
   <mock-tooltip
     arrow="true"
     classes="[object Object]"
-    enterdelay="300"
-    leavedelay="200"
     placement="top"
     title="[object Object]"
     transitioncomponent="[object Object]"

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
@@ -99,9 +99,13 @@ const TimelineItems = memo(
               TransitionProps={{ timeout: 0 }}
               placement="top"
               arrow
-              enterDelay={300}
-              leaveDelay={200}
-              {...(isShowingAAStormLayer ? { interactive: true } : null)}
+              {...(isShowingAAStormLayer
+                ? {
+                    enterDelay: 300,
+                    leaveDelay: 200,
+                    interactive: true,
+                  }
+                : null)}
               classes={{
                 tooltip: isShowingAAStormLayer
                   ? classes.AAStormTooltip

--- a/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
+++ b/frontend/src/components/MapView/DateSelector/TimelineItems/index.tsx
@@ -99,6 +99,8 @@ const TimelineItems = memo(
               TransitionProps={{ timeout: 0 }}
               placement="top"
               arrow
+              enterDelay={300}
+              leaveDelay={200}
               {...(isShowingAAStormLayer ? { interactive: true } : null)}
               classes={{
                 tooltip: isShowingAAStormLayer

--- a/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/AnticipatoryActionStormLayer/index.tsx
@@ -545,49 +545,44 @@ const AnticipatoryActionStormLayer = React.memo(
 
         {/* 48kt and 64kt wind forecast areas */}
         <>
-          {!stormData.readiness &&
-            stormData.activeDistricts?.Moderate?.polygon && (
-              <Source
-                key={`exposed-area-48kt-${reportId}`}
-                type="geojson"
-                data={stormData.activeDistricts?.Moderate?.polygon}
-              >
-                <Layer
-                  id="exposed-area-48kt"
-                  beforeId={getBeforeId()}
-                  type="line"
-                  paint={{
-                    'line-color': getAAColor(
-                      AACategory.Moderate,
-                      'Active',
-                      true,
-                    ).background,
-                    'line-width': 2,
-                    'line-opacity': 0.8,
-                  }}
-                />
-              </Source>
-            )}
-          {!stormData.readiness &&
-            stormData.activeDistricts?.Severe?.polygon && (
-              <Source
-                key={`exposed-area-64kt-${reportId}`}
-                type="geojson"
-                data={stormData.activeDistricts?.Severe?.polygon}
-              >
-                <Layer
-                  id="exposed-area-64kt"
-                  beforeId={getBeforeId()}
-                  type="line"
-                  paint={{
-                    'line-color': getAAColor(AACategory.Severe, 'Active', true)
-                      .background,
-                    'line-width': 2,
-                    'line-opacity': 0.8,
-                  }}
-                />
-              </Source>
-            )}
+          {stormData.activeDistricts?.Moderate?.polygon && (
+            <Source
+              key={`exposed-area-48kt-${reportId}`}
+              type="geojson"
+              data={stormData.activeDistricts?.Moderate?.polygon}
+            >
+              <Layer
+                id="exposed-area-48kt"
+                beforeId={getBeforeId()}
+                type="line"
+                paint={{
+                  'line-color': getAAColor(AACategory.Moderate, 'Active', true)
+                    .background,
+                  'line-width': 2,
+                  'line-opacity': 0.8,
+                }}
+              />
+            </Source>
+          )}
+          {stormData.activeDistricts?.Severe?.polygon && (
+            <Source
+              key={`exposed-area-64kt-${reportId}`}
+              type="geojson"
+              data={stormData.activeDistricts?.Severe?.polygon}
+            >
+              <Layer
+                id="exposed-area-64kt"
+                beforeId={getBeforeId()}
+                type="line"
+                paint={{
+                  'line-color': getAAColor(AACategory.Severe, 'Active', true)
+                    .background,
+                  'line-width': 2,
+                  'line-opacity': 0.8,
+                }}
+              />
+            </Source>
+          )}
         </>
 
         <AAStormDatePopup timeSeries={stormData.timeSeries} />


### PR DESCRIPTION
### Description

Improve tooltip behavior by:
- using colors to display the status of each hour
- always display storm name even when there is only one
- add tooltip "enter" and "leave" delays to make it a bit easier to move to the tooltip before it disappears

<img width="496" alt="Screenshot 2025-03-12 at 3 38 38 PM" src="https://github.com/user-attachments/assets/9f5c49d8-9524-4fa7-a4a3-6ee73b73213d" />
<img width="320" alt="Screenshot 2025-03-12 at 3 39 46 PM" src="https://github.com/user-attachments/assets/66fd4579-7401-4f1a-ac9f-f4794e359a2a" />

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
