### PR TITLE
Fix monster docker volumes - Tentatively add --rm flag

### DIFF
--- a/alerting/cron_aa_storm_alert_run.sh
+++ b/alerting/cron_aa_storm_alert_run.sh
@@ -4,7 +4,7 @@ cd ~/prism-app/alerting
 # source secrets from AWS
 source ../api/set_envs.sh
 
-docker compose run --entrypoint 'yarn aa-storm-alert-worker' alerting-node 2>&1 | tee -a ~/prism-app/alerting/aa_storm_alert_worker.log
+docker compose run --rm --entrypoint 'yarn aa-storm-alert-worker' alerting-node 2>&1 | tee -a ~/prism-app/alerting/aa_storm_alert_worker.log
 
 ## To set up the cron job, run the following command on the server:
 # crontab -e

--- a/alerting/cron_alert_run.sh
+++ b/alerting/cron_alert_run.sh
@@ -4,7 +4,7 @@ cd ~/prism-app/alerting
 # source secrets from AWS
 source ../api/set_envs.sh
 
-docker compose run --entrypoint 'yarn alert-worker' alerting-node 2>&1 | tee -a ~/prism-app/alerting/alert_worker.log
+docker compose run --rm --entrypoint 'yarn alert-worker' alerting-node 2>&1 | tee -a ~/prism-app/alerting/alert_worker.log
 
 ## To set up the cron job, run the following command on the server:
 # crontab -e

--- a/api/README.md
+++ b/api/README.md
@@ -170,4 +170,4 @@ sudo lsof -i -P -n | grep PORT
 sudo kill PROCESS_ID
 ```
 
-- `OOS — out of storage` when creating new deployments in AWS. This is due to unmounted (historic) docker volumes in long running EC2 instances. To delete these volumes and free up storage, run the following while ssh-ed into your EC2 instance: `docker system prune -a`
+- `OOS — out of storage` when creating new deployments in AWS. This is due to unmounted (historic) docker volumes in long running EC2 instances. To delete these volumes and free up storage, run the following while ssh-ed into your EC2 instance: `docker system prune -a` and `docker volume prune -a`


### PR DESCRIPTION
### Description

This fixes an issue with the alerting docker leaving a bunch of orphan volumes and racking up all the available space on the server.

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
