### PR TITLE
Setup basic action sanitizers to make redux-dev-tools more usable

### DIFF
--- a/frontend/src/context/store.ts
+++ b/frontend/src/context/store.ts
@@ -39,6 +39,50 @@ const reducer = combineReducers({
 
 export const store = configureStore({
   reducer,
+  devTools: {
+    // sanitizers to make the state vaguely manageable by redux-dev-tools
+    // actionSanitizer returns the action "cleaned up" for faster display (it does not
+    // affect the original action, just how its displayed in redux-dev-tools)
+    actionSanitizer: action => {
+      switch (action.type) {
+        case 'mapState/loadLayerData/fulfilled':
+          return {
+            ...action,
+            payload: {
+              ...action?.payload,
+              data: {
+                ...action.payload.data,
+                features: `array of ${action.payload.data.features.length} features`,
+              },
+            },
+          };
+        case 'serverState/loadAvailableDates/fulfilled':
+          return {
+            ...action,
+            payload: Object.fromEntries(
+              Object.entries(action.payload).map(([layerName, dateArray]) => [
+                layerName,
+                `array of ${dateArray.length} date objects`,
+              ]),
+            ),
+          };
+        case 'serverState/preloadLayerDatesForWMS/fulfilled':
+        case 'serverState/preloadLayerDatesForPointData/fulfilled':
+          return {
+            ...action,
+            payload: {
+              arrays_of_numbers_for_these_layers: Object.keys(action.payload),
+            },
+          };
+        default:
+          return action;
+      }
+    },
+    // stateSanitizer does the same for the state. This example is a bit radical!
+    stateSanitizer: (_state: RootState) => ({
+      empty: 'state',
+    }),
+  },
   middleware: getDefaultMiddleware({
     // TODO: Instead of snoozing this check, we might want to
     // serialize the state


### PR DESCRIPTION
### Description

@gislawill following our conversation last week, a small PR proposal to help make redux-dev-tools more usable. This needs a bit more work, but it does allow the dev tools to load and show the sequence of actions and the corresponding state. Most likely, when working on a specific part of the state, it might make sense to tweak this code a bit to get more details where required, but this should help start the tools without everything collapsing under its own weight.

Hopefully this can help with tracking down problems with the multimaps changes you're working on.

<!-- what this does -->

## How to test the feature:
- [ ] install/activate [redux-dev-tools](https://github.com/reduxjs/redux-devtools)
- [ ] `yarn start` with any country

## Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

Test your changes with

- [ ] `REACT_APP_COUNTRY=rbd yarn start`
- [ ] `REACT_APP_COUNTRY=cambodia yarn start`
- [ ] `REACT_APP_COUNTRY=mozambique yarn start`
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

## Screenshot/video of feature:
