### PR TITLE
add spi 2-month for active countries; COUNTRY=mozambique

### DIFF
--- a/frontend/src/config/afghanistan/prism.json
+++ b/frontend/src/config/afghanistan/prism.json
@@ -110,6 +110,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month",
               "main": false

--- a/frontend/src/config/bhutan/prism.json
+++ b/frontend/src/config/bhutan/prism.json
@@ -96,6 +96,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/cambodia/prism.json
+++ b/frontend/src/config/cambodia/prism.json
@@ -127,6 +127,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month",
               "main": false

--- a/frontend/src/config/cameroon/prism.json
+++ b/frontend/src/config/cameroon/prism.json
@@ -94,6 +94,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/colombia/prism.json
+++ b/frontend/src/config/colombia/prism.json
@@ -119,6 +119,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/cuba/prism.json
+++ b/frontend/src/config/cuba/prism.json
@@ -166,6 +166,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month",
               "main": false

--- a/frontend/src/config/ecuador/prism.json
+++ b/frontend/src/config/ecuador/prism.json
@@ -104,6 +104,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month",
               "main": false

--- a/frontend/src/config/global/prism.json
+++ b/frontend/src/config/global/prism.json
@@ -101,6 +101,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/haiti/prism.json
+++ b/frontend/src/config/haiti/prism.json
@@ -116,6 +116,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/indonesia/prism.json
+++ b/frontend/src/config/indonesia/prism.json
@@ -104,6 +104,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/jordan/prism.json
+++ b/frontend/src/config/jordan/prism.json
@@ -100,6 +100,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/kyrgyzstan/prism.json
+++ b/frontend/src/config/kyrgyzstan/prism.json
@@ -115,6 +115,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month",
               "main": false

--- a/frontend/src/config/mozambique/prism.json
+++ b/frontend/src/config/mozambique/prism.json
@@ -267,6 +267,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/myanmar/prism.json
+++ b/frontend/src/config/myanmar/prism.json
@@ -145,6 +145,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month",
               "main": false

--- a/frontend/src/config/namibia/prism.json
+++ b/frontend/src/config/namibia/prism.json
@@ -155,6 +155,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/nepal/prism.json
+++ b/frontend/src/config/nepal/prism.json
@@ -109,6 +109,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month",
               "main": false

--- a/frontend/src/config/nigeria/prism.json
+++ b/frontend/src/config/nigeria/prism.json
@@ -93,6 +93,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/rbd/prism.json
+++ b/frontend/src/config/rbd/prism.json
@@ -103,6 +103,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/shared/layers.json
+++ b/frontend/src/config/shared/layers.json
@@ -249,6 +249,21 @@
     "legend_text": "1-month Standardized Precipitation Index calculated from dekadal CHIRPS data",
     "legend": "spi"
   },
+  "spi_2m": {
+    "title": "SPI - 2-month",
+    "type": "wms",
+    "server_layer_name": "r2s_dekad",
+    "base_url": "https://api.earthobservation.vam.wfp.org/ows/",
+    "date_interval": "days",
+    "wcsConfig": {
+      "scale": 0.001,
+      "offset": 0,
+      "pixelResolution": 64
+    },
+    "opacity": 0.7,
+    "legend_text": "2-month Standardized Precipitation Index calculated from dekadal CHIRPS data",
+    "legend": "spi"
+  },
   "spi_3m": {
     "title": "SPI - 3-month",
     "type": "wms",

--- a/frontend/src/config/sierraleone/prism.json
+++ b/frontend/src/config/sierraleone/prism.json
@@ -94,6 +94,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/somalia/prism.json
+++ b/frontend/src/config/somalia/prism.json
@@ -110,6 +110,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/southsudan/prism.json
+++ b/frontend/src/config/southsudan/prism.json
@@ -99,6 +99,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/srilanka/prism.json
+++ b/frontend/src/config/srilanka/prism.json
@@ -163,6 +163,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/sudan/prism.json
+++ b/frontend/src/config/sudan/prism.json
@@ -95,6 +95,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/tajikistan/prism.json
+++ b/frontend/src/config/tajikistan/prism.json
@@ -111,6 +111,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month",
               "main": false

--- a/frontend/src/config/tanzania/prism.json
+++ b/frontend/src/config/tanzania/prism.json
@@ -89,6 +89,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },

--- a/frontend/src/config/zimbabwe/prism.json
+++ b/frontend/src/config/zimbabwe/prism.json
@@ -187,6 +187,10 @@
               "main": true
             },
             {
+              "id": "spi_2m",
+              "label": "2-month"
+            },
+            {
               "id": "spi_3m",
               "label": "3-month"
             },


### PR DESCRIPTION
### Description

This PR is a layer configuration change that adds spi 2-month to the shared layers.json file, and then adds the layer to layers.json for all active countries

## How to test the feature:

- [ ] go to rainfall anomaly, spi, and activate 2-month

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:
