### PR TITLE
Always display AA flood geojson button; COUNTRY=mozambique

### DIFF
--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/AnticipatoryActionStormPanel/ActivationTriggerView/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/AnticipatoryActionStormPanel/ActivationTriggerView/index.tsx
@@ -1,9 +1,4 @@
-import {
-  Typography,
-  createStyles,
-  makeStyles,
-  Button,
-} from '@material-ui/core';
+import { Typography, createStyles, makeStyles } from '@material-ui/core';
 import { useSelector } from 'react-redux';
 import { AADataSelector } from 'context/anticipatoryAction/AAStormStateSlice';
 import { useSafeTranslation } from 'i18n';
@@ -101,27 +96,6 @@ function ActivationTrigger({ dialogs }: ActivationTriggerProps) {
   const parsedStormData = useSelector(AADataSelector);
   const commonClasses = useAACommonStyles();
 
-  const handleDownloadGeoJSON = () => {
-    if (!parsedStormData.mergedGeoJSON || !parsedStormData.forecastDetails) {
-      return;
-    }
-
-    const dataStr = JSON.stringify(parsedStormData.mergedGeoJSON);
-    const dataBlob = new Blob([dataStr], { type: 'application/json' });
-    const url = URL.createObjectURL(dataBlob);
-    const link = document.createElement('a');
-    // eslint-disable-next-line fp/no-mutation
-    link.href = url;
-    const date =
-      parsedStormData.forecastDetails.reference_time.split(':00Z')[0];
-    // eslint-disable-next-line fp/no-mutation
-    link.download = `${parsedStormData.forecastDetails?.cyclone_name || 'cyclone'}_${date}.geojson`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  };
-
   const filteredActiveDistricts = parsedStormData.activeDistricts
     ? Object.entries(parsedStormData.activeDistricts).filter(([category]) =>
         AAPanelCategories.includes(category as AACategory),
@@ -214,20 +188,6 @@ function ActivationTrigger({ dialogs }: ActivationTriggerProps) {
               {t(dialog.text)}
             </Typography>
           ))}
-          {parsedStormData.mergedGeoJSON && (
-            <Button
-              style={{
-                width: '50%',
-                margin: '1rem auto',
-              }}
-              className={commonClasses.footerButton}
-              variant="outlined"
-              fullWidth
-              onClick={handleDownloadGeoJSON}
-            >
-              <Typography>{t('Download GeoJSON')}</Typography>
-            </Button>
-          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/AnticipatoryActionStormPanel/DownloadGeoJSONButton/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/AnticipatoryActionStormPanel/DownloadGeoJSONButton/index.tsx
@@ -1,0 +1,53 @@
+import { Button, Typography } from '@material-ui/core';
+import { useSelector } from 'react-redux';
+import { AADataSelector } from 'context/anticipatoryAction/AAStormStateSlice';
+import { useSafeTranslation } from 'i18n';
+import { useAACommonStyles } from '../../utils';
+
+function DownloadGeoJSONButton() {
+  const { t } = useSafeTranslation();
+  const commonClasses = useAACommonStyles();
+  const parsedStormData = useSelector(AADataSelector);
+
+  const handleDownloadGeoJSON = () => {
+    if (!parsedStormData.mergedGeoJSON || !parsedStormData.forecastDetails) {
+      return;
+    }
+
+    const dataStr = JSON.stringify(parsedStormData.mergedGeoJSON);
+    const dataBlob = new Blob([dataStr], { type: 'application/json' });
+    const url = URL.createObjectURL(dataBlob);
+    const link = document.createElement('a');
+    // eslint-disable-next-line fp/no-mutation
+    link.href = url;
+    const date =
+      parsedStormData.forecastDetails.reference_time.split(':00Z')[0];
+    // eslint-disable-next-line fp/no-mutation
+    link.download = `${parsedStormData.forecastDetails?.cyclone_name || 'cyclone'}_${date}.geojson`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  if (!parsedStormData.mergedGeoJSON) {
+    return null;
+  }
+
+  return (
+    <Button
+      style={{
+        width: '50%',
+        margin: '1rem auto',
+      }}
+      className={commonClasses.footerButton}
+      variant="outlined"
+      fullWidth
+      onClick={handleDownloadGeoJSON}
+    >
+      <Typography>{t('Download GeoJSON')}</Typography>
+    </Button>
+  );
+}
+
+export default DownloadGeoJSONButton;

--- a/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/AnticipatoryActionStormPanel/index.tsx
+++ b/frontend/src/components/MapView/LeftPanel/AnticipatoryActionPanel/AnticipatoryActionStormPanel/index.tsx
@@ -19,9 +19,10 @@ import { DateFormat } from 'utils/name-utils';
 import { useUrlHistory } from 'utils/url-utils';
 import HowToReadModal from '../HowToReadModal';
 import ActivationTrigger from './ActivationTriggerView';
-import { StyledSelect } from '../utils';
+import { StyledSelect, useAACommonStyles } from '../utils';
 import { useAnticipatoryAction } from '../useAnticipatoryAction';
 import ReadyTrigger from './ReadyTriggerView';
+import DownloadGeoJSONButton from './DownloadGeoJSONButton';
 
 function AnticipatoryActionStormPanel() {
   const classes = useStyles();
@@ -31,6 +32,7 @@ function AnticipatoryActionStormPanel() {
   const { AAData, AAAvailableDates } = useAnticipatoryAction(
     AnticipatoryAction.storm,
   );
+  const commonClasses = useAACommonStyles();
   const [howToReadModalOpen, setHowToReadModalOpen] = React.useState(false);
   const reportRefTime = AAData.forecastDetails?.reference_time;
 
@@ -111,6 +113,11 @@ function AnticipatoryActionStormPanel() {
         </Typography>
       </div>
       {AAData.readiness ? <ReadyTrigger /> : <ActivationTrigger dialogs={[]} />}
+      <div className={commonClasses.footerWrapper}>
+        <div className={commonClasses.footerDialogsWrapper}>
+          <DownloadGeoJSONButton />
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Description

This fixes #1486 by moving the download button to the main component instead of the "active layer" component.

<!-- what this does -->

## How to test the feature:

- [ ] verify the button appears for `?hazardLayerIds=anticipatory_action_storm&date=2024-12-12`
- [ ] verify the button appears for `?hazardLayerIds=anticipatory_action_storm&date=2024-12-11`

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
