### PR TITLE
Fix RBD CH tooltip table size

### DIFF
--- a/frontend/src/components/MapView/MapTooltip/index.tsx
+++ b/frontend/src/components/MapView/MapTooltip/index.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles(() =>
     },
     popup: {
       // Overrides the default maxWidth of 240px set by react-map-gl
-      maxWidth: 'none !important',
+      maxWidth: '40em !important',
       zIndex: 5,
       '& div.maplibregl-popup-content': {
         background: 'black',


### PR DESCRIPTION
### Description

This fixes a new issue introuded in #1328 for RBD CH tables
<img width="2986" height="1612" alt="Screenshot 2025-07-29 at 17 47 34" src="https://github.com/user-attachments/assets/4f49c63a-3cf1-4e26-aa12-28886e42dbd9" />

@gislawill can you check that it doesn't impact the issue you were having at the time? https://github.com/WFP-VAM/prism-app/pull/1328/files#r1838419804


<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
