### PR TITLE
Dashboard shell

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -44,7 +44,7 @@ module.exports = {
     'fp/no-mutating-methods': [
       'warn',
       {
-        allowedObjects: ['_'],
+        allowedObjects: ['_', 'history'],
       },
     ],
     'fp/no-mutation': [

--- a/frontend/src/components/App/index.tsx
+++ b/frontend/src/components/App/index.tsx
@@ -7,6 +7,7 @@ import { Font } from '@react-pdf/renderer';
 import { authRequired } from 'config';
 import NavBar from 'components/NavBar';
 import MapView from 'components/MapView';
+import DashboardView from 'components/DashboardView';
 import Login from 'components/Login';
 import muiTheme from 'muiTheme';
 import Notifier from 'components/Notifier';
@@ -60,6 +61,13 @@ const Wrapper = memo(() => (
   <div id="app">
     <NavBar />
     <Switch>
+      <Route path="/dashboard" exact>
+        <DashboardView />
+      </Route>
+      <Route path="/" exact>
+        <MapView />
+        <AuthModal />
+      </Route>
       <Route>
         <MapView />
         <AuthModal />

--- a/frontend/src/components/App/index.tsx
+++ b/frontend/src/components/App/index.tsx
@@ -64,10 +64,6 @@ const Wrapper = memo(() => (
       <Route path="/dashboard" exact>
         <DashboardView />
       </Route>
-      <Route path="/" exact>
-        <MapView />
-        <AuthModal />
-      </Route>
       <Route>
         <MapView />
         <AuthModal />

--- a/frontend/src/components/DashboardView/index.tsx
+++ b/frontend/src/components/DashboardView/index.tsx
@@ -1,0 +1,29 @@
+import { memo } from 'react';
+import { Box, Typography } from '@material-ui/core';
+import { useSafeTranslation } from 'i18n';
+
+const DashboardView = memo(() => {
+  const { t } = useSafeTranslation();
+
+  return (
+    <Box
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        padding: '2rem',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Typography variant="h4" gutterBottom>
+        {t('Dashboard')}
+      </Typography>
+      <Typography variant="body1" color="textSecondary">
+        {t('Dashboard view coming soon...')}
+      </Typography>
+    </Box>
+  );
+});
+
+export default DashboardView;

--- a/frontend/src/components/NavBar/__snapshots__/index.test.tsx.snap
+++ b/frontend/src/components/NavBar/__snapshots__/index.test.tsx.snap
@@ -103,6 +103,42 @@ exports[`renders as expected 1`] = `
                   viewBox="0 0 24 24"
                 >
                   <path
+                    d="M20.38 8.57l-1.23 1.85a8 8 0 01-.22 7.58H5.07A8 8 0 0115.58 6.85l1.85-1.23A10 10 0 003.35 19a2 2 0 001.72 1h13.85a2 2 0 001.74-1 10 10 0 00-.27-10.44z"
+                  />
+                  <path
+                    d="M10.59 15.41a2 2 0 002.83 0l5.66-8.49-8.49 5.66a2 2 0 000 2.83z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+            <mock-menu
+              open="false"
+            >
+              <mock-menuitem
+                selected="false"
+              >
+                Population Exposure
+              </mock-menuitem>
+            </mock-menu>
+            <button
+              class="MuiButtonBase-root MuiIconButton-root"
+              style="color: white;"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiIconButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
                     d="M16 10h-2v2h2v-2zm0 4h-2v2h2v-2zm-8-4H6v2h2v-2zm4 0h-2v2h2v-2zm8-6H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V6h16v12z"
                   />
                 </svg>

--- a/frontend/src/components/NavBar/index.tsx
+++ b/frontend/src/components/NavBar/index.tsx
@@ -13,7 +13,8 @@ import {
   useTheme,
   useMediaQuery,
 } from '@material-ui/core';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useSafeTranslation } from 'i18n';
 import { appConfig } from 'config';
 import {
@@ -120,6 +121,8 @@ const panels: PanelItem[] = [
 function NavBar() {
   const { t } = useSafeTranslation();
   const dispatch = useDispatch();
+  const history = useHistory();
+  const location = useLocation();
   const classes = useStyles();
   const tabValue = useSelector(leftPanelTabValueSelector);
   const theme = useTheme();
@@ -131,6 +134,15 @@ function NavBar() {
   const [selectedChild, setSelectedChild] = useState<Record<string, PanelItem>>(
     {},
   );
+
+  // Sync URL with panel state
+  useEffect(() => {
+    if (location.pathname === '/dashboard' && tabValue !== Panel.Dashboard) {
+      dispatch(setTabValue(Panel.Dashboard));
+    } else if (location.pathname === '/' && tabValue === Panel.Dashboard) {
+      dispatch(setTabValue(Panel.Layers));
+    }
+  }, [location.pathname, tabValue, dispatch]);
 
   const rightSideLinks = [
     {
@@ -165,6 +177,11 @@ function NavBar() {
 
   const handlePanelClick = (panel: Panel) => {
     dispatch(setTabValue(panel));
+    if (panel === Panel.Dashboard) {
+      history.push('/dashboard');
+    } else if (location.pathname !== '/') {
+      history.push('/');
+    }
   };
 
   const handleChildSelection = (panel: any, child: any) => {
@@ -172,8 +189,10 @@ function NavBar() {
       [panel.label]: child,
     });
     handleMenuClose(panel.label);
+
     if (panel.panel === Panel.Dashboard && child.reportIndex !== undefined) {
-      handlePanelClick(Panel.Dashboard);
+      dispatch(setTabValue(Panel.Dashboard));
+      history.push('/dashboard');
     } else {
       handlePanelClick(child.panel);
     }

--- a/frontend/src/config/mozambique/prism.json
+++ b/frontend/src/config/mozambique/prism.json
@@ -464,5 +464,15 @@
     "exposure": {
       "population": ["pop_proj_2025"]
     }
-  }
+  },
+  "configuredReports": [
+    {
+      "title": "Population Exposure",
+      "selectedDate": "2025-01-01",
+      "mapPosition": "left",
+      "minMapBounds": [31, -25, 40, -11],
+      "mapLayers": [],
+      "flexElements": []
+    }
+  ]
 }

--- a/frontend/src/config/types.ts
+++ b/frontend/src/config/types.ts
@@ -998,3 +998,52 @@ export class AnticipatoryActionLayerProps extends CommonLayerProps {
   @makeRequired
   declare title: string;
 }
+
+export enum DashboardMapPosition {
+  left = 'left',
+  right = 'right',
+}
+
+export enum DashboardElementType {
+  CHART = 'CHART',
+  TEXT = 'TEXT',
+  TABLE = 'TABLE',
+}
+
+export interface DashboardChartConfig {
+  type: DashboardElementType.CHART;
+  startDate: string;
+  endDate: string;
+  wmsLayerId: string;
+  adminUnitLevel?: number;
+  adminUnitId?: number;
+}
+
+export interface DashboardTextConfig {
+  type: DashboardElementType.TEXT;
+  content: string;
+  textUpdatedAt?: string;
+}
+
+export interface DashboardTableConfig {
+  type: DashboardElementType.TABLE;
+  startDate: string;
+  endDate: string;
+  hazardLayerId: string;
+  baselineLayerId: string;
+  stat: AggregationOperations;
+}
+
+export interface ConfiguredReport {
+  title: string;
+  selectedDate: string;
+  mapPosition: DashboardMapPosition;
+  minMapBounds: number[];
+  mapLayers: Array<{
+    layerId: string;
+    opacity?: number;
+  }>;
+  flexElements: Array<
+    DashboardChartConfig | DashboardTextConfig | DashboardTableConfig
+  >;
+}

--- a/frontend/src/config/types.ts
+++ b/frontend/src/config/types.ts
@@ -803,12 +803,14 @@ export type PanelItem = {
   label: string;
   icon: React.ReactNode;
   children?: PanelItem[];
+  reportIndex?: number;
 };
 
 export enum Panel {
   None = 'none',
   Layers = 'layers',
   Charts = 'charts',
+  Dashboard = 'dashboard',
   Analysis = 'analysis',
   Tables = 'tables',
   AnticipatoryActionDrought = 'anticipatory_action_drought',

--- a/frontend/src/config/types.ts
+++ b/frontend/src/config/types.ts
@@ -1038,7 +1038,7 @@ export interface DashboardTableConfig {
 
 export interface ConfiguredReport {
   title: string;
-  selectedDate: string;
+  selectedDate?: string;
   mapPosition: DashboardMapPosition;
   minMapBounds: number[];
   mapLayers: Array<{

--- a/frontend/src/config/utils.ts
+++ b/frontend/src/config/utils.ts
@@ -8,6 +8,7 @@ import {
   BoundaryLayerProps,
   checkRequiredKeys,
   CompositeLayerProps,
+  ConfiguredReport,
   DateItem,
   GeojsonDataLayerProps,
   ImpactLayerProps,
@@ -334,6 +335,22 @@ export const isWindowedDates = (
   'Window 2' in dates;
 
 export const areChartLayersAvailable = getWMSLayersWithChart().length > 0;
+
+export const areDashboardsAvailable = (): boolean =>
+  'configuredReports' in appConfig;
+
+export const getConfiguredReports = (): ConfiguredReport[] => {
+  if (!areDashboardsAvailable()) {
+    return [];
+  }
+
+  const { configuredReports } = appConfig;
+  if (Array.isArray(configuredReports)) {
+    return configuredReports;
+  }
+
+  return [];
+};
 
 const isValidReportsDefinition = (
   maybeReport: object,

--- a/frontend/src/context/leftPanelStateSlice.ts
+++ b/frontend/src/context/leftPanelStateSlice.ts
@@ -10,12 +10,22 @@ const initialState: LeftPanelState = {
   panelSize: PanelSize.medium,
 };
 
+// Panels with multiple options should not get “unset” when selecting the same child
+const DROPDOWN_PANELS = [
+  Panel.AnticipatoryActionDrought,
+  Panel.AnticipatoryActionStorm,
+  Panel.Dashboard,
+];
+
 export const leftPanelSlice = createSlice({
   name: 'leftPanelState',
   initialState,
   reducers: {
     setTabValue: (state, { payload }: PayloadAction<Panel>) => {
-      if (payload === state.tabValue) {
+      if (
+        payload === state.tabValue &&
+        !DROPDOWN_PANELS.includes(state.tabValue)
+      ) {
         return {
           ...state,
           tabValue: Panel.None,


### PR DESCRIPTION
### Description

This sets up some foundational pieces of the dashboard/reports* feature. Highlights:

- Add `ConfiguredReport` and associated types
- Display Dashboard in nav bar if it exists for a given deployment config
- Allow a user to choose a configured report

<details><summary>*<strong>Dashboard context</strong></summary>
<p>
Just a bit of background on the dashboard/reports feature…

This is the very beginning phase of a larger effort to provide configurable reports to Prism users. Deployment configs can specify a “dashboard” comprising a map and one or more content blocks (e.g. text, a chart, or a table). This inaugural PR is to specify the overall structure of the config shape and initialize a navigable placeholder dashboard.

</p>
</details> 

I’ve left a few inline comments throughout to provide context and pose a few questions concerning next steps.

<!-- what this does -->

## How to test the feature:

1. Start the Mozambique deployment
2. Observe “Dashboard” in the main navigation
3. Select “Dashboard” and the single report it contains
4. Observe the dashboard placeholder content

### Additional testing notes
* The route will update as users navigate to and from the dashboard tab — try navigating to the dashboard view directly via your browser’s address bar and observe the route changing when selecting dashboard vs. non-dashboard tabs
* If you change the config title, you should see that reflected in the UI

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. →

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:
