### PR TITLE
Reverting google floods in Deployments; COUNTRY=mozambique

### DIFF
--- a/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/MapView/__snapshots__/index.test.tsx.snap
@@ -306,52 +306,6 @@ exports[`MapView renders as expected 1`] = `
                     </div>
                   </div>
                 </div>
-                <div
-                  class="MuiPaper-root MuiAccordion-root makeStyles-root-8 MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
-                >
-                  <div
-                    aria-controls="Flood"
-                    aria-disabled="false"
-                    aria-expanded="false"
-                    class="MuiButtonBase-root MuiAccordionSummary-root makeStyles-rootSummary-9"
-                    id="Flood"
-                    role="button"
-                    tabindex="0"
-                  >
-                    <div
-                      class="MuiAccordionSummary-content makeStyles-summaryContent-12"
-                    >
-                      <mock-typography
-                        classes="[object Object]"
-                      >
-                        Flood
-                      </mock-typography>
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-hidden="true"
-                      class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon makeStyles-expandIcon-11 MuiIconButton-edgeEnd"
-                    >
-                      <span
-                        class="MuiIconButton-label"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root"
-                          focusable="false"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                          />
-                        </svg>
-                      </span>
-                      <span
-                        class="MuiTouchRipple-root"
-                      />
-                    </div>
-                  </div>
-                </div>
               </div>
               <div
                 class="MuiBox-root MuiBox-root-16"

--- a/frontend/src/config/cambodia/prism.json
+++ b/frontend/src/config/cambodia/prism.json
@@ -33,24 +33,7 @@
     "flood": {
       "flood_monitoring": ["flood_extent"],
       "flood_risk": ["flood_hazard"],
-      "early_warning": ["ews_remote"],
-      "flood_status": [
-        {
-          "group_title": "Flood Status",
-          "activate_all": true,
-          "layers": [
-            {
-              "id": "forecast_river_discharge_at_gauges",
-              "label": "Flood Gauges",
-              "main": true
-            },
-            {
-              "id": "predicted_flood_inundation_maps",
-              "label": "Predicted Inundation Maps"
-            }
-          ]
-        }
-      ]
+      "early_warning": ["ews_remote"]
     },
     "rainfall": {
       "forecasts": [

--- a/frontend/src/config/mozambique/prism.json
+++ b/frontend/src/config/mozambique/prism.json
@@ -21,8 +21,7 @@
     "risk": "icon_impact.png",
     "tropical_storms": "icon_tropical_storm.png",
     "vulnerability": "icon_vulnerable.png",
-    "exposure": "icon_basemap.png",
-    "flood": "icon_flood.png"
+    "exposure": "icon_basemap.png"
   },
   "defaultDisplayBoundaries": [
     "admin_boundaries",
@@ -464,25 +463,6 @@
     },
     "exposure": {
       "population": ["pop_proj_2025"]
-    },
-    "flood": {
-      "flood_status": [
-        {
-          "group_title": "Flood Status",
-          "activate_all": true,
-          "layers": [
-            {
-              "id": "forecast_river_discharge_at_gauges",
-              "label": "Flood Gauges",
-              "main": true
-            },
-            {
-              "id": "predicted_flood_inundation_maps",
-              "label": "Predicted Inundation Maps"
-            }
-          ]
-        }
-      ]
     }
   }
 }

--- a/frontend/src/config/rbd/prism.json
+++ b/frontend/src/config/rbd/prism.json
@@ -11,8 +11,7 @@
     "risk_analysis": "icon_table.png",
     "rainfall": "icon_rain.png",
     "vegetation": "icon_veg.png",
-    "temperature": "icon_climate.png",
-    "flooding": "icon_basemap.png"
+    "temperature": "icon_climate.png"
   },
   "alertFormActive": false,
   "serversUrls": {
@@ -443,25 +442,6 @@
         "mdr_coping_capacity",
         "mdr_fsn_outcomes",
         "mdr_index"
-      ]
-    },
-    "flooding": {
-      "flood_status": [
-        {
-          "group_title": "Flood Status",
-          "activate_all": true,
-          "layers": [
-            {
-              "id": "google_flood_status_at_gauges",
-              "label": "Flood Gauges",
-              "main": true
-            },
-            {
-              "id": "google_flood_inundation_maps",
-              "label": "Inundation Maps"
-            }
-          ]
-        }
       ]
     }
   }


### PR DESCRIPTION
### Description

This reverts the prism.json updates in https://github.com/WFP-VAM/prism-app/pull/1332 that result Google Floods being accessible in Cambodia, Mozambique, and RBD deployments.

## How to test the feature:
- [ ] Pull up deployment
- [ ] Confirm Google Floods layer does not show

## Checklist - did you ...
Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
