### PR TITLE
Extract shared fetchJsonOrNull helper to fix silent failures on missing /data/*.json

### DIFF
--- a/frontend/src/components/DashboardView/DashboardExport/DashboardExportDialog.tsx
+++ b/frontend/src/components/DashboardView/DashboardExport/DashboardExportDialog.tsx
@@ -23,6 +23,7 @@ import { jsPDF } from 'jspdf';
 import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getFormattedDate } from 'utils/date-utils';
+import { fetchJsonOrNull } from 'utils/fetchJsonOrNull';
 
 import DashboardExportContext, {
   ExportToggles,
@@ -136,10 +137,17 @@ function DashboardExportDialog({
 
     // admin-boundary-unified-polygon.json is generated using "yarn preprocess-layers"
     if (selectedBoundaries.length === 0) {
-      fetch(`data/${safeCountry}/admin-boundary-unified-polygon.json`)
-        .then(response => response.json())
+      fetchJsonOrNull<any>(
+        `data/${safeCountry}/admin-boundary-unified-polygon.json`,
+      )
         .then(polygonData => {
-          const maskedPolygon = mask(polygonData as any);
+          if (polygonData === null) {
+            console.warn(
+              `Missing admin-boundary-unified-polygon.json for ${safeCountry}`,
+            );
+            return;
+          }
+          const maskedPolygon = mask(polygonData);
           setAdminBoundaryPolygon(maskedPolygon as any);
         })
         .catch(error =>
@@ -166,12 +174,22 @@ function DashboardExportDialog({
 
     if (filteredData.features.length === 0) {
       // Fall back to full country mask if no features match
-      fetch(`data/${safeCountry}/admin-boundary-unified-polygon.json`)
-        .then(response => response.json())
+      fetchJsonOrNull<any>(
+        `data/${safeCountry}/admin-boundary-unified-polygon.json`,
+      )
         .then(polygonData => {
-          const maskedPolygon = mask(polygonData as any);
+          if (polygonData === null) {
+            console.warn(
+              `Missing admin-boundary-unified-polygon.json for ${safeCountry}`,
+            );
+            return;
+          }
+          const maskedPolygon = mask(polygonData);
           setAdminBoundaryPolygon(maskedPolygon as any);
-        });
+        })
+        .catch(error =>
+          console.error('Error loading admin boundary polygon:', error),
+        );
       return;
     }
 

--- a/frontend/src/components/MapView/Layers/CompositeLayer/index.tsx
+++ b/frontend/src/components/MapView/Layers/CompositeLayer/index.tsx
@@ -16,6 +16,7 @@ import { FillLayerSpecification, MapLayerMouseEvent } from 'maplibre-gl';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { Layer, Source } from 'react-map-gl/maplibre';
 import { useDispatch, useSelector } from 'react-redux';
+import { fetchJsonOrNull } from 'utils/fetchJsonOrNull';
 import {
   findFeature,
   getEvtCoords,
@@ -75,9 +76,18 @@ const CompositeLayer = memo(({ layer, before }: Props) => {
   useEffect(() => {
     // admin-boundary-unified-polygon.json is generated using "yarn preprocess-layers"
     // which runs ./src/scripts/preprocess-layers.js
-    fetch(`/data/${safeCountry}/admin-boundary-unified-polygon.json`)
-      .then(response => response.json())
-      .then(polygonData => setAdminBoundaryPolygon(polygonData))
+    fetchJsonOrNull<any>(
+      `/data/${safeCountry}/admin-boundary-unified-polygon.json`,
+    )
+      .then(polygonData => {
+        if (polygonData === null) {
+          console.warn(
+            `Missing admin-boundary-unified-polygon.json for ${safeCountry}`,
+          );
+          return;
+        }
+        setAdminBoundaryPolygon(polygonData);
+      })
       .catch(error => console.error('Error:', error));
   }, []);
 

--- a/frontend/src/dashboardConfig/fetchDashboardConfig.ts
+++ b/frontend/src/dashboardConfig/fetchDashboardConfig.ts
@@ -1,4 +1,5 @@
 import type { Dashboard } from 'config/types';
+import { fetchJsonOrNull, JsonFetchError } from 'utils/fetchJsonOrNull';
 
 import {
   formatDashboardValidationError,
@@ -32,46 +33,35 @@ function parseValidatedDashboardBody(parsed: unknown): Dashboard[] {
  * parses the body, and validates it against the dashboard schema.
  */
 export async function fetchDashboardConfig(url: string): Promise<Dashboard[]> {
-  let response: Response;
+  let parsed: unknown;
   try {
-    response = await fetch(url);
+    parsed = await fetchJsonOrNull(url);
   } catch (e) {
-    const message =
-      e instanceof Error ? e.message : 'Network error loading dashboard config';
-    throw new DashboardConfigFetchError(
-      `Could not load dashboard configuration: ${message}`,
-      'network',
-    );
+    if (e instanceof JsonFetchError) {
+      if (e.causeType === 'json') {
+        throw new DashboardConfigFetchError(
+          'Dashboard configuration is not valid JSON',
+          'json',
+        );
+      }
+      throw new DashboardConfigFetchError(
+        e.causeType === 'network'
+          ? `Could not load dashboard configuration: ${e.message}`
+          : `Dashboard configuration request failed (${e.status})`,
+        e.causeType,
+        e.status,
+      );
+    }
+    throw e;
   }
 
-  if (!response.ok) {
-    throw new DashboardConfigFetchError(
-      `Dashboard configuration request failed (${response.status} ${response.statusText})`,
-      'http',
-      response.status,
-    );
-  }
-
-  // Static hosts (e.g. Firebase Hosting, see frontend/firebase.json) rewrite unknown paths
-  // to `/index.html` and return it with status 200, so a missing dashboard.json arrives as
-  // HTML — not a 404 — and JSON.parse below would throw. Treat a non-JSON content-type as
-  // "not found" so the UI stays silent, matching the 404 path.
-  const contentType = response.headers.get('content-type') ?? '';
-  if (!contentType.toLowerCase().includes('json')) {
+  // Missing file: a real 404, or the SPA-fallback HTML served with status 200
+  // (see fetchJsonOrNull). Surface both as a 404 so the UI stays silent.
+  if (parsed === null) {
     throw new DashboardConfigFetchError(
       'Dashboard configuration not found',
       'http',
       404,
-    );
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = await response.json();
-  } catch {
-    throw new DashboardConfigFetchError(
-      'Dashboard configuration is not valid JSON',
-      'json',
     );
   }
 

--- a/frontend/src/utils/adminAreaClipPolygon.test.ts
+++ b/frontend/src/utils/adminAreaClipPolygon.test.ts
@@ -83,6 +83,8 @@ describe('adminAreaClipPolygon', () => {
 
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
       json: async () => preprocessedMask,
     }) as jest.Mock;
 

--- a/frontend/src/utils/adminAreaClipPolygon.ts
+++ b/frontend/src/utils/adminAreaClipPolygon.ts
@@ -10,6 +10,7 @@ import {
   filterFeaturesBySelectedAdminCodes,
   resolveFeaturesForAdminCodes,
 } from './adminAreaSelection';
+import { fetchJsonOrNull } from './fetchJsonOrNull';
 import { isUniversalDeployment } from './universal-utils';
 
 export type AdminAreaClipPolygon = Feature<Polygon | MultiPolygon>;
@@ -148,16 +149,13 @@ export async function fetchUnifiedCountryBoundaryPolygon(
   }
 
   const request = (async () => {
-    const response = await fetch(
+    const polygon = await fetchJsonOrNull<Feature>(
       `/data/${country}/admin-boundary-unified-polygon.json`,
     );
-    if (!response.ok) {
-      throw new Error(
-        `Failed to load admin boundary polygon for ${country}: ${response.status}`,
-      );
+    if (polygon === null) {
+      throw new Error(`Missing admin boundary polygon for ${country}`);
     }
 
-    const polygon = await response.json();
     if (!isPolygonOrMultiPolygonFeature(polygon)) {
       throw new Error(
         `Invalid admin boundary polygon for ${country}: expected Polygon or MultiPolygon`,

--- a/frontend/src/utils/fetchJsonOrNull.test.ts
+++ b/frontend/src/utils/fetchJsonOrNull.test.ts
@@ -1,0 +1,90 @@
+import { fetchJsonOrNull } from './fetchJsonOrNull';
+
+describe('fetchJsonOrNull', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const jsonHeaders = new Headers({ 'content-type': 'application/json' });
+
+  it('returns the parsed body on success', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: jsonHeaders,
+      json: async () => ({ a: 1 }),
+    } as unknown as Response);
+
+    const data = await fetchJsonOrNull('/data/mozambique/some.json');
+    expect(data).toEqual({ a: 1 });
+  });
+
+  it('returns null on HTTP 404', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as unknown as Response);
+
+    await expect(fetchJsonOrNull('/data/x/missing.json')).resolves.toBeNull();
+  });
+
+  it('returns null on 200 + HTML (SPA fallback)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      json: async () => {
+        throw new SyntaxError('Unexpected token <');
+      },
+    } as unknown as Response);
+
+    await expect(fetchJsonOrNull('/data/x/missing.json')).resolves.toBeNull();
+  });
+
+  it('throws JsonFetchError on network failure', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new TypeError('Failed to fetch'));
+
+    await expect(fetchJsonOrNull('/data/x/some.json')).rejects.toMatchObject({
+      name: 'JsonFetchError',
+      causeType: 'network',
+    });
+  });
+
+  it('throws JsonFetchError on non-OK statuses other than 404', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    } as unknown as Response);
+
+    await expect(fetchJsonOrNull('/data/x/some.json')).rejects.toMatchObject({
+      name: 'JsonFetchError',
+      causeType: 'http',
+      status: 500,
+    });
+  });
+
+  it('throws JsonFetchError on invalid JSON', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: jsonHeaders,
+      json: async () => {
+        throw new SyntaxError('Unexpected token');
+      },
+    } as unknown as Response);
+
+    await expect(fetchJsonOrNull('/data/x/broken.json')).rejects.toMatchObject({
+      name: 'JsonFetchError',
+      causeType: 'json',
+    });
+  });
+});

--- a/frontend/src/utils/fetchJsonOrNull.ts
+++ b/frontend/src/utils/fetchJsonOrNull.ts
@@ -1,0 +1,58 @@
+export class JsonFetchError extends Error {
+  constructor(
+    message: string,
+    public readonly causeType: 'http' | 'network' | 'json',
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'JsonFetchError';
+  }
+}
+
+/**
+ * Fetches a JSON resource, treating a missing file as a normal outcome.
+ *
+ * Returns `null` for HTTP 404 responses and for OK responses whose
+ * content-type is not JSON: static hosts (e.g. Firebase Hosting, see
+ * frontend/firebase.json) rewrite unknown paths to `/index.html` and return
+ * it with status 200, so a missing file arrives as HTML rather than a 404.
+ *
+ * Throws `JsonFetchError` with a distinct `causeType` for network failures
+ * ('network'), non-OK statuses other than 404 ('http'), and bodies that fail
+ * to parse as JSON ('json'), so callers can tell "file not configured" apart
+ * from "file exists but is broken".
+ */
+export async function fetchJsonOrNull<T = unknown>(
+  url: string,
+): Promise<T | null> {
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Network error';
+    throw new JsonFetchError(`Could not load ${url}: ${message}`, 'network');
+  }
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new JsonFetchError(
+      `Request for ${url} failed (${response.status} ${response.statusText})`,
+      'http',
+      response.status,
+    );
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('json')) {
+    return null;
+  }
+
+  try {
+    return (await response.json()) as T;
+  } catch {
+    throw new JsonFetchError(`Response from ${url} is not valid JSON`, 'json');
+  }
+}

--- a/frontend/src/utils/server-utils.ts
+++ b/frontend/src/utils/server-utils.ts
@@ -55,6 +55,7 @@ import {
 import { LocalError } from './error-utils';
 import { createEWSDatesArray } from './ews-utils';
 import { fetchWithTimeout } from './fetch-with-timeout';
+import { fetchJsonOrNull } from './fetchJsonOrNull';
 import { queryParamsToString } from './url-utils';
 
 /**
@@ -823,15 +824,15 @@ async function fetchPreprocessedDates(): Promise<
     try {
       // preprocessed-layer-dates.json is generated using "yarn preprocess-layers"
       // which runs ./scripts/preprocess-layers.js - preprocessValidityPeriods
-      const response = await fetch(
+      const dates = await fetchJsonOrNull<Record<string, StartEndDate[]>>(
         `data/${safeCountry}/preprocessed-layer-dates.json`,
       );
-      if (!response.ok) {
-        console.error(`HTTP error! status: ${response.status}`);
-        cachedPreprocessedDates = {};
-      }
-      cachedPreprocessedDates = await response.json();
-    } catch (_error) {
+      cachedPreprocessedDates = dates ?? {};
+    } catch (error) {
+      console.error(
+        `Failed to load preprocessed layer dates for ${safeCountry}:`,
+        error,
+      );
       cachedPreprocessedDates = {};
     }
   }


### PR DESCRIPTION
### Description

This fixes #1829.

Adds `utils/fetchJsonOrNull.ts`, a small shared helper that treats a missing JSON file as a normal outcome: it returns `null` on HTTP 404 **and** on the SPA-fallback case where the static host rewrites unknown paths to `/index.html` and serves HTML with status 200 (see `frontend/firebase.json`). It throws `JsonFetchError` with a distinct `causeType` (`network` / `http` / `json`) so callers can tell "file not configured" apart from "file exists but is broken".

Call sites migrated (note: two sites listed in the issue — ExportView and PrintImage — have since been consolidated into `adminAreaClipPolygon.ts`, so the actual list is):

- `dashboardConfig/fetchDashboardConfig.ts` — refactored on top of the helper; public behavior and all existing tests unchanged.
- `utils/server-utils.ts` `fetchPreprocessedDates` — also fixes the pre-existing `!response.ok` fall-through, where the `{}` fallback was immediately overwritten by `await response.json()`.
- `utils/adminAreaClipPolygon.ts` `fetchUnifiedCountryBoundaryPolygon` — a missing file now surfaces as a clean "Missing admin boundary polygon" error (still triggering the existing boundary-union fallback) instead of a JSON parse error.
- `components/MapView/Layers/CompositeLayer/index.tsx` — missing file now logs a `console.warn` naming the file instead of a generic parse error.
- `components/DashboardView/DashboardExport/DashboardExportDialog.tsx` — both fetches migrated; the second one previously had no `.catch` at all.

New tests in `utils/fetchJsonOrNull.test.ts` (6 cases: success, 404, SPA-fallback HTML, network, non-404 http error, invalid JSON). One existing mock in `adminAreaClipPolygon.test.ts` gained the `headers`/`status` fields the helper reads.

Out of scope, as flagged in the issue: deriving the `countriesWithPreprocessedDates` allowlist at runtime and a build-time validator for referenced `data/{country}/*.json` files.

Developed with AI assistance (Claude Code); all changes reviewed and verified locally.

## How to test the feature:

- [x] `yarn test src/utils/fetchJsonOrNull.test.ts src/dashboardConfig/fetchDashboardConfig.test.ts src/utils/adminAreaClipPolygon.test.ts` — 23 tests green
- [x] Rename `public/data/mozambique/admin-boundary-unified-polygon.json` and load the map: you get a targeted `console.warn` naming the missing file instead of a silent JSON parse error

## Checklist - did you ...

Test your changes with

- [x] `REACT_APP_COUNTRY=rbd yarn start`
- [x] `REACT_APP_COUNTRY=cambodia yarn start`
- [x] `REACT_APP_COUNTRY=mozambique yarn start`
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

## Screenshot/video of feature:

No visual change — verified the map, rainfall layer and legend render normally for all three country configs above (`yarn typecheck` and `eslint` clean).