### PR TITLE
Initial preview mode

### DIFF
--- a/frontend/src/components/DashboardView/DashboardPreview.tsx
+++ b/frontend/src/components/DashboardView/DashboardPreview.tsx
@@ -1,0 +1,40 @@
+import { Box, makeStyles, Typography } from '@material-ui/core';
+
+function DashboardPreview() {
+  const classes = useStyles();
+
+  return (
+    <Box className={classes.container}>
+      <Typography variant="h4" className={classes.title}>
+        Dashboard Preview
+      </Typography>
+      <Typography variant="body1" className={classes.placeholder}>
+        This is a placeholder for the dashboard preview content. The actual
+        dashboard content will be rendered here in a later phase.
+      </Typography>
+    </Box>
+  );
+}
+
+const useStyles = makeStyles(() => ({
+  container: {
+    padding: 24,
+    minHeight: '400px',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: -16,
+    right: 16,
+    zIndex: 100,
+  },
+  title: {
+    marginBottom: 16,
+    fontWeight: 600,
+  },
+  placeholder: {
+    color: '#666',
+    lineHeight: 1.6,
+  },
+}));
+
+export default DashboardPreview;

--- a/frontend/src/components/DashboardView/DashboardPreview.tsx
+++ b/frontend/src/components/DashboardView/DashboardPreview.tsx
@@ -1,39 +1,70 @@
 import { Box, makeStyles, Typography } from '@material-ui/core';
+import { useSelector } from 'react-redux';
+import type { DashboardTextConfig } from 'config/types';
+import TextBlock from './TextBlock';
+
+import {
+  dashboardTitleSelector,
+  dashboardFlexElementsSelector,
+} from '../../context/dashboardStateSlice';
 
 function DashboardPreview() {
   const classes = useStyles();
+  const dashboardTitle = useSelector(dashboardTitleSelector);
+  const dashboardFlexElements = useSelector(dashboardFlexElementsSelector);
 
   return (
-    <Box className={classes.container}>
-      <Typography variant="h4" className={classes.title}>
-        Dashboard Preview
-      </Typography>
-      <Typography variant="body1" className={classes.placeholder}>
-        This is a placeholder for the dashboard preview content. The actual
-        dashboard content will be rendered here in a later phase.
-      </Typography>
+    <Box className={classes.layout}>
+      <Box className={classes.leadingContentArea}>
+        <Box>
+          <Typography
+            variant="h2"
+            component="h1"
+            className={classes.titleBarTypography}
+          >
+            {dashboardTitle || 'Untitled Dashboard'}
+          </Typography>
+        </Box>
+      </Box>
+      <Box className={classes.trailingContentArea}>
+        {dashboardFlexElements?.map((element, index) => {
+          if (element.type === 'TEXT') {
+            const content = (element as DashboardTextConfig)?.content || '';
+            return (
+              <TextBlock
+                // eslint-disable-next-line react/no-array-index-key
+                key={`text-block-${index}`}
+                content={content}
+                index={index}
+                mode="preview"
+              />
+            );
+          }
+          return <div>Content type not yet supported</div>;
+        })}
+      </Box>
     </Box>
   );
 }
 
 const useStyles = makeStyles(() => ({
-  container: {
-    padding: 24,
-    minHeight: '400px',
+  layout: {
+    display: 'flex',
+    padding: 16,
+    margin: 16,
+    gap: 16,
   },
-  closeButton: {
-    position: 'absolute',
-    top: -16,
-    right: 16,
-    zIndex: 100,
+  leadingContentArea: {
+    flex: '2',
   },
-  title: {
-    marginBottom: 16,
-    fontWeight: 600,
+  trailingContentArea: {
+    flex: '1',
   },
-  placeholder: {
-    color: '#666',
-    lineHeight: 1.6,
+  titleBarTypography: {
+    padding: 16,
+    fontWeight: 500,
+    fontSize: 20,
+    margin: 0,
   },
 }));
 

--- a/frontend/src/components/DashboardView/TextBlock.tsx
+++ b/frontend/src/components/DashboardView/TextBlock.tsx
@@ -1,20 +1,99 @@
+import React from 'react';
 import { Box, makeStyles, Typography } from '@material-ui/core';
 import { useDispatch } from 'react-redux';
+import Markdown from 'react-markdown';
 import { setTextContent } from '../../context/dashboardStateSlice';
+
+type TextBlockMode = 'edit' | 'preview';
 
 interface TextBlockProps {
   label?: string;
   content: string;
   index: number;
+  mode?: TextBlockMode;
 }
+
+const createMarkdownComponents = (classes: any) => ({
+  p: ({ children }: { children: React.ReactNode }) => (
+    <Typography variant="body1" className={classes.previewText}>
+      {children}
+    </Typography>
+  ),
+  h1: ({ children }: { children: React.ReactNode }) => (
+    <Typography variant="h4" className={classes.previewHeading}>
+      {children}
+    </Typography>
+  ),
+  h2: ({ children }: { children: React.ReactNode }) => (
+    <Typography variant="h5" className={classes.previewHeading}>
+      {children}
+    </Typography>
+  ),
+  h3: ({ children }: { children: React.ReactNode }) => (
+    <Typography variant="h6" className={classes.previewHeading}>
+      {children}
+    </Typography>
+  ),
+  strong: ({ children }: { children: React.ReactNode }) => (
+    <Typography component="span" style={{ fontWeight: 600 }}>
+      {children}
+    </Typography>
+  ),
+  em: ({ children }: { children: React.ReactNode }) => (
+    <Typography component="span" style={{ fontStyle: 'italic' }}>
+      {children}
+    </Typography>
+  ),
+  a: ({ children, href }: { children: React.ReactNode; href?: string }) => (
+    <Typography
+      component="a"
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{ color: '#1976d2', textDecoration: 'underline' }}
+    >
+      {children}
+    </Typography>
+  ),
+});
 
 function TextBlock({
   index,
   label = `Block #${index + 1}`,
   content,
+  mode = 'edit',
 }: TextBlockProps) {
   const dispatch = useDispatch();
   const classes = useStyles();
+
+  if (mode === 'preview') {
+    if (!content || content.trim() === '') {
+      return null;
+    }
+
+    return (
+      <Box className={classes.previewContainer}>
+        <Markdown
+          linkTarget="_blank"
+          components={createMarkdownComponents(classes)}
+          allowedElements={[
+            'p',
+            'h1',
+            'h2',
+            'h3',
+            'strong',
+            'em',
+            'a',
+            'ul',
+            'ol',
+            'li',
+          ]}
+        >
+          {content}
+        </Markdown>
+      </Box>
+    );
+  }
 
   return (
     <Box className={classes.grayCard}>
@@ -57,6 +136,24 @@ const useStyles = makeStyles(() => ({
     background: 'white',
     fontFamily: 'Roboto',
     resize: 'vertical',
+  },
+  previewContainer: {
+    background: 'white',
+    borderRadius: 8,
+    padding: 16,
+    marginBottom: 16,
+  },
+  previewText: {
+    fontSize: 14,
+    lineHeight: 1.6,
+    margin: '0 0 12px 0',
+  },
+  previewHeading: {
+    fontWeight: 600,
+    margin: '16px 0 8px 0',
+    '&:first-child': {
+      marginTop: 0,
+    },
   },
 }));
 

--- a/frontend/src/components/DashboardView/index.tsx
+++ b/frontend/src/components/DashboardView/index.tsx
@@ -1,7 +1,19 @@
-import { Box, makeStyles, Typography } from '@material-ui/core';
+import {
+  Box,
+  makeStyles,
+  Typography,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogActions,
+} from '@material-ui/core';
+import { ArrowForward, Edit, VisibilityOutlined } from '@material-ui/icons';
 import { useSelector, useDispatch } from 'react-redux';
+import { useState } from 'react';
 import type { DashboardTextConfig } from 'config/types';
+import { black, cyanBlue } from 'muiTheme';
 import TextBlock from './TextBlock';
+import DashboardPreview from './DashboardPreview';
 
 import {
   dashboardTitleSelector,
@@ -14,59 +26,124 @@ function DashboardView() {
   const dashboardTitle = useSelector(dashboardTitleSelector);
   const dashboardFlexElements = useSelector(dashboardFlexElementsSelector);
   const dispatch = useDispatch();
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+
+  const handlePreviewClick = () => {
+    setIsPreviewOpen(true);
+  };
+
+  const handleClosePreview = () => {
+    setIsPreviewOpen(false);
+  };
 
   return (
-    <Box className={classes.layout}>
-      <Box className={classes.leadingContentArea}>
-        <Box className={classes.grayCard}>
-          <label className={classes.titleBarLabel}>
-            <Typography
-              variant="h2"
-              component="span"
-              className={classes.titleBarTypography}
-            >
-              Dashboard title
-            </Typography>
-            <input
-              type="text"
-              className={classes.titleBarInput}
-              placeholder="Enter dashboard title"
-              value={dashboardTitle}
-              onChange={e => dispatch(setTitle(e.target.value))}
-              name="dashboard-title"
-            />
-          </label>
-        </Box>
-        <Box className={classes.grayCard}>
-          <div>MAP PLACEHOLDER</div>
-        </Box>
-      </Box>
-      <Box className={classes.trailingContentArea}>
-        {dashboardFlexElements?.map((element, index) => {
-          if (element.type === 'TEXT') {
-            const content = (element as DashboardTextConfig)?.content || '';
-            return (
-              <TextBlock
-                // eslint-disable-next-line react/no-array-index-key
-                key={`text-block-${index}`}
-                content={content}
-                index={index}
+    <Box className={classes.container}>
+      <Box className={classes.layout}>
+        <Box className={classes.leadingContentArea}>
+          <Box className={classes.grayCard}>
+            <label className={classes.titleBarLabel}>
+              <Typography
+                variant="h2"
+                component="span"
+                className={classes.titleBarTypography}
+              >
+                Dashboard title
+              </Typography>
+              <input
+                type="text"
+                className={classes.titleBarInput}
+                placeholder="Enter dashboard title"
+                value={dashboardTitle}
+                onChange={e => dispatch(setTitle(e.target.value))}
+                name="dashboard-title"
               />
-            );
-          }
-          return <div>Content type not yet supported</div>;
-        })}
+            </label>
+          </Box>
+          <Box className={classes.grayCard}>
+            <div>MAP PLACEHOLDER</div>
+          </Box>
+        </Box>
+        <Box className={classes.trailingContentArea}>
+          {dashboardFlexElements?.map((element, index) => {
+            if (element.type === 'TEXT') {
+              const content = (element as DashboardTextConfig)?.content || '';
+              return (
+                <TextBlock
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={`text-block-${index}`}
+                  content={content}
+                  index={index}
+                />
+              );
+            }
+            return <div>Content type not yet supported</div>;
+          })}
+        </Box>
       </Box>
+      <Box className={classes.toolbar}>
+        <Button
+          variant="outlined"
+          color="primary"
+          startIcon={<VisibilityOutlined />}
+          onClick={handlePreviewClick}
+          className={classes.previewButton}
+          size="small"
+        >
+          Preview
+        </Button>
+      </Box>
+
+      <Dialog
+        open={isPreviewOpen}
+        onClose={handleClosePreview}
+        maxWidth={false}
+        fullWidth
+        className={classes.previewDialog}
+      >
+        <DialogActions>
+          <Button
+            color="primary"
+            variant="outlined"
+            disableElevation
+            startIcon={<Edit />}
+            onClick={handleClosePreview}
+            size="small"
+          >
+            Back to Edit
+          </Button>
+          <Button
+            color="primary"
+            variant="contained"
+            disableElevation
+            endIcon={<ArrowForward />}
+            size="small"
+            style={{ backgroundColor: cyanBlue, color: black }}
+          >
+            Publish
+          </Button>
+        </DialogActions>
+        <DialogContent className={classes.dialogContent}>
+          <DashboardPreview />
+        </DialogContent>
+      </Dialog>
     </Box>
   );
 }
 
 const useStyles = makeStyles(() => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100vh',
+    position: 'relative',
+  },
   layout: {
     display: 'flex',
     padding: 16,
     margin: 16,
     gap: 16,
+    flex: 1,
+    overflow: 'auto',
   },
   leadingContentArea: {
     flex: '2',
@@ -101,6 +178,35 @@ const useStyles = makeStyles(() => ({
     outline: 'none',
     background: 'white',
     fontFamily: 'Roboto',
+  },
+  toolbar: {
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    background: 'white',
+    borderTop: '1px solid #E0E0E0',
+    padding: '12px 16px',
+    display: 'flex',
+    justifyContent: 'center',
+    zIndex: 1000,
+  },
+  previewButton: {
+    textTransform: 'none',
+    fontWeight: 500,
+  },
+  previewDialog: {
+    '& .MuiDialog-paper': {
+      margin: '48px 0 0 0',
+      height: '100vh',
+    },
+    '& .MuiDialog-paperFullWidth ': {
+      maxWidth: 'calc(100% - 16px)',
+      width: '100%',
+    },
+  },
+  dialogContent: {
+    padding: 0,
   },
 }));
 

--- a/frontend/src/components/DashboardView/index.tsx
+++ b/frontend/src/components/DashboardView/index.tsx
@@ -199,6 +199,7 @@ const useStyles = makeStyles(() => ({
     '& .MuiDialog-paper': {
       margin: '48px 0 0 0',
       height: '100vh',
+      background: '#F8F8F8',
     },
     '& .MuiDialog-paperFullWidth ': {
       maxWidth: 'calc(100% - 16px)',

--- a/frontend/src/components/DashboardView/index.tsx
+++ b/frontend/src/components/DashboardView/index.tsx
@@ -87,7 +87,7 @@ function DashboardView() {
           startIcon={<VisibilityOutlined />}
           onClick={handlePreviewClick}
           className={classes.previewButton}
-          size="small"
+          size="medium"
         >
           Preview
         </Button>
@@ -107,7 +107,7 @@ function DashboardView() {
             disableElevation
             startIcon={<Edit />}
             onClick={handleClosePreview}
-            size="small"
+            size="medium"
           >
             Back to Edit
           </Button>
@@ -116,7 +116,7 @@ function DashboardView() {
             variant="contained"
             disableElevation
             endIcon={<ArrowForward />}
-            size="small"
+            size="medium"
             style={{ backgroundColor: cyanBlue, color: black }}
           >
             Publish


### PR DESCRIPTION
### Description

Implements a basic preview mode for Dashboards. You should be able to select **Preview** in the new toolbar at the bottom of the main Dashboard view. This will display a modal with read-only versions of the title and text block components.

TextBlock will render Markdown content — we can adjust which elements are allowed and how they’re styled as needed.

#### Notes
* I had trouble finding a way within the MUI APIs to render the “Back to Edit” and “Publish” buttons above the modal as shown in designs. Willing to keep playing around with it but didn’t it to be come too big of a time sink — any guidance or suggestions appreciated
* Publish button in the toolbar is not in scope for this PR

<!-- what this does -->

## How to test the feature:

- [ ]
- [ ]

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
