### PR TITLE
Editable title and text

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -87,6 +87,17 @@ module.exports = {
     '@typescript-eslint/no-shadow': 'warn',
     'react/prop-types': 'off',
     'default-param-last': 'warn',
+    // Configure jsx-a11y label-has-associated-control rule to allow inputs nested within labels
+    'jsx-a11y/label-has-associated-control': [
+      'error',
+      {
+        labelComponents: [],
+        labelAttributes: [],
+        controlComponents: [],
+        assert: 'either',
+        depth: 3,
+      },
+    ],
   },
   settings: {
     'import/resolver': {

--- a/frontend/src/components/DashboardView/TextBlock.tsx
+++ b/frontend/src/components/DashboardView/TextBlock.tsx
@@ -1,0 +1,63 @@
+import { Box, makeStyles, Typography } from '@material-ui/core';
+import { useSelector, useDispatch } from 'react-redux';
+import {
+  dashboardTextContentSelector,
+  setTextContent,
+} from '../../context/dashboardStateSlice';
+
+interface TextBlockProps {
+  label?: string;
+  placeholder?: string;
+}
+
+function TextBlock({
+  label = 'Block #1',
+  placeholder = 'Add custom text here',
+}: TextBlockProps) {
+  const textContent = useSelector(dashboardTextContentSelector);
+  const dispatch = useDispatch();
+  const classes = useStyles();
+
+  return (
+    <Box className={classes.grayCard}>
+      <Typography variant="h3" className={classes.blockLabel}>
+        {label}
+      </Typography>
+      <textarea
+        name="text-block"
+        className={classes.textarea}
+        placeholder={placeholder}
+        value={textContent}
+        onChange={e => dispatch(setTextContent(e.target.value))}
+      />
+    </Box>
+  );
+}
+
+const useStyles = makeStyles(() => ({
+  grayCard: {
+    background: '#F1F1F1',
+    borderRadius: 8,
+    padding: 16,
+    marginBottom: 16,
+  },
+  blockLabel: {
+    fontWeight: 600,
+    fontSize: 16,
+    marginBottom: 12,
+  },
+  textarea: {
+    width: '95%',
+    minHeight: 120,
+    padding: '12px',
+    borderRadius: 4,
+    fontSize: 14,
+    border: 'none',
+    outline: 'none',
+    background: 'white',
+    fontFamily: 'Roboto',
+    resize: 'vertical',
+  },
+}));
+
+export default TextBlock;

--- a/frontend/src/components/DashboardView/index.tsx
+++ b/frontend/src/components/DashboardView/index.tsx
@@ -4,6 +4,7 @@ import {
   dashboardTitleSelector,
   setTitle,
 } from '../../context/dashboardStateSlice';
+import TextBlock from './TextBlock';
 
 function DashboardView() {
   const classes = useStyles();
@@ -11,37 +12,68 @@ function DashboardView() {
   const dispatch = useDispatch();
 
   return (
-    <Box className={classes.titleBar}>
-      <label className={classes.titleBarLabel}>
-        <Typography variant="h2" component="span">
-          Dashboard title
-        </Typography>
-        <input
-          type="text"
-          className={classes.titleBarInput}
-          placeholder="Enter dashboard title"
-          value={dashboardTitle}
-          onChange={e => dispatch(setTitle(e.target.value))}
-        />
-      </label>
+    <Box className={classes.layout}>
+      <Box className={classes.leadingContentArea}>
+        <Box className={classes.grayCard}>
+          <label className={classes.titleBarLabel}>
+            <Typography
+              variant="h2"
+              component="span"
+              className={classes.titleBarTypography}
+            >
+              Dashboard title
+            </Typography>
+            <input
+              type="text"
+              className={classes.titleBarInput}
+              placeholder="Enter dashboard title"
+              value={dashboardTitle}
+              onChange={e => dispatch(setTitle(e.target.value))}
+              name="dashboard-title"
+            />
+          </label>
+        </Box>
+        <Box className={classes.grayCard}>
+          <div>MAP PLACEHOLDER</div>
+        </Box>
+      </Box>
+      <Box className={classes.trailingContentArea}>
+        <TextBlock />
+      </Box>
     </Box>
   );
 }
 
 const useStyles = makeStyles(() => ({
-  titleBar: {
+  layout: {
     display: 'flex',
-    alignItems: 'center',
-    background: '#F1F1F1',
-    borderRadius: 8,
     padding: 16,
     margin: 16,
+    gap: 16,
+  },
+  leadingContentArea: {
+    flex: '2',
+  },
+  trailingContentArea: {
+    flex: '1',
+  },
+  grayCard: {
+    background: '#F1F1F1',
+    borderRadius: 8,
+    width: '100%',
+    marginBottom: 16,
   },
   titleBarLabel: {
+    display: 'flex',
+    alignItems: 'center',
     marginRight: 16,
     fontWeight: 600,
     fontSize: 16,
+    padding: 16,
+  },
+  titleBarTypography: {
     flex: '1 0 fit-content',
+    marginInlineEnd: 16,
   },
   titleBarInput: {
     width: '100%',

--- a/frontend/src/components/DashboardView/index.tsx
+++ b/frontend/src/components/DashboardView/index.tsx
@@ -1,29 +1,58 @@
-import { memo } from 'react';
-import { Box, Typography } from '@material-ui/core';
-import { useSafeTranslation } from 'i18n';
+import { Box, makeStyles, Typography } from '@material-ui/core';
+import { useSelector, useDispatch } from 'react-redux';
+import {
+  dashboardTitleSelector,
+  setTitle,
+} from '../../context/dashboardStateSlice';
 
-const DashboardView = memo(() => {
-  const { t } = useSafeTranslation();
+function DashboardView() {
+  const classes = useStyles();
+  const dashboardTitle = useSelector(dashboardTitleSelector);
+  const dispatch = useDispatch();
 
   return (
-    <Box
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100vh',
-        padding: '2rem',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <Typography variant="h4" gutterBottom>
-        {t('Dashboard')}
-      </Typography>
-      <Typography variant="body1" color="textSecondary">
-        {t('Dashboard view coming soon...')}
-      </Typography>
+    <Box className={classes.titleBar}>
+      <label className={classes.titleBarLabel}>
+        <Typography variant="h2" component="span">
+          Dashboard title
+        </Typography>
+        <input
+          type="text"
+          className={classes.titleBarInput}
+          placeholder="Enter dashboard title"
+          value={dashboardTitle}
+          onChange={e => dispatch(setTitle(e.target.value))}
+        />
+      </label>
     </Box>
   );
-});
+}
+
+const useStyles = makeStyles(() => ({
+  titleBar: {
+    display: 'flex',
+    alignItems: 'center',
+    background: '#F1F1F1',
+    borderRadius: 8,
+    padding: 16,
+    margin: 16,
+  },
+  titleBarLabel: {
+    marginRight: 16,
+    fontWeight: 600,
+    fontSize: 16,
+    flex: '1 0 fit-content',
+  },
+  titleBarInput: {
+    width: '100%',
+    padding: '8px 12px',
+    borderRadius: 4,
+    fontSize: 16,
+    border: 'none',
+    outline: 'none',
+    background: 'white',
+    fontFamily: 'Roboto',
+  },
+}));
 
 export default DashboardView;

--- a/frontend/src/context/dashboardStateSlice.ts
+++ b/frontend/src/context/dashboardStateSlice.ts
@@ -4,10 +4,12 @@ import type { RootState } from './store';
 
 export interface DashboardState {
   title: string;
+  textContent: string;
 }
 
 const initialState: DashboardState = {
   title: appConfig.configuredReports[0]?.title || 'Dashboard',
+  textContent: '',
 };
 
 export const dashboardStateSlice = createSlice({
@@ -18,6 +20,10 @@ export const dashboardStateSlice = createSlice({
       ...state,
       title: action.payload,
     }),
+    setTextContent: (state, action: PayloadAction<string>) => ({
+      ...state,
+      textContent: action.payload,
+    }),
   },
 });
 
@@ -25,7 +31,10 @@ export const dashboardStateSlice = createSlice({
 export const dashboardTitleSelector = (state: RootState): string =>
   state.dashboardState.title;
 
+export const dashboardTextContentSelector = (state: RootState): string =>
+  state.dashboardState.textContent;
+
 // Setters
-export const { setTitle } = dashboardStateSlice.actions;
+export const { setTitle, setTextContent } = dashboardStateSlice.actions;
 
 export default dashboardStateSlice.reducer;

--- a/frontend/src/context/dashboardStateSlice.ts
+++ b/frontend/src/context/dashboardStateSlice.ts
@@ -1,0 +1,31 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { appConfig } from 'config';
+import type { RootState } from './store';
+
+export interface DashboardState {
+  title: string;
+}
+
+const initialState: DashboardState = {
+  title: appConfig.configuredReports[0]?.title || 'Dashboard',
+};
+
+export const dashboardStateSlice = createSlice({
+  name: 'dashboardState',
+  initialState,
+  reducers: {
+    setTitle: (state, action: PayloadAction<string>) => ({
+      ...state,
+      title: action.payload,
+    }),
+  },
+});
+
+// Getters
+export const dashboardTitleSelector = (state: RootState): string =>
+  state.dashboardState.title;
+
+// Setters
+export const { setTitle } = dashboardStateSlice.actions;
+
+export default dashboardStateSlice.reducer;

--- a/frontend/src/context/store.ts
+++ b/frontend/src/context/store.ts
@@ -17,6 +17,7 @@ import datasetResultStateReduce from './datasetStateSlice';
 import mapTileLoadingStateReduce from './mapTileLoadingStateSlice';
 import leftPanelStateReduce from './leftPanelStateSlice';
 import opacityStateReduce from './opacityStateSlice';
+import dashboardStateReduce from './dashboardStateSlice';
 import anticipatoryActionDroughtStateReduce from './anticipatoryAction/AADroughtStateSlice';
 import anticipatoryActionStormStateReduce from './anticipatoryAction/AAStormStateSlice';
 
@@ -33,6 +34,7 @@ const reducer = combineReducers({
   mapTileLoadingState: mapTileLoadingStateReduce,
   leftPanelState: leftPanelStateReduce,
   opacityState: opacityStateReduce,
+  dashboardState: dashboardStateReduce,
   anticipatoryActionDroughtState: anticipatoryActionDroughtStateReduce,
   anticipatoryActionStormState: anticipatoryActionStormStateReduce,
 });


### PR DESCRIPTION
### Description

This PR’s primary purpose is to set up the Redux store for holding dashboard state. In it, you’ll find you can edit the Dashboard title and enter some text in a rudimentary content block. 

Both will update the store in a new `dashboardState` slice.

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
